### PR TITLE
feat: #90 feat(payment): Add merchant fee tier automatic upgrade base…

### DIFF
--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -37,7 +37,8 @@ fn test_reputation_increases_on_escrow_completion() {
 
     // Use default config (completion_reward = 100).
     env.ledger().set_timestamp(2000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
     client.release_escrow(&admin, &escrow_id, &true);
 
     let merchant_rep = client.get_reputation(&merchant);
@@ -72,7 +73,8 @@ fn test_reputation_config_overrides_defaults() {
     );
 
     env.ledger().set_timestamp(2000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
     client.release_escrow(&admin, &escrow_id, &true);
 
     // completion_reward is 50 now.
@@ -94,7 +96,8 @@ fn test_reputation_after_dispute_win() {
     env.mock_all_auths();
 
     // Default config: win_reward=200, loss_penalty=200.
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id);
 
     // Admin resolves in merchant's favour.
@@ -122,7 +125,8 @@ fn test_reputation_after_dispute_loss() {
 
     env.mock_all_auths();
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&merchant, &escrow_id);
 
     // Admin resolves in customer's favour.
@@ -160,7 +164,8 @@ fn test_score_clamped_at_10000() {
         },
     );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id);
     client.resolve_dispute(&admin, &escrow_id, &true); // merchant wins
 
@@ -191,7 +196,8 @@ fn test_score_clamped_at_zero() {
         },
     );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id);
     client.resolve_dispute(&admin, &escrow_id, &true); // merchant wins, customer loses
 
@@ -216,7 +222,7 @@ fn test_weighted_auto_resolve_merchant_wins_higher_reputation() {
     client.set_reputation_config(
         &admin,
         &ReputationConfig {
-            win_reward: 3000, // push merchant to 8000
+            win_reward: 3000,   // push merchant to 8000
             loss_penalty: 3000, // push customer to 2000
             completion_reward: 0,
             dispute_initiation_penalty: 0,
@@ -224,19 +230,29 @@ fn test_weighted_auto_resolve_merchant_wins_higher_reputation() {
     );
 
     // First escrow to establish reputation difference.
-    let escrow_id1 = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let escrow_id1 =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id1);
     client.resolve_dispute(&admin, &escrow_id1, &true); // merchant wins → merchant=8000, customer=2000
 
     // Second escrow for the weighted auto-resolve test.
     env.ledger().set_timestamp(100);
-    let escrow_id2 = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let escrow_id2 =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id2);
 
     // Each party submits one piece of evidence.
     env.ledger().set_timestamp(200);
-    client.submit_evidence(&customer, &escrow_id2, &String::from_str(&env, "ipfs://cust"));
-    client.submit_evidence(&merchant, &escrow_id2, &String::from_str(&env, "ipfs://merch"));
+    client.submit_evidence(
+        &customer,
+        &escrow_id2,
+        &String::from_str(&env, "ipfs://cust"),
+    );
+    client.submit_evidence(
+        &merchant,
+        &escrow_id2,
+        &String::from_str(&env, "ipfs://merch"),
+    );
 
     // After timeout, auto-resolve should favour merchant (higher reputation).
     env.ledger().set_timestamp(800); // > 200 + 500 timeout
@@ -271,18 +287,28 @@ fn test_weighted_auto_resolve_customer_wins_higher_reputation() {
     );
 
     // First escrow: customer wins → customer=8000, merchant=2000.
-    let escrow_id1 = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let escrow_id1 =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&merchant, &escrow_id1);
     client.resolve_dispute(&admin, &escrow_id1, &false); // customer wins
 
     // Second escrow for weighted auto-resolve.
     env.ledger().set_timestamp(100);
-    let escrow_id2 = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let escrow_id2 =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&merchant, &escrow_id2);
 
     env.ledger().set_timestamp(200);
-    client.submit_evidence(&customer, &escrow_id2, &String::from_str(&env, "ipfs://cust"));
-    client.submit_evidence(&merchant, &escrow_id2, &String::from_str(&env, "ipfs://merch"));
+    client.submit_evidence(
+        &customer,
+        &escrow_id2,
+        &String::from_str(&env, "ipfs://cust"),
+    );
+    client.submit_evidence(
+        &merchant,
+        &escrow_id2,
+        &String::from_str(&env, "ipfs://merch"),
+    );
 
     env.ledger().set_timestamp(800);
     client.auto_resolve_dispute(&escrow_id2);
@@ -892,13 +918,22 @@ fn test_submit_evidence_by_both_parties() {
     let merchant = Address::generate(&env);
     let token = Address::generate(&env);
     env.mock_all_auths();
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
     env.ledger().set_timestamp(1000);
     client.dispute_escrow(&customer, &escrow_id);
     env.ledger().set_timestamp(1200);
-    client.submit_evidence(&customer, &escrow_id, &String::from_str(&env, "ipfs://hash1"));
+    client.submit_evidence(
+        &customer,
+        &escrow_id,
+        &String::from_str(&env, "ipfs://hash1"),
+    );
     env.ledger().set_timestamp(1300);
-    client.submit_evidence(&merchant, &escrow_id, &String::from_str(&env, "ipfs://hash2"));
+    client.submit_evidence(
+        &merchant,
+        &escrow_id,
+        &String::from_str(&env, "ipfs://hash2"),
+    );
     let count = client.get_evidence_count(&escrow_id);
     assert_eq!(count, 2);
     let items = client.get_evidence(&escrow_id, &10_u64, &0_u64);
@@ -916,11 +951,16 @@ fn test_auto_resolve_to_customer_on_timeout() {
     let merchant = Address::generate(&env);
     let token = Address::generate(&env);
     env.mock_all_auths();
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
     env.ledger().set_timestamp(1000);
     client.dispute_escrow(&customer, &escrow_id);
     env.ledger().set_timestamp(1200);
-    client.submit_evidence(&customer, &escrow_id, &String::from_str(&env, "ipfs://cust"));
+    client.submit_evidence(
+        &customer,
+        &escrow_id,
+        &String::from_str(&env, "ipfs://cust"),
+    );
     env.ledger().set_timestamp(1801);
     client.auto_resolve_dispute(&escrow_id);
     let escrow = client.get_escrow(&escrow_id);
@@ -936,11 +976,16 @@ fn test_auto_resolve_to_merchant_on_timeout() {
     let merchant = Address::generate(&env);
     let token = Address::generate(&env);
     env.mock_all_auths();
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
     env.ledger().set_timestamp(1000);
     client.dispute_escrow(&merchant, &escrow_id);
     env.ledger().set_timestamp(1200);
-    client.submit_evidence(&merchant, &escrow_id, &String::from_str(&env, "ipfs://merch"));
+    client.submit_evidence(
+        &merchant,
+        &escrow_id,
+        &String::from_str(&env, "ipfs://merch"),
+    );
     env.ledger().set_timestamp(1801);
     client.auto_resolve_dispute(&escrow_id);
     let escrow = client.get_escrow(&escrow_id);
@@ -1098,7 +1143,8 @@ fn test_escalate_dispute() {
     let merchant = Address::generate(&env);
     let token = Address::generate(&env);
     env.mock_all_auths();
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1500_u64, &0_u64);
     env.ledger().set_timestamp(1000);
     client.dispute_escrow(&customer, &escrow_id);
     client.escalate_dispute(&customer, &escrow_id);
@@ -1179,16 +1225,15 @@ fn test_create_vesting_escrow_with_milestones() {
         },
     ];
 
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &4000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &4000_u64,
+        &milestones,
+    );
 
     assert_eq!(escrow_id, 1);
 
@@ -1215,16 +1260,15 @@ fn test_create_vesting_escrow_time_linear() {
 
     // Create time-linear vesting (no milestones)
     let milestones = Vec::new(&env);
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &2000_u64,
-            &10000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &2000_u64,
+        &10000_u64,
+        &milestones,
+    );
 
     let vesting_schedule = client.get_vesting_schedule(&escrow_id);
     assert_eq!(vesting_schedule.total_amount, 10000);
@@ -1262,16 +1306,15 @@ fn test_create_vesting_escrow_invalid_milestone_sum() {
         },
     ];
 
-    client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &4000_u64,
-            &milestones,
-        );
+    client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &4000_u64,
+        &milestones,
+    );
 }
 
 // ── MULTI-PARTY ESCROW TESTS ────────────────────────────────────────────────
@@ -1285,7 +1328,9 @@ fn test_create_multi_party_escrow_success() {
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_id);
 
     let customer = Address::generate(&env);
@@ -1352,16 +1397,15 @@ fn test_create_vesting_escrow_cliff_before_current_time() {
 
     // Cliff timestamp is in the past - should fail
     let milestones = Vec::new(&env);
-    client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &500_u64,
-            &4000_u64,
-            &milestones,
-        );
+    client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &500_u64,
+        &4000_u64,
+        &milestones,
+    );
 }
 
 #[test]
@@ -1380,16 +1424,15 @@ fn test_create_vesting_escrow_end_before_cliff() {
 
     // End timestamp is before cliff - should fail
     let milestones = Vec::new(&env);
-    client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &5000_u64,
-            &4000_u64,
-            &milestones,
-        );
+    client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &5000_u64,
+        &4000_u64,
+        &milestones,
+    );
 }
 
 #[test]
@@ -1406,16 +1449,15 @@ fn test_get_vested_amount_before_cliff() {
     env.mock_all_auths();
 
     let milestones = Vec::new(&env);
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &2000_u64,
-            &10000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &2000_u64,
+        &10000_u64,
+        &milestones,
+    );
 
     // Before cliff - should be 0
     env.ledger().set_timestamp(1500);
@@ -1437,16 +1479,15 @@ fn test_get_vested_amount_after_cliff_linear() {
     env.mock_all_auths();
 
     let milestones = Vec::new(&env);
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &2000_u64,
-            &10000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &2000_u64,
+        &10000_u64,
+        &milestones,
+    );
 
     // At cliff - nothing vested yet in linear model (elapsed = 0)
     env.ledger().set_timestamp(2000);
@@ -1499,16 +1540,15 @@ fn test_get_vested_amount_milestone_based() {
         },
     ];
 
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &4000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &4000_u64,
+        &milestones,
+    );
 
     // Before first milestone
     env.ledger().set_timestamp(1800);
@@ -1561,16 +1601,15 @@ fn test_get_releasable_amount() {
         },
     ];
 
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &3000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &3000_u64,
+        &milestones,
+    );
 
     // After first milestone - releasable = vested
     env.ledger().set_timestamp(2500);
@@ -1620,16 +1659,15 @@ fn test_release_vested_amount_milestone() {
         },
     ];
 
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &3000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &3000_u64,
+        &milestones,
+    );
 
     // Try to release before cliff - should fail
     env.ledger().set_timestamp(1400);
@@ -1671,16 +1709,15 @@ fn test_release_vested_amount_before_cliff() {
     env.mock_all_auths();
 
     let milestones = Vec::new(&env);
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &2000_u64,
-            &10000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &2000_u64,
+        &10000_u64,
+        &milestones,
+    );
 
     // Try to release before cliff
     env.ledger().set_timestamp(1500);
@@ -1722,7 +1759,9 @@ fn test_approve_release_success() {
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_id);
     let customer = Address::generate(&env);
     token_client.mint(&customer, &10000);
@@ -1744,7 +1783,8 @@ fn test_approve_release_success() {
         required_approval: true,
     });
 
-    let escrow_id = client.create_multi_party_escrow(&customer, &participants, &10000, &token_id, &1000);
+    let escrow_id =
+        client.create_multi_party_escrow(&customer, &participants, &10000, &token_id, &1000);
 
     client.approve_release(&p1, &escrow_id);
     let escrow = client.get_multi_party_escrow(&escrow_id);
@@ -1764,7 +1804,9 @@ fn test_release_multi_party_escrow_success() {
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_id);
     let token_user_client = token::Client::new(&env, &token_id);
 
@@ -1796,7 +1838,8 @@ fn test_release_multi_party_escrow_success() {
     });
 
     env.ledger().set_timestamp(500);
-    let escrow_id = client.create_multi_party_escrow(&customer, &participants, &10000, &token_id, &1000);
+    let escrow_id =
+        client.create_multi_party_escrow(&customer, &participants, &10000, &token_id, &1000);
 
     client.approve_release(&p1, &escrow_id);
     client.approve_release(&p2, &escrow_id);
@@ -1838,16 +1881,15 @@ fn test_release_vested_amount_nothing_to_release() {
         },
     ];
 
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &2000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &2000_u64,
+        &milestones,
+    );
 
     // Before milestone unlocks
     env.ledger().set_timestamp(1800);
@@ -1896,16 +1938,15 @@ fn test_full_vesting_completion() {
         },
     ];
 
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &5000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &5000_u64,
+        &milestones,
+    );
 
     // Release each milestone as it unlocks
     env.ledger().set_timestamp(2500);
@@ -1960,16 +2001,15 @@ fn test_partial_milestone_release() {
         },
     ];
 
-    let escrow_id = client
-        .create_vesting_escrow(
-            &customer,
-            &merchant,
-            &10000_i128,
-            &token,
-            &1500_u64,
-            &3000_u64,
-            &milestones,
-        );
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &1500_u64,
+        &3000_u64,
+        &milestones,
+    );
 
     // Only first milestone unlocked
     env.ledger().set_timestamp(2500);
@@ -1995,7 +2035,9 @@ fn test_release_multi_party_escrow_threshold_not_met() {
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_id);
 
     let customer = Address::generate(&env);
@@ -2018,7 +2060,8 @@ fn test_release_multi_party_escrow_threshold_not_met() {
         required_approval: true,
     });
 
-    let escrow_id = client.create_multi_party_escrow(&customer, &participants, &10000, &token_id, &1000);
+    let escrow_id =
+        client.create_multi_party_escrow(&customer, &participants, &10000, &token_id, &1000);
 
     client.approve_release(&p1, &escrow_id);
     // Only 1 approval, 2 required
@@ -2058,21 +2101,19 @@ fn test_multisig_propose_release_escrow() {
 
     client.initialize(&admin);
     env.ledger().set_timestamp(2000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
 
     // Encode escrow_id as 8 big-endian bytes + 1 byte for early_release=true
     let mut data_bytes = [0u8; 9];
     let id_bytes = escrow_id.to_be_bytes();
-    for i in 0..8 { data_bytes[i] = id_bytes[i]; }
+    for i in 0..8 {
+        data_bytes[i] = id_bytes[i];
+    }
     data_bytes[8] = 1u8; // early_release = true
     let data = soroban_sdk::Bytes::from_slice(&env, &data_bytes);
 
-    let proposal_id = client.propose_action(
-        &admin,
-        &ActionType::ReleaseEscrow,
-        &merchant,
-        &data,
-    );
+    let proposal_id = client.propose_action(&admin, &ActionType::ReleaseEscrow, &merchant, &data);
 
     // proposal id should be "1"
     assert_eq!(proposal_id, String::from_str(&env, "1"));
@@ -2091,29 +2132,25 @@ fn test_multisig_approve_and_execute() {
 
     client.initialize(&admin);
     env.ledger().set_timestamp(2000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
 
     // Encode escrow_id + early_release=true
     let mut data_bytes = [0u8; 9];
     let id_bytes = escrow_id.to_be_bytes();
-    for i in 0..8 { data_bytes[i] = id_bytes[i]; }
+    for i in 0..8 {
+        data_bytes[i] = id_bytes[i];
+    }
     data_bytes[8] = 1u8;
     let data = soroban_sdk::Bytes::from_slice(&env, &data_bytes);
 
-    let proposal_id = client.propose_action(
-        &admin,
-        &ActionType::ReleaseEscrow,
-        &merchant,
-        &data,
-    );
+    let proposal_id = client.propose_action(&admin, &ActionType::ReleaseEscrow, &merchant, &data);
 
     // With required_signatures=1 and 1 approval already from proposer, execute directly
     client.execute_action(&proposal_id);
 
     // Verify escrow was released by querying via client
-    let escrow = env.as_contract(&contract_id, || {
-        EscrowContract::get_escrow(&env, escrow_id)
-    });
+    let escrow = env.as_contract(&contract_id, || EscrowContract::get_escrow(&env, escrow_id));
     assert_eq!(escrow.status, EscrowStatus::Released);
 }
 
@@ -2133,12 +2170,7 @@ fn test_multisig_duplicate_approval_rejected() {
     client.update_required_signatures(&admin, &2_u32);
 
     let data = soroban_sdk::Bytes::from_slice(&env, &[0u8; 9]);
-    let proposal_id = client.propose_action(
-        &admin,
-        &ActionType::ReleaseEscrow,
-        &admin2,
-        &data,
-    );
+    let proposal_id = client.propose_action(&admin, &ActionType::ReleaseEscrow, &admin2, &data);
 
     // admin already approved when proposing, approving again should panic
     client.approve_action(&admin, &proposal_id);
@@ -2159,12 +2191,7 @@ fn test_multisig_proposal_expires() {
 
     env.ledger().set_timestamp(1000);
     let data = soroban_sdk::Bytes::from_slice(&env, &[0u8; 9]);
-    let proposal_id = client.propose_action(
-        &admin,
-        &ActionType::ReleaseEscrow,
-        &admin2,
-        &data,
-    );
+    let proposal_id = client.propose_action(&admin, &ActionType::ReleaseEscrow, &admin2, &data);
 
     // Advance past TTL (604800 seconds = 7 days)
     env.ledger().set_timestamp(1000 + 604801);
@@ -2189,12 +2216,7 @@ fn test_multisig_threshold_not_met() {
     client.update_required_signatures(&admin, &2_u32);
 
     let data = soroban_sdk::Bytes::from_slice(&env, &[0u8; 9]);
-    let proposal_id = client.propose_action(
-        &admin,
-        &ActionType::ReleaseEscrow,
-        &admin2,
-        &data,
-    );
+    let proposal_id = client.propose_action(&admin, &ActionType::ReleaseEscrow, &admin2, &data);
 
     // Only 1 approval (from proposer), threshold is 2 — should panic
     client.execute_action(&proposal_id);
@@ -2245,12 +2267,7 @@ fn test_multisig_reject_action() {
     client.update_required_signatures(&admin, &2_u32);
 
     let data = soroban_sdk::Bytes::from_slice(&env, &[0u8; 9]);
-    let proposal_id = client.propose_action(
-        &admin,
-        &ActionType::ReleaseEscrow,
-        &admin2,
-        &data,
-    );
+    let proposal_id = client.propose_action(&admin, &ActionType::ReleaseEscrow, &admin2, &data);
 
     client.reject_action(&admin2, &proposal_id);
 
@@ -2272,27 +2289,23 @@ fn test_multisig_resolve_dispute_via_proposal() {
 
     client.initialize(&admin);
     env.ledger().set_timestamp(2000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id);
 
     // Encode escrow_id + release_to_merchant=false (0)
     let mut data_bytes = [0u8; 9];
     let id_bytes = escrow_id.to_be_bytes();
-    for i in 0..8 { data_bytes[i] = id_bytes[i]; }
+    for i in 0..8 {
+        data_bytes[i] = id_bytes[i];
+    }
     data_bytes[8] = 0u8; // release to customer
     let data = soroban_sdk::Bytes::from_slice(&env, &data_bytes);
 
-    let proposal_id = client.propose_action(
-        &admin,
-        &ActionType::ResolveDispute,
-        &customer,
-        &data,
-    );
+    let proposal_id = client.propose_action(&admin, &ActionType::ResolveDispute, &customer, &data);
 
     client.execute_action(&proposal_id);
 
-    let escrow = env.as_contract(&contract_id, || {
-        EscrowContract::get_escrow(&env, escrow_id)
-    });
+    let escrow = env.as_contract(&contract_id, || EscrowContract::get_escrow(&env, escrow_id));
     assert_eq!(escrow.status, EscrowStatus::Resolved);
 }

--- a/contracts/escrow/src/timelock_test.rs
+++ b/contracts/escrow/src/timelock_test.rs
@@ -15,13 +15,9 @@ mod timelock_tests {
         let action_type = EscrowActionType::ResolveDispute(true);
         let data = Bytes::new(&env);
 
-        let action_id = EscrowContract::queue_action(
-            env.clone(),
-            admin.clone(),
-            escrow_id,
-            action_type,
-            data,
-        ).unwrap();
+        let action_id =
+            EscrowContract::queue_action(env.clone(), admin.clone(), escrow_id, action_type, data)
+                .unwrap();
 
         assert_eq!(action_id, 1);
 
@@ -43,13 +39,9 @@ mod timelock_tests {
         let action_type = EscrowActionType::ResolveDispute(true);
         let data = Bytes::new(&env);
 
-        let action_id = EscrowContract::queue_action(
-            env.clone(),
-            admin.clone(),
-            escrow_id,
-            action_type,
-            data,
-        ).unwrap();
+        let action_id =
+            EscrowContract::queue_action(env.clone(), admin.clone(), escrow_id, action_type, data)
+                .unwrap();
 
         // Try to execute immediately - should fail
         let result = EscrowContract::execute_queued_action(env.clone(), action_id);
@@ -68,13 +60,9 @@ mod timelock_tests {
         let action_type = EscrowActionType::ForceRelease;
         let data = Bytes::new(&env);
 
-        let action_id = EscrowContract::queue_action(
-            env.clone(),
-            admin.clone(),
-            escrow_id,
-            action_type,
-            data,
-        ).unwrap();
+        let action_id =
+            EscrowContract::queue_action(env.clone(), admin.clone(), escrow_id, action_type, data)
+                .unwrap();
 
         EscrowContract::cancel_queued_action(env.clone(), admin.clone(), action_id).unwrap();
 
@@ -91,7 +79,7 @@ mod timelock_tests {
         EscrowContract::initialize(env.clone(), admin.clone());
 
         let config = TimeLockConfig {
-            delay: 7200,      // 2 hours
+            delay: 7200,        // 2 hours
             grace_period: 3600, // 1 hour
         };
 
@@ -112,7 +100,7 @@ mod timelock_tests {
 
         // Test delay too short (less than 1 hour)
         let config = TimeLockConfig {
-            delay: 1800,      // 30 minutes
+            delay: 1800, // 30 minutes
             grace_period: 3600,
         };
 
@@ -121,7 +109,7 @@ mod timelock_tests {
 
         // Test delay too long (more than 7 days)
         let config = TimeLockConfig {
-            delay: 700000,    // > 7 days
+            delay: 700000, // > 7 days
             grace_period: 3600,
         };
 

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -33,6 +33,7 @@ pub enum DataKey {
     AdminProposal(String),
     ProposalCounter,
     FeeConfig,
+    TierThresholds,
     MerchantFeeRecord(Address),
     AccumulatedFees,
     // Analytics
@@ -161,6 +162,7 @@ pub enum Error {
     OracleCallFailed = 42,
     ContractPaused = 43,
     FunctionPaused = 44,
+    InvalidTierThresholds = 45,
 }
 
 #[contractevent]
@@ -1449,7 +1451,7 @@ impl PaymentContract {
         }
 
         // Deduct platform fee (if configured) and get net amount for merchant
-        let net_amount = PaymentContract::deduct_fee(
+        let fee = PaymentContract::collect_fee(
             env,
             payment_id,
             payment.amount,
@@ -1457,6 +1459,7 @@ impl PaymentContract {
             &payment.token,
             &payment.customer,
         );
+        let net_amount = payment.amount - fee;
 
         // Token transfer: net amount from customer to merchant
         let token_client = token::Client::new(env, &payment.token);
@@ -1472,6 +1475,12 @@ impl PaymentContract {
         env.storage()
             .instance()
             .set(&DataKey::Payment(payment_id), &payment);
+        PaymentContract::record_merchant_payment_completion(
+            env,
+            &payment.merchant,
+            payment.amount,
+            fee,
+        );
 
         // Update analytics
         let mut analytics: PaymentAnalytics = env
@@ -3038,12 +3047,7 @@ impl PaymentContract {
             .storage()
             .instance()
             .get(&DataKey::MerchantFeeRecord(merchant.clone()))
-            .unwrap_or(MerchantFeeRecord {
-                merchant,
-                total_fees_paid: 0,
-                total_volume: 0,
-                fee_tier: FeeTier::Standard,
-            });
+            .unwrap_or(PaymentContract::default_merchant_fee_record(merchant));
         PaymentContract::compute_fee_amount(
             amount,
             config.fee_bps,
@@ -3053,17 +3057,51 @@ impl PaymentContract {
         )
     }
 
+    pub fn get_merchant_tier(env: Env, merchant: Address) -> FeeTier {
+        PaymentContract::get_merchant_fee_record(env, merchant).fee_tier
+    }
+
+    pub fn manually_set_merchant_tier(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+        tier: FeeTier,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        PaymentContract::require_admin(&env, &admin)?;
+
+        let mut record = PaymentContract::get_merchant_fee_record(env.clone(), merchant.clone());
+        record.fee_tier = tier;
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantFeeRecord(merchant), &record);
+        Ok(())
+    }
+
+    pub fn get_tier_thresholds(env: Env) -> Vec<(FeeTier, i128)> {
+        PaymentContract::load_tier_thresholds(&env)
+    }
+
+    pub fn set_tier_thresholds(
+        env: Env,
+        admin: Address,
+        thresholds: Vec<(FeeTier, i128)>,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        PaymentContract::require_admin(&env, &admin)?;
+        PaymentContract::validate_tier_thresholds(&thresholds)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::TierThresholds, &thresholds);
+        Ok(())
+    }
+
     /// Returns the fee record for a given merchant.
     pub fn get_merchant_fee_record(env: Env, merchant: Address) -> MerchantFeeRecord {
         env.storage()
             .instance()
             .get(&DataKey::MerchantFeeRecord(merchant.clone()))
-            .unwrap_or(MerchantFeeRecord {
-                merchant,
-                total_fees_paid: 0,
-                total_volume: 0,
-                fee_tier: FeeTier::Standard,
-            })
+            .unwrap_or(PaymentContract::default_merchant_fee_record(merchant))
     }
 
     /// Returns the total fees accumulated in the contract.
@@ -3115,9 +3153,8 @@ impl PaymentContract {
         Ok(())
     }
 
-    /// Internal: deducts the platform fee from a payment, transfers fee to contract,
-    /// updates merchant record and accumulated fees, and returns the net amount.
-    fn deduct_fee(
+    /// Internal: collects the platform fee for a payment and returns the fee amount.
+    fn collect_fee(
         env: &Env,
         payment_id: u64,
         amount: i128,
@@ -3128,27 +3165,18 @@ impl PaymentContract {
         let config: Option<FeeConfig> = env.storage().instance().get(&DataKey::FeeConfig);
         let config = match config {
             None => {
-                return amount;
+                return 0;
             }
             Some(c) if !c.active => {
-                return amount;
+                return 0;
             }
             Some(c) if c.fee_token != *token => {
-                return amount;
+                return 0;
             }
             Some(c) => c,
         };
 
-        let mut record: MerchantFeeRecord = env
-            .storage()
-            .instance()
-            .get(&DataKey::MerchantFeeRecord(merchant.clone()))
-            .unwrap_or(MerchantFeeRecord {
-                merchant: merchant.clone(),
-                total_fees_paid: 0,
-                total_volume: 0,
-                fee_tier: FeeTier::Standard,
-            });
+        let record = PaymentContract::get_fee_record_or_default(env, merchant);
 
         let fee = PaymentContract::compute_fee_amount(
             amount,
@@ -3159,10 +3187,8 @@ impl PaymentContract {
         );
 
         if fee <= 0 {
-            return amount;
+            return 0;
         }
-
-        let net_amount = amount - fee;
 
         // Transfer fee from customer to contract
         let token_client = token::Client::new(env, token);
@@ -3179,26 +3205,6 @@ impl PaymentContract {
             .instance()
             .set(&DataKey::AccumulatedFees, &(accumulated + fee));
 
-        // Update merchant record and check for tier upgrades
-        let old_tier = record.fee_tier.clone();
-        record.total_fees_paid += fee;
-        record.total_volume += amount;
-
-        let new_tier = PaymentContract::get_tier_for_volume(record.total_volume);
-        if new_tier != old_tier {
-            record.fee_tier = new_tier.clone();
-            (MerchantTierUpgraded {
-                merchant: merchant.clone(),
-                old_tier,
-                new_tier,
-            })
-            .publish(env);
-        }
-
-        env.storage()
-            .instance()
-            .set(&DataKey::MerchantFeeRecord(merchant.clone()), &record);
-
         (FeeCollected {
             payment_id,
             fee_amount: fee,
@@ -3206,7 +3212,7 @@ impl PaymentContract {
         })
         .publish(env);
 
-        net_amount
+        fee
     }
 
     /// Computes the fee amount applying tier discount and min/max clamping.
@@ -3248,16 +3254,134 @@ impl PaymentContract {
         }
     }
 
-    fn get_tier_for_volume(volume: i128) -> FeeTier {
-        if volume > PLATINUM_VOLUME_THRESHOLD {
-            FeeTier::Platinum
-        } else if volume > GOLD_VOLUME_THRESHOLD {
-            FeeTier::Gold
-        } else if volume > SILVER_VOLUME_THRESHOLD {
-            FeeTier::Silver
-        } else {
-            FeeTier::Standard
+    fn default_merchant_fee_record(merchant: Address) -> MerchantFeeRecord {
+        MerchantFeeRecord {
+            merchant,
+            total_fees_paid: 0,
+            total_volume: 0,
+            fee_tier: FeeTier::Standard,
         }
+    }
+
+    fn get_fee_record_or_default(env: &Env, merchant: &Address) -> MerchantFeeRecord {
+        env.storage()
+            .instance()
+            .get(&DataKey::MerchantFeeRecord(merchant.clone()))
+            .unwrap_or(PaymentContract::default_merchant_fee_record(
+                merchant.clone(),
+            ))
+    }
+
+    fn default_tier_thresholds(env: &Env) -> Vec<(FeeTier, i128)> {
+        soroban_sdk::vec![
+            env,
+            (FeeTier::Silver, SILVER_VOLUME_THRESHOLD),
+            (FeeTier::Gold, GOLD_VOLUME_THRESHOLD),
+            (FeeTier::Platinum, PLATINUM_VOLUME_THRESHOLD)
+        ]
+    }
+
+    fn load_tier_thresholds(env: &Env) -> Vec<(FeeTier, i128)> {
+        env.storage()
+            .instance()
+            .get(&DataKey::TierThresholds)
+            .unwrap_or(PaymentContract::default_tier_thresholds(env))
+    }
+
+    fn require_admin(env: &Env, admin: &Address) -> Result<(), Error> {
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(admin) {
+            return Err(Error::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn tier_rank(tier: &FeeTier) -> u32 {
+        match tier {
+            FeeTier::Standard => 0,
+            FeeTier::Silver => 1,
+            FeeTier::Gold => 2,
+            FeeTier::Platinum => 3,
+        }
+    }
+
+    fn validate_tier_thresholds(thresholds: &Vec<(FeeTier, i128)>) -> Result<(), Error> {
+        if thresholds.is_empty() {
+            return Err(Error::InvalidTierThresholds);
+        }
+
+        let mut last_rank = 0;
+        let mut last_amount: Option<i128> = None;
+
+        for threshold in thresholds.iter() {
+            let (tier, amount) = threshold;
+            let rank = PaymentContract::tier_rank(&tier);
+
+            if rank == 0 || amount < 0 {
+                return Err(Error::InvalidTierThresholds);
+            }
+
+            if rank <= last_rank {
+                return Err(Error::InvalidTierThresholds);
+            }
+
+            if let Some(previous_amount) = last_amount {
+                if amount <= previous_amount {
+                    return Err(Error::InvalidTierThresholds);
+                }
+            }
+
+            last_rank = rank;
+            last_amount = Some(amount);
+        }
+
+        Ok(())
+    }
+
+    fn calculate_tier(env: &Env, volume: i128) -> FeeTier {
+        let thresholds = PaymentContract::load_tier_thresholds(env);
+        let mut tier = FeeTier::Standard;
+
+        for threshold in thresholds.iter() {
+            let (candidate_tier, min_volume) = threshold;
+            if volume > min_volume {
+                tier = candidate_tier;
+            }
+        }
+
+        tier
+    }
+
+    fn record_merchant_payment_completion(
+        env: &Env,
+        merchant: &Address,
+        amount: i128,
+        fee_paid: i128,
+    ) {
+        let mut record = PaymentContract::get_fee_record_or_default(env, merchant);
+        let old_tier = record.fee_tier.clone();
+
+        record.total_volume += amount;
+        record.total_fees_paid += fee_paid;
+
+        let calculated_tier = PaymentContract::calculate_tier(env, record.total_volume);
+        if PaymentContract::tier_rank(&calculated_tier) > PaymentContract::tier_rank(&old_tier) {
+            record.fee_tier = calculated_tier.clone();
+            (MerchantTierUpgraded {
+                merchant: merchant.clone(),
+                old_tier,
+                new_tier: calculated_tier,
+            })
+            .publish(env);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantFeeRecord(merchant.clone()), &record);
     }
 
     // ── BATCH PAYMENT OPERATIONS ──────────────────────────────────────────────

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -1,9 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::testutils::{ Events, Ledger };
-use soroban_sdk::{ testutils::Address as _, token, Address, Env };
-use escrow::{ EscrowContract, EscrowContractClient, EscrowStatus };
+use escrow::{EscrowContract, EscrowContractClient, EscrowStatus};
+use soroban_sdk::testutils::{Events, Ledger};
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
 
 // ── RATE LIMITING / ANTI-FRAUD TESTS ────────────────────────────────────────
 
@@ -34,17 +34,41 @@ fn test_rate_limit_window_resets_after_duration() {
             window_duration: 100,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Advance past the window; counter should reset.
     env.ledger().set_timestamp(1200);
     // This third payment would fail if the window hadn't reset.
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     let rl = client.get_address_rate_limit(&customer);
     assert_eq!(rl.payment_count, 1); // only 1 payment in the new window
@@ -69,13 +93,29 @@ fn test_rate_limit_exceeded_within_window() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
     // Second payment in the same window — must panic.
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 }
 
 #[test]
@@ -96,11 +136,15 @@ fn test_flag_address_blocks_payments() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     // Flag the customer.
-    client.flag_address(&admin, &customer, &String::from_str(&env, "velocity attack"));
+    client.flag_address(
+        &admin,
+        &customer,
+        &String::from_str(&env, "velocity attack"),
+    );
     let rl = client.get_address_rate_limit(&customer);
     assert!(rl.flagged);
 
@@ -112,7 +156,7 @@ fn test_flag_address_blocks_payments() {
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
     assert!(result.is_err());
 }
@@ -134,7 +178,7 @@ fn test_unflag_address_allows_payments() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     client.flag_address(&admin, &customer, &String::from_str(&env, "test"));
@@ -144,7 +188,15 @@ fn test_unflag_address_allows_payments() {
     assert!(!rl.flagged);
 
     // Payment must succeed after unflag.
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 }
 
 #[test]
@@ -161,7 +213,7 @@ fn test_flag_unflag_events_emitted() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     client.flag_address(&admin, &customer, &String::from_str(&env, "fraud"));
@@ -189,11 +241,19 @@ fn test_rate_limit_breach_event_emitted() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Second attempt should fail due to the per-window limit.
     let result = client.try_create_payment(
@@ -203,7 +263,7 @@ fn test_rate_limit_breach_event_emitted() {
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
     assert!(result.is_err());
 
@@ -230,11 +290,19 @@ fn test_amount_exceeds_limit() {
             window_duration: 100_000,
             max_payment_amount: 100,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     // Within limit — must succeed.
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Over limit — must fail.
     let result = client.try_create_payment(
@@ -244,7 +312,7 @@ fn test_amount_exceeds_limit() {
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
     assert!(result.is_err());
 }
@@ -267,28 +335,45 @@ fn test_daily_volume_limit() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 200,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
-
-    // Third payment would exceed daily volume.
-    let result = client.try_create_payment(
+    client.create_payment(
         &customer,
         &merchant,
-        &1,
+        &100,
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+
+    // Third payment would exceed daily volume.
+    let result =
+        client.try_create_payment(&customer, &merchant, &1, &token, &Currency::USDC, &0, &meta);
     assert!(result.is_err());
 
     // Advance a full day — daily volume resets.
     env.ledger().set_timestamp(1000 + 86400 + 1);
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 }
 
 #[test]
@@ -312,7 +397,7 @@ fn test_create_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
     assert_eq!(payment_id, 1);
 
@@ -347,7 +432,7 @@ fn test_get_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment = client.get_payment(&payment_id);
@@ -377,7 +462,9 @@ fn test_complete_payment_success() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -401,7 +488,7 @@ fn test_complete_payment_success() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -415,7 +502,9 @@ fn test_complete_payment_event_emission() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -439,7 +528,7 @@ fn test_complete_payment_event_emission() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -453,7 +542,10 @@ fn test_complete_payment_event_emission() {
             payment_event_count += 1;
         }
     }
-    assert_eq!(payment_event_count, 1, "PaymentCompleted must be emitted exactly once");
+    assert_eq!(
+        payment_event_count, 1,
+        "PaymentCompleted must be emitted exactly once"
+    );
 
     // PaymentCompleted is the last event emitted by complete_payment
     let last_event = all_events.last().unwrap();
@@ -483,7 +575,7 @@ fn test_refund_payment_success() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment
@@ -517,14 +609,18 @@ fn test_refund_payment_event_emission() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.refund_payment(&admin, &payment_id);
 
     // Verify PaymentRefunded event is emitted exactly once
     let events = env.events().all();
-    assert_eq!(events.len(), 1, "PaymentRefunded must be emitted exactly once");
+    assert_eq!(
+        events.len(),
+        1,
+        "PaymentRefunded must be emitted exactly once"
+    );
     let event = events.get(0).unwrap();
     assert_eq!(event.0, contract_id);
 }
@@ -585,7 +681,7 @@ fn test_complete_already_completed_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Complete the payment first time
@@ -619,7 +715,7 @@ fn test_refund_already_refunded_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment first time
@@ -653,7 +749,7 @@ fn test_complete_refunded_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment first
@@ -685,7 +781,7 @@ fn test_refund_completed_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Complete the payment first
@@ -701,7 +797,9 @@ fn test_multiple_payments_correct_modification() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -726,7 +824,7 @@ fn test_multiple_payments_correct_modification() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment_id2 = client.create_payment(
         &customer2,
@@ -735,7 +833,7 @@ fn test_multiple_payments_correct_modification() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id1);
@@ -767,7 +865,7 @@ fn test_customer_cancel_pending_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Customer cancels their pending payment
@@ -799,7 +897,7 @@ fn test_merchant_cancel_pending_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Merchant cancels the pending payment
@@ -848,7 +946,7 @@ fn test_cancel_payment_unauthorized() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Try to cancel as unauthorized user
@@ -864,7 +962,9 @@ fn test_cancel_completed_payment() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -888,7 +988,7 @@ fn test_cancel_completed_payment() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -919,7 +1019,7 @@ fn test_cancel_refunded_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment first
@@ -951,7 +1051,7 @@ fn test_cancel_already_cancelled_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Cancel the payment first time
@@ -983,14 +1083,18 @@ fn test_cancel_payment_event_emission() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.cancel_payment(&customer, &payment_id);
 
     // Verify PaymentCancelled event is emitted exactly once
     let events = env.events().all();
-    assert_eq!(events.len(), 1, "PaymentCancelled must be emitted exactly once");
+    assert_eq!(
+        events.len(),
+        1,
+        "PaymentCancelled must be emitted exactly once"
+    );
     let event = events.get(0).unwrap();
     assert_eq!(event.0, contract_id);
 }
@@ -1016,7 +1120,7 @@ fn test_cancel_multiple_payments_correct_modification() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment_id2 = client.create_payment(
         &customer2,
@@ -1025,7 +1129,7 @@ fn test_cancel_multiple_payments_correct_modification() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Cancel first payment
@@ -1060,7 +1164,7 @@ fn test_get_payments_by_customer_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer,
@@ -1069,7 +1173,7 @@ fn test_get_payments_by_customer_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id3 = client.create_payment(
         &customer,
@@ -1078,7 +1182,7 @@ fn test_get_payments_by_customer_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_customer(&customer, &10, &0);
@@ -1109,7 +1213,7 @@ fn test_get_payments_by_merchant_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer2,
@@ -1118,7 +1222,7 @@ fn test_get_payments_by_merchant_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id3 = client.create_payment(
         &customer1,
@@ -1127,7 +1231,7 @@ fn test_get_payments_by_merchant_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_merchant(&merchant, &10, &0);
@@ -1158,7 +1262,7 @@ fn test_customer_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_customer(&customer), 1);
 
@@ -1169,7 +1273,7 @@ fn test_customer_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_customer(&customer), 2);
 
@@ -1180,7 +1284,7 @@ fn test_customer_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_customer(&customer), 3);
 }
@@ -1206,7 +1310,7 @@ fn test_merchant_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_merchant(&merchant), 1);
 
@@ -1217,7 +1321,7 @@ fn test_merchant_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_merchant(&merchant), 2);
 
@@ -1228,7 +1332,7 @@ fn test_merchant_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_merchant(&merchant), 3);
 }
@@ -1254,7 +1358,7 @@ fn test_pagination_first_page() {
             &token,
             &Currency::USDC,
             &0,
-            &String::from_str(&env, "")
+            &String::from_str(&env, ""),
         );
     }
 
@@ -1285,7 +1389,7 @@ fn test_pagination_second_page() {
             &token,
             &Currency::USDC,
             &0,
-            &String::from_str(&env, "")
+            &String::from_str(&env, ""),
         );
     }
 
@@ -1315,7 +1419,7 @@ fn test_pagination_limit_larger_than_total() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1324,7 +1428,7 @@ fn test_pagination_limit_larger_than_total() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1333,7 +1437,7 @@ fn test_pagination_limit_larger_than_total() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_customer(&customer, &100, &0);
@@ -1360,7 +1464,7 @@ fn test_pagination_offset_beyond_available() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1369,7 +1473,7 @@ fn test_pagination_offset_beyond_available() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1378,7 +1482,7 @@ fn test_pagination_offset_beyond_available() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_customer(&customer, &5, &10);
@@ -1436,7 +1540,7 @@ fn test_payments_not_mixed_between_customers() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer1,
@@ -1445,7 +1549,7 @@ fn test_payments_not_mixed_between_customers() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Create payments for customer2
@@ -1456,7 +1560,7 @@ fn test_payments_not_mixed_between_customers() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments1 = client.get_payments_by_customer(&customer1, &10, &0);
@@ -1490,7 +1594,7 @@ fn test_payments_not_mixed_between_merchants() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer,
@@ -1499,7 +1603,7 @@ fn test_payments_not_mixed_between_merchants() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Create payments for merchant2
@@ -1510,7 +1614,7 @@ fn test_payments_not_mixed_between_merchants() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments1 = client.get_payments_by_merchant(&merchant1, &10, &0);
@@ -1547,7 +1651,7 @@ fn test_create_payment_with_expiration_duration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment = client.get_payment(&payment_id);
@@ -1575,7 +1679,7 @@ fn test_create_payment_no_expiration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment = client.get_payment(&payment_id);
@@ -1603,10 +1707,11 @@ fn test_is_payment_expired_true() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     assert!(client.is_payment_expired(&payment_id));
 }
@@ -1632,7 +1737,7 @@ fn test_is_payment_expired_false_not_yet() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 10);
@@ -1661,7 +1766,7 @@ fn test_is_payment_expired_false_no_expiration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 1000);
@@ -1701,10 +1806,11 @@ fn test_expire_pending_payment_success() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     let result = client.try_expire_payment(&payment_id);
     assert!(result.is_ok());
@@ -1747,7 +1853,7 @@ fn test_expire_payment_before_expiration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 10);
@@ -1777,7 +1883,7 @@ fn test_expire_payment_no_expiration_set() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     env.ledger().set_timestamp(env.ledger().timestamp() + 1000);
 
@@ -1809,11 +1915,12 @@ fn test_expire_completed_payment() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 }
@@ -1843,11 +1950,12 @@ fn test_expire_refunded_payment() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.refund_payment(&admin, &payment_id);
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 }
@@ -1874,11 +1982,12 @@ fn test_expire_cancelled_payment() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.cancel_payment(&customer, &payment_id);
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 }
@@ -1904,11 +2013,12 @@ fn test_payment_expired_event_emitted() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let _expected_expires_at = env.ledger().timestamp() + expiration_duration;
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 
@@ -1939,7 +2049,7 @@ fn test_multiple_payments_different_expiration_times() {
         &token,
         &Currency::USDC,
         &10,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let initial_timestamp1 = env.ledger().timestamp();
 
@@ -1950,7 +2060,7 @@ fn test_multiple_payments_different_expiration_times() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment_id3 = client.create_payment(
@@ -1960,7 +2070,7 @@ fn test_multiple_payments_different_expiration_times() {
         &token,
         &Currency::USDC,
         &30,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let initial_timestamp3 = env.ledger().timestamp();
 
@@ -2008,10 +2118,11 @@ fn test_complete_expired_payment_fails() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.complete_payment(&admin, &payment_id);
 }
@@ -2041,10 +2152,11 @@ fn test_refund_expired_payment_fails() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.refund_payment(&admin, &payment_id);
 }
@@ -2056,7 +2168,9 @@ fn test_complete_payment_transfers_tokens_to_merchant() {
 
     // Register a real mock token contract
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2084,7 +2198,7 @@ fn test_complete_payment_transfers_tokens_to_merchant() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2100,7 +2214,9 @@ fn test_complete_payment_status_is_completed_after_transfer() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2124,7 +2240,7 @@ fn test_complete_payment_status_is_completed_after_transfer() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2140,7 +2256,9 @@ fn test_complete_payment_fails_without_allowance() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
 
     let contract_id = env.register(PaymentContract, ());
@@ -2163,7 +2281,7 @@ fn test_complete_payment_fails_without_allowance() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2176,7 +2294,9 @@ fn test_complete_payment_fails_insufficient_balance() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
     let contract_id = env.register(PaymentContract, ());
@@ -2199,7 +2319,7 @@ fn test_complete_payment_fails_insufficient_balance() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2211,7 +2331,9 @@ fn test_complete_payment_partial_allowance_with_exact_amount() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2236,7 +2358,7 @@ fn test_complete_payment_partial_allowance_with_exact_amount() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2268,7 +2390,7 @@ fn test_create_payment_with_metadata() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -2297,7 +2419,7 @@ fn test_create_payment_with_empty_metadata() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -2327,7 +2449,7 @@ fn test_create_payment_metadata_too_large() {
         &token,
         &Currency::USDC,
         &0,
-        &large_metadata
+        &large_metadata,
     );
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().unwrap(), Error::MetadataTooLarge);
@@ -2356,7 +2478,7 @@ fn test_create_payment_metadata_at_max_size() {
         &token,
         &Currency::USDC,
         &0,
-        &max_metadata
+        &max_metadata,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -2384,7 +2506,7 @@ fn test_update_payment_notes_success() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Customer requested express delivery");
@@ -2416,7 +2538,7 @@ fn test_update_payment_notes_multiple_times() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes1 = String::from_str(&env, "First note");
@@ -2451,7 +2573,7 @@ fn test_update_payment_notes_unauthorized() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Unauthorized note");
@@ -2481,7 +2603,7 @@ fn test_update_payment_notes_customer_cannot_update() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Customer trying to add notes");
@@ -2527,7 +2649,7 @@ fn test_update_payment_notes_too_large() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     // Create notes larger than MAX_NOTES_SIZE (1024)
@@ -2558,7 +2680,7 @@ fn test_update_payment_notes_at_max_size() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     // Create notes exactly at MAX_NOTES_SIZE (1024)
@@ -2576,7 +2698,9 @@ fn test_metadata_persists_through_payment_lifecycle() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2601,7 +2725,7 @@ fn test_metadata_persists_through_payment_lifecycle() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     // Add notes
@@ -2639,7 +2763,7 @@ fn test_metadata_included_in_query_responses() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata1
+        &metadata1,
     );
     let id2 = client.create_payment(
         &customer,
@@ -2648,7 +2772,7 @@ fn test_metadata_included_in_query_responses() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata2
+        &metadata2,
     );
 
     // Query by customer
@@ -2685,7 +2809,7 @@ fn test_notes_persist_after_cancellation() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Customer requested cancellation");
@@ -2719,7 +2843,7 @@ fn test_create_payment_with_xlm_currency() {
         &token,
         &Currency::XLM,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::XLM);
@@ -2744,7 +2868,7 @@ fn test_create_payment_with_btc_currency() {
         &token,
         &Currency::BTC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::BTC);
@@ -2769,7 +2893,7 @@ fn test_create_payment_with_eth_currency() {
         &token,
         &Currency::ETH,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::ETH);
@@ -2794,7 +2918,7 @@ fn test_create_payment_with_usdt_currency() {
         &token,
         &Currency::USDT,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::USDT);
@@ -2884,7 +3008,7 @@ fn test_multiple_currencies_in_payments() {
         &token,
         &Currency::XLM,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer,
@@ -2893,7 +3017,7 @@ fn test_multiple_currencies_in_payments() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id3 = client.create_payment(
         &customer,
@@ -2902,7 +3026,7 @@ fn test_multiple_currencies_in_payments() {
         &token,
         &Currency::BTC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let p1 = client.get_payment(&id1);
@@ -2939,7 +3063,7 @@ fn test_partial_refund_success() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &300);
@@ -2972,7 +3096,7 @@ fn test_multiple_partial_refunds() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &200);
@@ -3006,7 +3130,7 @@ fn test_partial_refund_becomes_full_refund() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &600);
@@ -3040,7 +3164,7 @@ fn test_partial_refund_exceeds_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let result = client.try_partial_refund(&admin, &payment_id, &1500);
@@ -3071,7 +3195,7 @@ fn test_partial_refund_cumulative_exceeds_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &700);
@@ -3083,7 +3207,7 @@ fn test_partial_refund_cumulative_exceeds_payment() {
 // ── DUNNING MANAGEMENT TESTS ─────────────────────────────────────────
 
 fn setup_dunning_contract(
-    env: &Env
+    env: &Env,
 ) -> (PaymentContractClient, Address, Address, Address, Address) {
     let contract_id = env.register(PaymentContract, ());
     let client = PaymentContractClient::new(env, &contract_id);
@@ -3099,11 +3223,11 @@ fn setup_dunning_contract(
     client.set_dunning_config(
         &admin,
         &(DunningConfig {
-            grace_period: 86400, // 1 day
+            grace_period: 86400,                                                 // 1 day
             retry_intervals: Vec::from_array(env, [3600u64, 7200u64, 14400u64]), // 1h, 2h, 4h
             max_dunning_attempts: 4,
             suspend_after_attempts: 3,
-        })
+        }),
     );
 
     (client, admin, customer, merchant, token)
@@ -3127,7 +3251,9 @@ fn test_create_escrowed_payment_locks_funds_in_escrow() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3155,7 +3281,7 @@ fn test_create_escrowed_payment_locks_funds_in_escrow() {
         &1000_u64,
         &0_u64,
         &String::from_str(&env, "bridge"),
-        &true
+        &true,
     );
 
     assert_eq!(ids.0, 1);
@@ -3176,7 +3302,9 @@ fn test_complete_escrowed_payment_releases_escrow_and_merchant_funds() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3206,7 +3334,7 @@ fn test_complete_escrowed_payment_releases_escrow_and_merchant_funds() {
         &1000_u64,
         &0_u64,
         &String::from_str(&env, "bridge"),
-        &true
+        &true,
     );
 
     payment_client.complete_escrowed_payment(&admin, &ids.0);
@@ -3225,7 +3353,9 @@ fn test_cancel_escrowed_payment_refunds_customer() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3253,7 +3383,7 @@ fn test_cancel_escrowed_payment_refunds_customer() {
         &1000_u64,
         &0_u64,
         &String::from_str(&env, "bridge"),
-        &true
+        &true,
     );
 
     payment_client.cancel_escrowed_payment(&customer, &ids.0);
@@ -3304,7 +3434,7 @@ fn test_payment_multisig_propose_complete_payment() {
         &token,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let mut data_bytes = [0u8; 8];
@@ -3485,7 +3615,7 @@ fn test_create_batch_payment_partial_failure() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     let entries = soroban_sdk::vec![
@@ -3522,7 +3652,9 @@ fn test_complete_batch_payment_success() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_mint_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3546,7 +3678,7 @@ fn test_complete_batch_payment_success() {
         &token_contract_id,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let pid2 = client.create_payment(
         &customer,
@@ -3555,7 +3687,7 @@ fn test_complete_batch_payment_success() {
         &token_contract_id,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment_ids = soroban_sdk::vec![&env, pid1, pid2];
@@ -3572,7 +3704,9 @@ fn test_complete_batch_payment_partial_failure() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_mint_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3593,7 +3727,7 @@ fn test_complete_batch_payment_partial_failure() {
         &token_contract_id,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     // Complete pid1 first so it's already processed
     client.complete_payment(&admin, &pid1);
@@ -3627,7 +3761,7 @@ fn test_cancel_batch_payment_success() {
         &token,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let pid2 = client.create_payment(
         &customer,
@@ -3636,7 +3770,7 @@ fn test_cancel_batch_payment_success() {
         &token,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment_ids = soroban_sdk::vec![&env, pid1, pid2];
@@ -3665,15 +3799,18 @@ fn test_batch_payment_events_emitted() {
 
     client.initialize(&admin);
 
-    let entries = soroban_sdk::vec![&env, BatchPaymentEntry {
-        customer: customer.clone(),
-        merchant: merchant.clone(),
-        amount: 100_i128,
-        token: token.clone(),
-        currency: Currency::USDC,
-        expiration_duration: 0,
-        metadata: String::from_str(&env, "batch_event_test"),
-    }];
+    let entries = soroban_sdk::vec![
+        &env,
+        BatchPaymentEntry {
+            customer: customer.clone(),
+            merchant: merchant.clone(),
+            amount: 100_i128,
+            token: token.clone(),
+            currency: Currency::USDC,
+            expiration_duration: 0,
+            metadata: String::from_str(&env, "batch_event_test"),
+        }
+    ];
 
     let results = client.create_batch_payment(&entries);
     assert!(results.get(0).unwrap().success);
@@ -3687,10 +3824,18 @@ fn test_batch_payment_events_emitted() {
 // ── FEE MANAGEMENT TESTS ─────────────────────────────────────────────────────
 
 fn setup_fee_contract(
-    env: &Env
-) -> (PaymentContractClient<'_>, Address, Address, Address, Address) {
+    env: &Env,
+) -> (
+    PaymentContractClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let token_admin = Address::generate(env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
 
     let contract_id = env.register(PaymentContract, ());
     let client = PaymentContractClient::new(env, &contract_id);
@@ -3700,6 +3845,20 @@ fn setup_fee_contract(
     client.initialize(&admin);
 
     (client, admin, contract_id, token_contract_id, token_admin)
+}
+
+fn fee_tier_thresholds(
+    env: &Env,
+    silver: i128,
+    gold: i128,
+    platinum: i128,
+) -> Vec<(FeeTier, i128)> {
+    soroban_sdk::vec![
+        env,
+        (FeeTier::Silver, silver),
+        (FeeTier::Gold, gold),
+        (FeeTier::Platinum, platinum)
+    ]
 }
 
 #[test]
@@ -3761,7 +3920,7 @@ fn test_fee_deducted_from_payment_amount() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -3790,7 +3949,7 @@ fn test_fee_min_clamping() {
 
     let fee_config = FeeConfig {
         fee_bps: 10, // 0.10%: raw_fee = 100 * 10 / 10000 = 0
-        min_fee: 5, // clamped to 5
+        min_fee: 5,  // clamped to 5
         max_fee: 0,
         treasury: treasury.clone(),
         fee_token: token_contract_id.clone(),
@@ -3808,7 +3967,7 @@ fn test_fee_min_clamping() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -3851,7 +4010,7 @@ fn test_fee_max_clamping() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -3894,7 +4053,7 @@ fn test_merchant_tier_upgrade_to_silver() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -3936,7 +4095,7 @@ fn test_merchant_tier_upgrade_to_gold() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -3977,7 +4136,7 @@ fn test_merchant_tier_upgrade_to_platinum() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4020,7 +4179,7 @@ fn test_tier_discount_reduces_fee() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &pid1);
 
@@ -4038,7 +4197,7 @@ fn test_tier_discount_reduces_fee() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &pid2);
 
@@ -4048,7 +4207,10 @@ fn test_tier_discount_reduces_fee() {
     assert_eq!(client.get_accumulated_fees(), total_fees);
 
     let merchant_balance = token_user_client.balance(&merchant);
-    assert_eq!(merchant_balance, vol_amount - fee1 + (amount2 - expected_fee2));
+    assert_eq!(
+        merchant_balance,
+        vol_amount - fee1 + (amount2 - expected_fee2)
+    );
 }
 
 #[test]
@@ -4084,7 +4246,7 @@ fn test_withdraw_fees_to_treasury() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4132,7 +4294,7 @@ fn test_withdraw_fees_only_to_treasury_address() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4175,7 +4337,7 @@ fn test_withdraw_fees_exceeds_accumulated_fails() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4217,7 +4379,7 @@ fn test_fee_not_collected_when_inactive() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4261,6 +4423,185 @@ fn test_get_merchant_fee_record_default() {
     assert_eq!(record.fee_tier, FeeTier::Standard);
 }
 
+#[test]
+fn test_get_and_set_tier_thresholds() {
+    let env = Env::default();
+    let (client, admin, _, _, _) = setup_fee_contract(&env);
+
+    let defaults = client.get_tier_thresholds();
+    assert_eq!(
+        defaults,
+        fee_tier_thresholds(&env, 10_000, 100_000, 1_000_000)
+    );
+
+    let updated = fee_tier_thresholds(&env, 500, 1_500, 5_000);
+    client.set_tier_thresholds(&admin, &updated);
+
+    assert_eq!(client.get_tier_thresholds(), updated);
+}
+
+#[test]
+fn test_set_tier_thresholds_requires_ascending_order() {
+    let env = Env::default();
+    let (client, admin, _, _, _) = setup_fee_contract(&env);
+
+    let invalid = soroban_sdk::vec![
+        &env,
+        (FeeTier::Silver, 1_000_i128),
+        (FeeTier::Gold, 500_i128),
+        (FeeTier::Platinum, 5_000_i128)
+    ];
+
+    let result = client.try_set_tier_thresholds(&admin, &invalid);
+    assert_eq!(result.err(), Some(Ok(Error::InvalidTierThresholds)));
+}
+
+#[test]
+fn test_merchant_tier_upgrade_runs_after_complete_payment_without_fee_collection() {
+    let env = Env::default();
+    let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let amount = 10_001_i128;
+
+    token_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &contract_id, &amount, &200);
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &payment_id);
+
+    let record = client.get_merchant_fee_record(&merchant);
+    assert_eq!(record.total_fees_paid, 0);
+    assert_eq!(record.total_volume, amount);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Silver);
+}
+
+#[test]
+fn test_merchant_tier_upgrade_uses_configured_thresholds() {
+    let env = Env::default();
+    let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    client.set_tier_thresholds(&admin, &fee_tier_thresholds(&env, 100, 200, 300));
+
+    let amount = 250_i128;
+    token_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &contract_id, &amount, &200);
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &payment_id);
+
+    let record = client.get_merchant_fee_record(&merchant);
+    assert_eq!(record.total_volume, amount);
+    assert_eq!(record.fee_tier, FeeTier::Gold);
+}
+
+#[test]
+fn test_merchant_tier_does_not_auto_downgrade() {
+    let env = Env::default();
+    let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    client.set_tier_thresholds(&admin, &fee_tier_thresholds(&env, 100, 200, 300));
+
+    let first_amount = 250_i128;
+    token_client.mint(&customer, &(first_amount + 1));
+    token_user_client.approve(&customer, &contract_id, &(first_amount + 1), &200);
+
+    let first_payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &first_amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &first_payment_id);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Gold);
+
+    client.set_tier_thresholds(&admin, &fee_tier_thresholds(&env, 500, 1_000, 2_000));
+
+    let second_payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &1_i128,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &second_payment_id);
+
+    let record = client.get_merchant_fee_record(&merchant);
+    assert_eq!(record.total_volume, 251);
+    assert_eq!(record.fee_tier, FeeTier::Gold);
+}
+
+#[test]
+fn test_manually_set_merchant_tier_overrides_record() {
+    let env = Env::default();
+    let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let amount = 10_001_i128;
+
+    token_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &contract_id, &amount, &200);
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &payment_id);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Silver);
+
+    client.manually_set_merchant_tier(&admin, &merchant, &FeeTier::Standard);
+
+    let record = client.get_merchant_fee_record(&merchant);
+    assert_eq!(record.total_volume, amount);
+    assert_eq!(record.fee_tier, FeeTier::Standard);
+}
+
 // ── CONDITIONAL PAYMENT TESTS ────────────────────────────────────────────
 
 fn setup_conditional_payment_contract(env: &Env) -> (PaymentContractClient<'_>, Address, Address) {
@@ -4294,7 +4635,7 @@ fn test_create_conditional_payment_timestamp_after() {
         &Currency::USDC,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     // Verify conditional payment was created
@@ -4334,7 +4675,7 @@ fn test_create_conditional_payment_timestamp_before() {
         &Currency::USDC,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     let conditional_payment = client.get_conditional_payment(&payment_id);
@@ -4358,7 +4699,7 @@ fn test_create_conditional_payment_oracle_price() {
         oracle,
         String::from_str(&env, "BTC"),
         50000,
-        PriceComparison::GreaterThan
+        PriceComparison::GreaterThan,
     );
 
     let payment_id = client.create_conditional_payment(
@@ -4369,7 +4710,7 @@ fn test_create_conditional_payment_oracle_price() {
         &Currency::BTC,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     let conditional_payment = client.get_conditional_payment(&payment_id);
@@ -4406,7 +4747,7 @@ fn test_create_conditional_payment_cross_contract_state() {
         &Currency::ETH,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     let conditional_payment = client.get_conditional_payment(&payment_id);
@@ -4442,7 +4783,7 @@ fn test_evaluate_condition_timestamp_after_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be true since 1000 > 500
@@ -4480,7 +4821,7 @@ fn test_evaluate_condition_timestamp_after_not_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be false since 1000 <= 2000
@@ -4514,7 +4855,7 @@ fn test_evaluate_condition_timestamp_before_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be true since 1000 < 2000
@@ -4548,7 +4889,7 @@ fn test_evaluate_condition_timestamp_before_not_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be false since 2000 >= 1000
@@ -4575,7 +4916,7 @@ fn test_evaluate_condition_oracle_price_fails() {
         oracle,
         String::from_str(&env, "BTC"),
         50000,
-        PriceComparison::GreaterThan
+        PriceComparison::GreaterThan,
     );
 
     let payment_id = client.create_conditional_payment(
@@ -4586,7 +4927,7 @@ fn test_evaluate_condition_oracle_price_fails() {
         &Currency::BTC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Oracle conditions should fail with OracleCallFailed error
@@ -4616,7 +4957,7 @@ fn test_evaluate_condition_cross_contract_state_false() {
         &Currency::ETH,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Cross-contract state conditions should return false (mock implementation)
@@ -4650,7 +4991,7 @@ fn test_complete_conditional_payment_success() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Complete the conditional payment
@@ -4682,7 +5023,7 @@ fn test_complete_conditional_payment_condition_not_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Attempt to complete should fail with ConditionNotMet
@@ -4715,7 +5056,7 @@ fn test_complete_conditional_payment_expired() {
         &Currency::USDC,
         &100, // Expires at 1100
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Advance time past expiration
@@ -4748,7 +5089,7 @@ fn test_complete_conditional_payment_unauthorized() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Attempt to complete with unauthorized user should fail
@@ -4788,7 +5129,7 @@ fn test_condition_evaluation_caching() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // First evaluation

--- a/contracts/payment/test_snapshots/test/test_cancel_completed_payment.1.json
+++ b/contracts/payment/test_snapshots/test/test_cancel_completed_payment.1.json
@@ -437,6 +437,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "1000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_complete_batch_payment_partial_failure.1.json
+++ b/contracts/payment/test_snapshots/test/test_complete_batch_payment_partial_failure.1.json
@@ -465,6 +465,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "100"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_complete_batch_payment_success.1.json
+++ b/contracts/payment/test_snapshots/test/test_complete_batch_payment_success.1.json
@@ -502,6 +502,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "300"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_complete_payment_event_emission.1.json
+++ b/contracts/payment/test_snapshots/test/test_complete_payment_event_emission.1.json
@@ -436,6 +436,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "1000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_complete_payment_partial_allowance_with_exact_amount.1.json
+++ b/contracts/payment/test_snapshots/test/test_complete_payment_partial_allowance_with_exact_amount.1.json
@@ -438,6 +438,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "750"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_complete_payment_status_is_completed_after_transfer.1.json
+++ b/contracts/payment/test_snapshots/test/test_complete_payment_status_is_completed_after_transfer.1.json
@@ -437,6 +437,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "500"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_complete_payment_success.1.json
+++ b/contracts/payment/test_snapshots/test/test_complete_payment_success.1.json
@@ -437,6 +437,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "1000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_complete_payment_transfers_tokens_to_merchant.1.json
+++ b/contracts/payment/test_snapshots/test/test_complete_payment_transfers_tokens_to_merchant.1.json
@@ -439,6 +439,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "1000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_fee_not_collected_when_inactive.1.json
+++ b/contracts/payment/test_snapshots/test/test_fee_not_collected_when_inactive.1.json
@@ -570,6 +570,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "10000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_get_and_set_tier_thresholds.1.json
+++ b/contracts/payment/test_snapshots/test/test_get_and_set_tier_thresholds.1.json
@@ -1,0 +1,486 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "set_tier_thresholds",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Silver"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Gold"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "1500"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Platinum"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "5000"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "balance": "0",
+                "seq_num": "0",
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "admins"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_ttl"
+                              },
+                              "val": {
+                                "u64": "604800"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "required_signatures"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_admins"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TierThresholds"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Silver"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Gold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "1500"
+                                }
+                              ]
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Platinum"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "5000"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/payment/test_snapshots/test/test_manually_set_merchant_tier_overrides_record.1.json
+++ b/contracts/payment/test_snapshots/test/test_manually_set_merchant_tier_overrides_record.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 7,
+    "address": 6,
     "nonce": 0,
     "mux_id": 0
   },
@@ -36,10 +36,10 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "10001"
                 }
               ]
             }
@@ -50,7 +50,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
         {
           "function": {
             "contract_fn": {
@@ -58,57 +58,16 @@
               "function_name": "approve",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "10001"
                 },
                 {
-                  "u32": 1000
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "function_name": "create_payment",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                },
-                {
-                  "i128": "1000"
-                },
-                {
-                  "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
-                },
-                {
-                  "vec": [
-                    {
-                      "symbol": "USDC"
-                    }
-                  ]
-                },
-                {
-                  "u64": "0"
-                },
-                {
-                  "string": ""
+                  "u32": 200
                 }
               ]
             }
@@ -133,7 +92,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
-                  "i128": "2000"
+                  "i128": "10001"
                 },
                 {
                   "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
@@ -160,7 +119,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -168,7 +127,7 @@
               "function_name": "complete_payment",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
                   "u64": "1"
@@ -181,6 +140,35 @@
       ]
     ],
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "manually_set_merchant_tier",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "Standard"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -319,7 +307,7 @@
                           ]
                         },
                         "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                         }
                       },
                       {
@@ -329,7 +317,7 @@
                               "symbol": "CustomerAnalytics"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             }
                           ]
                         },
@@ -372,81 +360,10 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "10001"
                               }
                             }
                           ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerAnalytics"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "total_cancelled"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_completed"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_payments"
-                              },
-                              "val": {
-                                "u64": "1"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_refunded"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_volume"
-                              },
-                              "val": {
-                                "i128": "2000"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerPaymentCount"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "1"
                         }
                       },
                       {
@@ -471,24 +388,6 @@
                               "symbol": "CustomerPayments"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            },
-                            {
-                              "u64": "0"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "1"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerPayments"
-                            },
-                            {
                               "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             },
                             {
@@ -497,7 +396,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       },
                       {
@@ -534,7 +433,7 @@
                                 "symbol": "total_payments"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -558,7 +457,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "10001"
                               }
                             }
                           ]
@@ -610,7 +509,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "10001"
                               }
                             }
                           ]
@@ -628,7 +527,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       },
                       {
@@ -653,24 +552,6 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "MerchantPayments"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                            },
-                            {
-                              "u64": "1"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "2"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
                               "symbol": "MultiSigConfig"
                             }
                           ]
@@ -684,7 +565,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                                   }
                                 ]
                               }
@@ -734,7 +615,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "10001"
                               }
                             },
                             {
@@ -762,7 +643,7 @@
                                 "symbol": "customer"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                               }
                             },
                             {
@@ -840,126 +721,6 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Payment"
-                            },
-                            {
-                              "u64": "2"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "amount"
-                              },
-                              "val": {
-                                "i128": "2000"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "created_at"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "currency"
-                              },
-                              "val": {
-                                "vec": [
-                                  {
-                                    "symbol": "USDC"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "customer"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "expires_at"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "id"
-                              },
-                              "val": {
-                                "u64": "2"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "merchant"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "metadata"
-                              },
-                              "val": {
-                                "string": ""
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "notes"
-                              },
-                              "val": {
-                                "string": ""
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "refunded_amount"
-                              },
-                              "val": {
-                                "i128": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "status"
-                              },
-                              "val": {
-                                "vec": [
-                                  {
-                                    "symbol": "Pending"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "token"
-                              },
-                              "val": {
-                                "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
                               "symbol": "PaymentAnalyticsKey"
                             }
                           ]
@@ -987,7 +748,7 @@
                                 "symbol": "total_payments_created"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -1011,7 +772,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "10001"
                               }
                             },
                             {
@@ -1019,7 +780,7 @@
                                 "symbol": "unique_customers"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -1042,7 +803,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       }
                     ]
@@ -1061,72 +822,6 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "1033654523790656264"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "1033654523790656264"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": "4837995959683129791"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "4837995959683129791"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-            "key": {
-              "ledger_key_nonce": {
                 "nonce": "2032731177588607455"
               }
             },
@@ -1139,7 +834,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "2032731177588607455"
@@ -1157,7 +852,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": "4270020994084947596"
@@ -1172,10 +867,76 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "4270020994084947596"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
                   }
                 },
                 "durability": "temporary",
@@ -1203,7 +964,7 @@
                         "symbol": "from"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                       }
                     },
                     {
@@ -1240,7 +1001,7 @@
                             "symbol": "from"
                           },
                           "val": {
-                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                           }
                         },
                         {
@@ -1271,7 +1032,7 @@
                         "symbol": "live_until_ledger"
                       },
                       "val": {
-                        "u32": 1000
+                        "u32": 200
                       }
                     }
                   ]
@@ -1280,7 +1041,7 @@
             },
             "ext": "v0"
           },
-          1000
+          200
         ]
       ],
       [
@@ -1293,7 +1054,7 @@
                   "symbol": "Balance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             },
@@ -1313,7 +1074,7 @@
                       "symbol": "Balance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -1395,7 +1156,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "1000"
+                        "i128": "10001"
                       }
                     },
                     {

--- a/contracts/payment/test_snapshots/test/test_merchant_tier_does_not_auto_downgrade.1.json
+++ b/contracts/payment/test_snapshots/test/test_merchant_tier_does_not_auto_downgrade.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 7,
+    "address": 6,
     "nonce": 0,
     "mux_id": 0
   },
@@ -28,6 +28,71 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "set_tier_thresholds",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Silver"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Gold"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "200"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Platinum"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "300"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
@@ -36,10 +101,10 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "251"
                 }
               ]
             }
@@ -50,7 +115,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
         {
           "function": {
             "contract_fn": {
@@ -58,57 +123,16 @@
               "function_name": "approve",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "251"
                 },
                 {
-                  "u32": 1000
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "function_name": "create_payment",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                },
-                {
-                  "i128": "1000"
-                },
-                {
-                  "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
-                },
-                {
-                  "vec": [
-                    {
-                      "symbol": "USDC"
-                    }
-                  ]
-                },
-                {
-                  "u64": "0"
-                },
-                {
-                  "string": ""
+                  "u32": 200
                 }
               ]
             }
@@ -133,7 +157,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
-                  "i128": "2000"
+                  "i128": "250"
                 },
                 {
                   "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
@@ -160,7 +184,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -168,7 +192,7 @@
               "function_name": "complete_payment",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
                   "u64": "1"
@@ -181,6 +205,134 @@
       ]
     ],
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "set_tier_thresholds",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Silver"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Gold"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "1000"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Platinum"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "2000"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "create_payment",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "i128": "1"
+                },
+                {
+                  "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "USDC"
+                    }
+                  ]
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "string": ""
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "complete_payment",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "2"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -260,7 +412,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -275,7 +427,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "5541220902715666415"
+                    "nonce": "1033654523790656264"
                   }
                 },
                 "durability": "temporary",
@@ -319,63 +471,7 @@
                           ]
                         },
                         "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerAnalytics"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "total_cancelled"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_completed"
-                              },
-                              "val": {
-                                "u64": "1"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_payments"
-                              },
-                              "val": {
-                                "u64": "1"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_refunded"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_volume"
-                              },
-                              "val": {
-                                "i128": "1000"
-                              }
-                            }
-                          ]
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                         }
                       },
                       {
@@ -404,7 +500,7 @@
                                 "symbol": "total_completed"
                               },
                               "val": {
-                                "u64": "0"
+                                "u64": "2"
                               }
                             },
                             {
@@ -412,7 +508,7 @@
                                 "symbol": "total_payments"
                               },
                               "val": {
-                                "u64": "1"
+                                "u64": "2"
                               }
                             },
                             {
@@ -428,7 +524,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "2000"
+                                "i128": "251"
                               }
                             }
                           ]
@@ -441,27 +537,12 @@
                               "symbol": "CustomerPaymentCount"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "1"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerPaymentCount"
-                            },
-                            {
                               "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             }
                           ]
                         },
                         "val": {
-                          "u64": "1"
+                          "u64": "2"
                         }
                       },
                       {
@@ -471,7 +552,7 @@
                               "symbol": "CustomerPayments"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             },
                             {
                               "u64": "0"
@@ -492,7 +573,7 @@
                               "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             },
                             {
-                              "u64": "0"
+                              "u64": "1"
                             }
                           ]
                         },
@@ -526,7 +607,7 @@
                                 "symbol": "total_completed"
                               },
                               "val": {
-                                "u64": "1"
+                                "u64": "2"
                               }
                             },
                             {
@@ -558,7 +639,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "251"
                               }
                             }
                           ]
@@ -584,7 +665,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "symbol": "Standard"
+                                    "symbol": "Gold"
                                   }
                                 ]
                               }
@@ -610,7 +691,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "251"
                               }
                             }
                           ]
@@ -684,7 +765,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                                   }
                                 ]
                               }
@@ -734,7 +815,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "250"
                               }
                             },
                             {
@@ -762,7 +843,7 @@
                                 "symbol": "customer"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                               }
                             },
                             {
@@ -854,7 +935,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "2000"
+                                "i128": "1"
                               }
                             },
                             {
@@ -940,7 +1021,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "symbol": "Pending"
+                                    "symbol": "Completed"
                                   }
                                 ]
                               }
@@ -979,7 +1060,7 @@
                                 "symbol": "total_payments_completed"
                               },
                               "val": {
-                                "u64": "1"
+                                "u64": "2"
                               }
                             },
                             {
@@ -1011,7 +1092,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "251"
                               }
                             },
                             {
@@ -1019,7 +1100,7 @@
                                 "symbol": "unique_customers"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -1044,6 +1125,61 @@
                         "val": {
                           "u64": "2"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TierThresholds"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Silver"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Gold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "1000"
+                                }
+                              ]
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Platinum"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "2000"
+                                }
+                              ]
+                            }
+                          ]
+                        }
                       }
                     ]
                   }
@@ -1061,7 +1197,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "1033654523790656264"
+                "nonce": "4270020994084947596"
               }
             },
             "durability": "temporary"
@@ -1076,7 +1212,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "1033654523790656264"
+                    "nonce": "4270020994084947596"
                   }
                 },
                 "durability": "temporary",
@@ -1094,7 +1230,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "4837995959683129791"
+                "nonce": "5541220902715666415"
               }
             },
             "durability": "temporary"
@@ -1109,7 +1245,73 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "4837995959683129791"
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5806905060045992000"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5806905060045992000"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "8370022561469687789"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "8370022561469687789"
                   }
                 },
                 "durability": "temporary",
@@ -1157,10 +1359,10 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "4270020994084947596"
+                "nonce": "4837995959683129791"
               }
             },
             "durability": "temporary"
@@ -1172,10 +1374,43 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "4270020994084947596"
+                    "nonce": "4837995959683129791"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "6277191135259896685"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "6277191135259896685"
                   }
                 },
                 "durability": "temporary",
@@ -1203,7 +1438,7 @@
                         "symbol": "from"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                       }
                     },
                     {
@@ -1240,7 +1475,7 @@
                             "symbol": "from"
                           },
                           "val": {
-                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                           }
                         },
                         {
@@ -1271,7 +1506,7 @@
                         "symbol": "live_until_ledger"
                       },
                       "val": {
-                        "u32": 1000
+                        "u32": 200
                       }
                     }
                   ]
@@ -1280,7 +1515,7 @@
             },
             "ext": "v0"
           },
-          1000
+          200
         ]
       ],
       [
@@ -1293,7 +1528,7 @@
                   "symbol": "Balance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             },
@@ -1313,7 +1548,7 @@
                       "symbol": "Balance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -1395,7 +1630,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "1000"
+                        "i128": "251"
                       }
                     },
                     {

--- a/contracts/payment/test_snapshots/test/test_merchant_tier_upgrade_runs_after_complete_payment_without_fee_collection.1.json
+++ b/contracts/payment/test_snapshots/test/test_merchant_tier_upgrade_runs_after_complete_payment_without_fee_collection.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 7,
+    "address": 6,
     "nonce": 0,
     "mux_id": 0
   },
@@ -36,10 +36,10 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "10001"
                 }
               ]
             }
@@ -50,7 +50,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
         {
           "function": {
             "contract_fn": {
@@ -58,57 +58,16 @@
               "function_name": "approve",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "10001"
                 },
                 {
-                  "u32": 1000
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "function_name": "create_payment",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                },
-                {
-                  "i128": "1000"
-                },
-                {
-                  "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
-                },
-                {
-                  "vec": [
-                    {
-                      "symbol": "USDC"
-                    }
-                  ]
-                },
-                {
-                  "u64": "0"
-                },
-                {
-                  "string": ""
+                  "u32": 200
                 }
               ]
             }
@@ -133,7 +92,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
-                  "i128": "2000"
+                  "i128": "10001"
                 },
                 {
                   "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
@@ -160,7 +119,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -168,7 +127,7 @@
               "function_name": "complete_payment",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
                   "u64": "1"
@@ -319,7 +278,7 @@
                           ]
                         },
                         "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                         }
                       },
                       {
@@ -329,7 +288,7 @@
                               "symbol": "CustomerAnalytics"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             }
                           ]
                         },
@@ -372,81 +331,10 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "10001"
                               }
                             }
                           ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerAnalytics"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "total_cancelled"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_completed"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_payments"
-                              },
-                              "val": {
-                                "u64": "1"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_refunded"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_volume"
-                              },
-                              "val": {
-                                "i128": "2000"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerPaymentCount"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "1"
                         }
                       },
                       {
@@ -471,24 +359,6 @@
                               "symbol": "CustomerPayments"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            },
-                            {
-                              "u64": "0"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "1"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerPayments"
-                            },
-                            {
                               "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             },
                             {
@@ -497,7 +367,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       },
                       {
@@ -534,7 +404,7 @@
                                 "symbol": "total_payments"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -558,7 +428,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "10001"
                               }
                             }
                           ]
@@ -584,7 +454,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "symbol": "Standard"
+                                    "symbol": "Silver"
                                   }
                                 ]
                               }
@@ -610,7 +480,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "10001"
                               }
                             }
                           ]
@@ -628,7 +498,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       },
                       {
@@ -653,24 +523,6 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "MerchantPayments"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                            },
-                            {
-                              "u64": "1"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "2"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
                               "symbol": "MultiSigConfig"
                             }
                           ]
@@ -684,7 +536,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                                   }
                                 ]
                               }
@@ -734,7 +586,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "10001"
                               }
                             },
                             {
@@ -762,7 +614,7 @@
                                 "symbol": "customer"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                               }
                             },
                             {
@@ -840,126 +692,6 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Payment"
-                            },
-                            {
-                              "u64": "2"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "amount"
-                              },
-                              "val": {
-                                "i128": "2000"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "created_at"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "currency"
-                              },
-                              "val": {
-                                "vec": [
-                                  {
-                                    "symbol": "USDC"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "customer"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "expires_at"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "id"
-                              },
-                              "val": {
-                                "u64": "2"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "merchant"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "metadata"
-                              },
-                              "val": {
-                                "string": ""
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "notes"
-                              },
-                              "val": {
-                                "string": ""
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "refunded_amount"
-                              },
-                              "val": {
-                                "i128": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "status"
-                              },
-                              "val": {
-                                "vec": [
-                                  {
-                                    "symbol": "Pending"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "token"
-                              },
-                              "val": {
-                                "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
                               "symbol": "PaymentAnalyticsKey"
                             }
                           ]
@@ -987,7 +719,7 @@
                                 "symbol": "total_payments_created"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -1011,7 +743,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "10001"
                               }
                             },
                             {
@@ -1019,7 +751,7 @@
                                 "symbol": "unique_customers"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -1042,7 +774,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       }
                     ]
@@ -1061,72 +793,6 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "1033654523790656264"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "1033654523790656264"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": "4837995959683129791"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "4837995959683129791"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-            "key": {
-              "ledger_key_nonce": {
                 "nonce": "2032731177588607455"
               }
             },
@@ -1139,7 +805,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "2032731177588607455"
@@ -1157,10 +823,10 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "4270020994084947596"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -1172,10 +838,43 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "4270020994084947596"
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
                   }
                 },
                 "durability": "temporary",
@@ -1203,7 +902,7 @@
                         "symbol": "from"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                       }
                     },
                     {
@@ -1240,7 +939,7 @@
                             "symbol": "from"
                           },
                           "val": {
-                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                           }
                         },
                         {
@@ -1271,7 +970,7 @@
                         "symbol": "live_until_ledger"
                       },
                       "val": {
-                        "u32": 1000
+                        "u32": 200
                       }
                     }
                   ]
@@ -1280,7 +979,7 @@
             },
             "ext": "v0"
           },
-          1000
+          200
         ]
       ],
       [
@@ -1293,7 +992,7 @@
                   "symbol": "Balance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             },
@@ -1313,7 +1012,7 @@
                       "symbol": "Balance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -1395,7 +1094,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "1000"
+                        "i128": "10001"
                       }
                     },
                     {

--- a/contracts/payment/test_snapshots/test/test_merchant_tier_upgrade_uses_configured_thresholds.1.json
+++ b/contracts/payment/test_snapshots/test/test_merchant_tier_upgrade_uses_configured_thresholds.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 7,
+    "address": 6,
     "nonce": 0,
     "mux_id": 0
   },
@@ -28,6 +28,71 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "set_tier_thresholds",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Silver"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Gold"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "200"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "symbol": "Platinum"
+                            }
+                          ]
+                        },
+                        {
+                          "i128": "300"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
@@ -36,10 +101,10 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "250"
                 }
               ]
             }
@@ -50,7 +115,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
         {
           "function": {
             "contract_fn": {
@@ -58,57 +123,16 @@
               "function_name": "approve",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "i128": "1000"
+                  "i128": "250"
                 },
                 {
-                  "u32": 1000
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "function_name": "create_payment",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                },
-                {
-                  "i128": "1000"
-                },
-                {
-                  "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
-                },
-                {
-                  "vec": [
-                    {
-                      "symbol": "USDC"
-                    }
-                  ]
-                },
-                {
-                  "u64": "0"
-                },
-                {
-                  "string": ""
+                  "u32": 200
                 }
               ]
             }
@@ -133,7 +157,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
-                  "i128": "2000"
+                  "i128": "250"
                 },
                 {
                   "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
@@ -160,7 +184,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -168,7 +192,7 @@
               "function_name": "complete_payment",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
                   "u64": "1"
@@ -180,7 +204,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -260,7 +283,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -275,7 +298,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "5541220902715666415"
+                    "nonce": "1033654523790656264"
                   }
                 },
                 "durability": "temporary",
@@ -319,7 +342,7 @@
                           ]
                         },
                         "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                         }
                       },
                       {
@@ -329,7 +352,7 @@
                               "symbol": "CustomerAnalytics"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             }
                           ]
                         },
@@ -372,81 +395,10 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "250"
                               }
                             }
                           ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerAnalytics"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "total_cancelled"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_completed"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_payments"
-                              },
-                              "val": {
-                                "u64": "1"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_refunded"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "total_volume"
-                              },
-                              "val": {
-                                "i128": "2000"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerPaymentCount"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "1"
                         }
                       },
                       {
@@ -471,24 +423,6 @@
                               "symbol": "CustomerPayments"
                             },
                             {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                            },
-                            {
-                              "u64": "0"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "1"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "CustomerPayments"
-                            },
-                            {
                               "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                             },
                             {
@@ -497,7 +431,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       },
                       {
@@ -534,7 +468,7 @@
                                 "symbol": "total_payments"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -558,7 +492,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "250"
                               }
                             }
                           ]
@@ -584,7 +518,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "symbol": "Standard"
+                                    "symbol": "Gold"
                                   }
                                 ]
                               }
@@ -610,7 +544,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "250"
                               }
                             }
                           ]
@@ -628,7 +562,7 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
                         }
                       },
                       {
@@ -653,24 +587,6 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "MerchantPayments"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                            },
-                            {
-                              "u64": "1"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u64": "2"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
                               "symbol": "MultiSigConfig"
                             }
                           ]
@@ -684,7 +600,7 @@
                               "val": {
                                 "vec": [
                                   {
-                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                                   }
                                 ]
                               }
@@ -734,7 +650,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "1000"
+                                "i128": "250"
                               }
                             },
                             {
@@ -762,7 +678,7 @@
                                 "symbol": "customer"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                               }
                             },
                             {
@@ -840,126 +756,6 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "Payment"
-                            },
-                            {
-                              "u64": "2"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "amount"
-                              },
-                              "val": {
-                                "i128": "2000"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "created_at"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "currency"
-                              },
-                              "val": {
-                                "vec": [
-                                  {
-                                    "symbol": "USDC"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "customer"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "expires_at"
-                              },
-                              "val": {
-                                "u64": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "id"
-                              },
-                              "val": {
-                                "u64": "2"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "merchant"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "metadata"
-                              },
-                              "val": {
-                                "string": ""
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "notes"
-                              },
-                              "val": {
-                                "string": ""
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "refunded_amount"
-                              },
-                              "val": {
-                                "i128": "0"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "status"
-                              },
-                              "val": {
-                                "vec": [
-                                  {
-                                    "symbol": "Pending"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "token"
-                              },
-                              "val": {
-                                "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
                               "symbol": "PaymentAnalyticsKey"
                             }
                           ]
@@ -987,7 +783,7 @@
                                 "symbol": "total_payments_created"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -1011,7 +807,7 @@
                                 "symbol": "total_volume"
                               },
                               "val": {
-                                "i128": "3000"
+                                "i128": "250"
                               }
                             },
                             {
@@ -1019,7 +815,7 @@
                                 "symbol": "unique_customers"
                               },
                               "val": {
-                                "u64": "2"
+                                "u64": "1"
                               }
                             },
                             {
@@ -1042,7 +838,62 @@
                           ]
                         },
                         "val": {
-                          "u64": "2"
+                          "u64": "1"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TierThresholds"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Silver"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "100"
+                                }
+                              ]
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Gold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "200"
+                                }
+                              ]
+                            },
+                            {
+                              "vec": [
+                                {
+                                  "vec": [
+                                    {
+                                      "symbol": "Platinum"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "i128": "300"
+                                }
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -1061,7 +912,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "1033654523790656264"
+                "nonce": "4270020994084947596"
               }
             },
             "durability": "temporary"
@@ -1076,7 +927,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "1033654523790656264"
+                    "nonce": "4270020994084947596"
                   }
                 },
                 "durability": "temporary",
@@ -1094,7 +945,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "4837995959683129791"
+                "nonce": "5541220902715666415"
               }
             },
             "durability": "temporary"
@@ -1109,7 +960,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "4837995959683129791"
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",
@@ -1157,10 +1008,10 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "4270020994084947596"
+                "nonce": "4837995959683129791"
               }
             },
             "durability": "temporary"
@@ -1172,10 +1023,10 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": "4270020994084947596"
+                    "nonce": "4837995959683129791"
                   }
                 },
                 "durability": "temporary",
@@ -1203,7 +1054,7 @@
                         "symbol": "from"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                       }
                     },
                     {
@@ -1240,7 +1091,7 @@
                             "symbol": "from"
                           },
                           "val": {
-                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                           }
                         },
                         {
@@ -1271,7 +1122,7 @@
                         "symbol": "live_until_ledger"
                       },
                       "val": {
-                        "u32": 1000
+                        "u32": 200
                       }
                     }
                   ]
@@ -1280,7 +1131,7 @@
             },
             "ext": "v0"
           },
-          1000
+          200
         ]
       ],
       [
@@ -1293,7 +1144,7 @@
                   "symbol": "Balance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             },
@@ -1313,7 +1164,7 @@
                       "symbol": "Balance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -1395,7 +1246,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "1000"
+                        "i128": "250"
                       }
                     },
                     {

--- a/contracts/payment/test_snapshots/test/test_metadata_persists_through_payment_lifecycle.1.json
+++ b/contracts/payment/test_snapshots/test/test_metadata_persists_through_payment_lifecycle.1.json
@@ -462,6 +462,58 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "MerchantFeeRecord"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_tier"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "symbol": "Standard"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_fees_paid"
+                              },
+                              "val": {
+                                "i128": "0"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_volume"
+                              },
+                              "val": {
+                                "i128": "1000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "MerchantPaymentCount"
                             },
                             {

--- a/contracts/payment/test_snapshots/test/test_set_tier_thresholds_requires_ascending_order.1.json
+++ b/contracts/payment/test_snapshots/test/test_set_tier_thresholds_requires_ascending_order.1.json
@@ -1,0 +1,332 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "balance": "0",
+                "seq_num": "0",
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MultiSigConfig"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "admins"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "proposal_ttl"
+                              },
+                              "val": {
+                                "u64": "604800"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "required_signatures"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_admins"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -302,7 +302,9 @@ impl RefundContract {
             auto_approve_below: 0, // No auto-approve by default
             active: true,
         };
-        env.storage().instance().set(&DataKey::DefaultRefundPolicy, &default_policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::DefaultRefundPolicy, &default_policy);
     }
 
     pub fn request_refund(
@@ -314,7 +316,7 @@ impl RefundContract {
         original_payment_amount: i128,
         token: Address,
         reason: String,
-        payment_created_at: u64
+        payment_created_at: u64,
     ) -> Result<u64, Error> {
         // Require merchant authentication
         merchant.require_auth();
@@ -341,11 +343,15 @@ impl RefundContract {
             &merchant,
             amount,
             original_payment_amount,
-            payment_created_at
+            payment_created_at,
         )?;
 
         // Get and increment refund counter
-        let counter: u64 = env.storage().instance().get(&DataKey::RefundCounter).unwrap_or(0);
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundCounter)
+            .unwrap_or(0);
         let refund_id = counter + 1;
 
         // Determine initial status based on policy
@@ -374,8 +380,12 @@ impl RefundContract {
         };
 
         // Store refund in contract storage
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
-        env.storage().instance().set(&DataKey::RefundCounter, &refund_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundCounter, &refund_id);
         Self::add_to_status_index(&env, initial_status.clone(), refund_id);
 
         // Index refund by merchant
@@ -431,14 +441,12 @@ impl RefundContract {
             customer,
             amount,
             token,
-        }).publish(&env);
+        })
+        .publish(&env);
 
         // Emit AutoApproved event if applicable
         if initial_status == RefundStatus::Approved {
-            (AutoApproved {
-                refund_id,
-                amount,
-            }).publish(&env);
+            (AutoApproved { refund_id, amount }).publish(&env);
         }
 
         // Return the new refund ID
@@ -447,7 +455,10 @@ impl RefundContract {
 
     pub fn get_refund(env: &Env, refund_id: u64) -> Result<Refund, Error> {
         // Retrieve refund from storage by ID
-        env.storage().instance().get(&DataKey::Refund(refund_id)).ok_or(Error::RefundNotFound)
+        env.storage()
+            .instance()
+            .get(&DataKey::Refund(refund_id))
+            .ok_or(Error::RefundNotFound)
     }
 
     pub fn approve_refund(env: Env, admin: Address, refund_id: u64) -> Result<(), Error> {
@@ -472,7 +483,9 @@ impl RefundContract {
         refund.status = RefundStatus::Approved;
 
         // Store updated refund back to storage
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(&env, RefundStatus::Approved, refund_id);
 
         // Emit RefundApproved event
@@ -480,7 +493,8 @@ impl RefundContract {
             refund_id,
             approved_by: admin,
             approved_at: env.ledger().timestamp(),
-        }).publish(&env);
+        })
+        .publish(&env);
 
         Ok(())
     }
@@ -489,7 +503,7 @@ impl RefundContract {
         env: Env,
         admin: Address,
         refund_id: u64,
-        rejection_reason: String
+        rejection_reason: String,
     ) -> Result<(), Error> {
         // Require admin authentication
         admin.require_auth();
@@ -512,7 +526,9 @@ impl RefundContract {
         refund.status = RefundStatus::Rejected;
 
         // Store updated refund back to storage
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(&env, RefundStatus::Rejected, refund_id);
 
         // Emit RefundRejected event
@@ -521,7 +537,8 @@ impl RefundContract {
             rejected_by: admin,
             rejected_at: env.ledger().timestamp(),
             rejection_reason,
-        }).publish(&env);
+        })
+        .publish(&env);
 
         Ok(())
     }
@@ -543,13 +560,15 @@ impl RefundContract {
             &env,
             refund.payment_id,
             refund.amount,
-            refund.original_payment_amount
+            refund.original_payment_amount,
         )?;
 
         Self::remove_from_status_index(&env, RefundStatus::Approved, refund_id)?;
         refund.status = RefundStatus::Processed;
 
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(&env, RefundStatus::Processed, refund_id);
 
         Ok(())
@@ -811,7 +830,7 @@ impl RefundContract {
         env: &Env,
         status: RefundStatus,
         limit: u64,
-        offset: u64
+        offset: u64,
     ) -> Vec<Refund> {
         let mut results: Vec<Refund> = Vec::new(env);
         let total = Self::get_refund_count_by_status(env, status.clone());
@@ -823,17 +842,15 @@ impl RefundContract {
         let end = core::cmp::min(total, offset.saturating_add(limit));
         let mut index = offset;
         while index < end {
-            if
-                let Some(refund_id) = env
+            if let Some(refund_id) = env
+                .storage()
+                .instance()
+                .get::<_, u64>(&DataKey::RefundsByStatus(status.clone(), index))
+            {
+                if let Some(refund) = env
                     .storage()
                     .instance()
-                    .get::<_, u64>(&DataKey::RefundsByStatus(status.clone(), index))
-            {
-                if
-                    let Some(refund) = env
-                        .storage()
-                        .instance()
-                        .get::<_, Refund>(&DataKey::Refund(refund_id))
+                    .get::<_, Refund>(&DataKey::Refund(refund_id))
                 {
                     results.push_back(refund);
                 }
@@ -845,11 +862,18 @@ impl RefundContract {
     }
 
     pub fn get_refund_count_by_status(env: &Env, status: RefundStatus) -> u64 {
-        env.storage().instance().get(&DataKey::RefundStatusCount(status)).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::RefundStatusCount(status))
+            .unwrap_or(0)
     }
 
     pub fn get_total_refunded_amount(env: &Env, payment_id: u64) -> i128 {
-        let total_refunds: u64 = env.storage().instance().get(&DataKey::RefundCounter).unwrap_or(0);
+        let total_refunds: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundCounter)
+            .unwrap_or(0);
         let mut total: i128 = 0;
 
         let mut id: u64 = 1;
@@ -873,7 +897,7 @@ impl RefundContract {
         env: &Env,
         payment_id: u64,
         requested_amount: i128,
-        original_amount: i128
+        original_amount: i128,
     ) -> Result<bool, Error> {
         let total_refunded = Self::get_total_refunded_amount(env, payment_id);
         if requested_amount.saturating_add(total_refunded) > original_amount {
@@ -889,7 +913,7 @@ impl RefundContract {
         refund_window: u64,
         max_refund_percentage: u32,
         requires_admin_approval: bool,
-        auto_approve_below: i128
+        auto_approve_below: i128,
     ) -> Result<(), Error> {
         // Require merchant authentication
         merchant.require_auth();
@@ -908,19 +932,24 @@ impl RefundContract {
             active: true,
         };
 
-        env.storage().instance().set(&DataKey::RefundPolicy(merchant.clone()), &policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicy(merchant.clone()), &policy);
 
         // Emit RefundPolicySet event
         (RefundPolicySet {
             merchant,
             refund_window,
-        }).publish(&env);
+        })
+        .publish(&env);
 
         Ok(())
     }
 
     pub fn get_refund_policy(env: &Env, merchant: Address) -> Option<RefundPolicy> {
-        env.storage().instance().get(&DataKey::RefundPolicy(merchant))
+        env.storage()
+            .instance()
+            .get(&DataKey::RefundPolicy(merchant))
     }
 
     pub fn deactivate_refund_policy(env: Env, merchant: Address) -> Result<(), Error> {
@@ -938,7 +967,9 @@ impl RefundContract {
         }
 
         policy.active = false;
-        env.storage().instance().set(&DataKey::RefundPolicy(merchant.clone()), &policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicy(merchant.clone()), &policy);
 
         // Emit RefundPolicyDeactivated event
         (RefundPolicyDeactivated { merchant }).publish(&env);
@@ -950,7 +981,7 @@ impl RefundContract {
         env: Env,
         admin: Address,
         refund_id: u64,
-        reason: String
+        reason: String,
     ) -> Result<(), Error> {
         // Require admin authentication
         admin.require_auth();
@@ -977,7 +1008,8 @@ impl RefundContract {
             refund_id,
             admin,
             reason,
-        }).publish(&env);
+        })
+        .publish(&env);
 
         Ok(())
     }
@@ -987,26 +1019,25 @@ impl RefundContract {
         merchant: &Address,
         amount: i128,
         original_amount: i128,
-        payment_created_at: u64
+        payment_created_at: u64,
     ) -> Result<(), Error> {
         // Get merchant-specific policy or default
-        let policy: RefundPolicy = if
-            let Some(merchant_policy) = Self::get_refund_policy(env, merchant.clone())
-        {
-            merchant_policy
-        } else {
-            env.storage()
-                .instance()
-                .get(&DataKey::DefaultRefundPolicy)
-                .unwrap_or_else(|| RefundPolicy {
-                    merchant: merchant.clone(),
-                    refund_window: 30 * 24 * 60 * 60, // 30 days
-                    max_refund_percentage: 10000, // 100%
-                    requires_admin_approval: true,
-                    auto_approve_below: 0,
-                    active: true,
-                })
-        };
+        let policy: RefundPolicy =
+            if let Some(merchant_policy) = Self::get_refund_policy(env, merchant.clone()) {
+                merchant_policy
+            } else {
+                env.storage()
+                    .instance()
+                    .get(&DataKey::DefaultRefundPolicy)
+                    .unwrap_or_else(|| RefundPolicy {
+                        merchant: merchant.clone(),
+                        refund_window: 30 * 24 * 60 * 60, // 30 days
+                        max_refund_percentage: 10000,     // 100%
+                        requires_admin_approval: true,
+                        auto_approve_below: 0,
+                        active: true,
+                    })
+            };
 
         // Check if policy is active
         if !policy.active {
@@ -1035,17 +1066,21 @@ impl RefundContract {
 
     fn add_to_status_index(env: &Env, status: RefundStatus, refund_id: u64) {
         let count = Self::get_refund_count_by_status(env, status.clone());
-        env.storage().instance().set(&DataKey::RefundsByStatus(status.clone(), count), &refund_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundsByStatus(status.clone(), count), &refund_id);
         env.storage()
             .instance()
             .set(&DataKey::RefundStatusCount(status.clone()), &(count + 1));
-        env.storage().instance().set(&DataKey::RefundStatusIndex(refund_id), &count);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundStatusIndex(refund_id), &count);
     }
 
     fn remove_from_status_index(
         env: &Env,
         status: RefundStatus,
-        refund_id: u64
+        refund_id: u64,
     ) -> Result<(), Error> {
         let count = Self::get_refund_count_by_status(env, status.clone());
         if count == 0 {
@@ -1074,9 +1109,15 @@ impl RefundContract {
                 .set(&DataKey::RefundStatusIndex(last_refund_id), &index);
         }
 
-        env.storage().instance().remove(&DataKey::RefundsByStatus(status.clone(), last_index));
-        env.storage().instance().remove(&DataKey::RefundStatusIndex(refund_id));
-        env.storage().instance().set(&DataKey::RefundStatusCount(status), &last_index);
+        env.storage()
+            .instance()
+            .remove(&DataKey::RefundsByStatus(status.clone(), last_index));
+        env.storage()
+            .instance()
+            .remove(&DataKey::RefundStatusIndex(refund_id));
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundStatusCount(status), &last_index);
 
         Ok(())
     }
@@ -1084,12 +1125,16 @@ impl RefundContract {
     // ── ANALYTICS FUNCTIONS ────────────────────────────────────────────────
 
     pub fn get_refund_analytics(env: Env) -> RefundAnalytics {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&DataKey::RefundAnalyticsKey)
             .unwrap_or(RefundAnalytics {
-                total_refunds_requested: 0, total_refunds_approved: 0,
-                total_refunds_rejected: 0, total_refunds_processed: 0,
-                total_refund_volume: 0, approval_rate_bps: 0,
+                total_refunds_requested: 0,
+                total_refunds_approved: 0,
+                total_refunds_rejected: 0,
+                total_refunds_processed: 0,
+                total_refund_volume: 0,
+                approval_rate_bps: 0,
             })
     }
 
@@ -1097,15 +1142,20 @@ impl RefundContract {
 
     pub fn pause_contract(env: Env, admin: Address, reason: String) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
         let now = env.ledger().timestamp();
-        let pause_state = if let Some(mut state) = env.storage().instance()
-            .get::<DataKey, PauseState>(&DataKey::PauseStateKey) {
+        let pause_state = if let Some(mut state) = env
+            .storage()
+            .instance()
+            .get::<DataKey, PauseState>(&DataKey::PauseStateKey)
+        {
             state.globally_paused = true;
             state.paused_at = now;
             state.paused_by = admin.clone();
@@ -1120,8 +1170,12 @@ impl RefundContract {
                 pause_reason: reason.clone(),
             }
         };
-        env.storage().instance().set(&DataKey::PauseStateKey, &pause_state);
-        let history_count: u64 = env.storage().instance()
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseStateKey, &pause_state);
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&DataKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -1132,27 +1186,45 @@ impl RefundContract {
             changed_at: now,
             reason: reason.clone(),
         };
-        env.storage().instance().set(&DataKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&DataKey::PauseHistoryCount, &(history_count + 1));
-        (ContractPausedEvent { paused_by: admin, reason, paused_at: now }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryCount, &(history_count + 1));
+        (ContractPausedEvent {
+            paused_by: admin,
+            reason,
+            paused_at: now,
+        })
+        .publish(&env);
         Ok(())
     }
 
     pub fn unpause_contract(env: Env, admin: Address) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
-        if let Some(mut state) = env.storage().instance()
-            .get::<DataKey, PauseState>(&DataKey::PauseStateKey) {
+        if let Some(mut state) = env
+            .storage()
+            .instance()
+            .get::<DataKey, PauseState>(&DataKey::PauseStateKey)
+        {
             state.globally_paused = false;
-            env.storage().instance().set(&DataKey::PauseStateKey, &state);
+            env.storage()
+                .instance()
+                .set(&DataKey::PauseStateKey, &state);
         }
         let now = env.ledger().timestamp();
-        let history_count: u64 = env.storage().instance()
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&DataKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -1163,9 +1235,17 @@ impl RefundContract {
             changed_at: now,
             reason: String::from_str(&env, ""),
         };
-        env.storage().instance().set(&DataKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&DataKey::PauseHistoryCount, &(history_count + 1));
-        (ContractUnpausedEvent { unpaused_by: admin, unpaused_at: now }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryCount, &(history_count + 1));
+        (ContractUnpausedEvent {
+            unpaused_by: admin,
+            unpaused_at: now,
+        })
+        .publish(&env);
         Ok(())
     }
 
@@ -1176,15 +1256,20 @@ impl RefundContract {
         reason: String,
     ) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
         let now = env.ledger().timestamp();
-        let mut pause_state = if let Some(state) = env.storage().instance()
-            .get::<DataKey, PauseState>(&DataKey::PauseStateKey) {
+        let mut pause_state = if let Some(state) = env
+            .storage()
+            .instance()
+            .get::<DataKey, PauseState>(&DataKey::PauseStateKey)
+        {
             state
         } else {
             PauseState {
@@ -1196,10 +1281,16 @@ impl RefundContract {
             }
         };
         if !pause_state.paused_functions.contains(&function_name) {
-            pause_state.paused_functions.push_back(function_name.clone());
+            pause_state
+                .paused_functions
+                .push_back(function_name.clone());
         }
-        env.storage().instance().set(&DataKey::PauseStateKey, &pause_state);
-        let history_count: u64 = env.storage().instance()
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseStateKey, &pause_state);
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&DataKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -1210,26 +1301,36 @@ impl RefundContract {
             changed_at: now,
             reason: reason.clone(),
         };
-        env.storage().instance().set(&DataKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&DataKey::PauseHistoryCount, &(history_count + 1));
-        (FunctionPausedEvent { function_name, paused_by: admin, reason }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryCount, &(history_count + 1));
+        (FunctionPausedEvent {
+            function_name,
+            paused_by: admin,
+            reason,
+        })
+        .publish(&env);
         Ok(())
     }
 
-    pub fn unpause_function(
-        env: Env,
-        admin: Address,
-        function_name: String,
-    ) -> Result<(), Error> {
+    pub fn unpause_function(env: Env, admin: Address, function_name: String) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
-        if let Some(mut state) = env.storage().instance()
-            .get::<DataKey, PauseState>(&DataKey::PauseStateKey) {
+        if let Some(mut state) = env
+            .storage()
+            .instance()
+            .get::<DataKey, PauseState>(&DataKey::PauseStateKey)
+        {
             let mut new_paused = Vec::new(&env);
             for fn_name in state.paused_functions.iter() {
                 if fn_name != function_name {
@@ -1237,10 +1338,14 @@ impl RefundContract {
                 }
             }
             state.paused_functions = new_paused;
-            env.storage().instance().set(&DataKey::PauseStateKey, &state);
+            env.storage()
+                .instance()
+                .set(&DataKey::PauseStateKey, &state);
         }
         let now = env.ledger().timestamp();
-        let history_count: u64 = env.storage().instance()
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&DataKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -1251,14 +1356,23 @@ impl RefundContract {
             changed_at: now,
             reason: String::from_str(&env, ""),
         };
-        env.storage().instance().set(&DataKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&DataKey::PauseHistoryCount, &(history_count + 1));
-        (FunctionUnpausedEvent { function_name, unpaused_by: admin }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistoryCount, &(history_count + 1));
+        (FunctionUnpausedEvent {
+            function_name,
+            unpaused_by: admin,
+        })
+        .publish(&env);
         Ok(())
     }
 
     pub fn get_pause_state(env: Env) -> PauseState {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&DataKey::PauseStateKey)
             .unwrap_or(PauseState {
                 globally_paused: false,
@@ -1270,19 +1384,29 @@ impl RefundContract {
     }
 
     pub fn is_function_paused(env: Env, function_name: String) -> bool {
-        if let Some(state) = env.storage().instance()
-            .get::<DataKey, PauseState>(&DataKey::PauseStateKey) {
-            if state.globally_paused { return true; }
+        if let Some(state) = env
+            .storage()
+            .instance()
+            .get::<DataKey, PauseState>(&DataKey::PauseStateKey)
+        {
+            if state.globally_paused {
+                return true;
+            }
             for fn_name in state.paused_functions.iter() {
-                if fn_name == function_name { return true; }
+                if fn_name == function_name {
+                    return true;
+                }
             }
         }
         false
     }
 
     fn require_not_paused(env: &Env, function_name: &str) -> Result<(), Error> {
-        if let Some(state) = env.storage().instance()
-            .get::<DataKey, PauseState>(&DataKey::PauseStateKey) {
+        if let Some(state) = env
+            .storage()
+            .instance()
+            .get::<DataKey, PauseState>(&DataKey::PauseStateKey)
+        {
             if state.globally_paused {
                 return Err(Error::ContractPaused);
             }
@@ -1298,5 +1422,5 @@ impl RefundContract {
 }
 
 mod test;
-mod test_process;
 mod test_policy;
+mod test_process;

--- a/contracts/refund/src/test.rs
+++ b/contracts/refund/src/test.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{ testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String };
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String,
+};
 
 #[test]
 fn test_request_refund_with_valid_data() {
@@ -26,7 +28,7 @@ fn test_request_refund_with_valid_data() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     assert_eq!(refund_id, 1u64);
@@ -57,7 +59,7 @@ fn test_refund_id_increments_correctly() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     let refund_id2 = client.request_refund(
@@ -68,7 +70,7 @@ fn test_refund_id_increments_correctly() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     assert_eq!(refund_id1, 1u64);
@@ -97,7 +99,7 @@ fn test_get_refund_by_id() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -143,7 +145,7 @@ fn test_request_multiple_refunds_and_retrieve_each() {
         &amount1,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     let refund_id2 = client.request_refund(
@@ -154,7 +156,7 @@ fn test_request_multiple_refunds_and_retrieve_each() {
         &amount2,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     let refund_id3 = client.request_refund(
@@ -165,7 +167,7 @@ fn test_request_multiple_refunds_and_retrieve_each() {
         &amount3,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     let refund1 = client.get_refund(&refund_id1);
@@ -200,7 +202,16 @@ fn test_request_refund_with_zero_amount_should_fail() {
     let reason = String::from_str(&env, "Test reason");
 
     env.mock_all_auths();
-    client.request_refund(&merchant, &payment_id, &customer, &amount, &amount, &token, &reason, &0_u64);
+    client.request_refund(
+        &merchant,
+        &payment_id,
+        &customer,
+        &amount,
+        &amount,
+        &token,
+        &reason,
+        &0_u64,
+    );
 }
 
 #[test]
@@ -218,7 +229,16 @@ fn test_request_refund_with_negative_amount_should_fail() {
     let reason = String::from_str(&env, "Test reason");
 
     env.mock_all_auths();
-    client.request_refund(&merchant, &payment_id, &customer, &amount, &amount, &token, &reason, &0_u64);
+    client.request_refund(
+        &merchant,
+        &payment_id,
+        &customer,
+        &amount,
+        &amount,
+        &token,
+        &reason,
+        &0_u64,
+    );
 }
 
 #[test]
@@ -236,7 +256,16 @@ fn test_request_refund_with_invalid_payment_id_should_fail() {
     let reason = String::from_str(&env, "Test reason");
 
     env.mock_all_auths();
-    client.request_refund(&merchant, &payment_id, &customer, &amount, &amount, &token, &reason, &0_u64);
+    client.request_refund(
+        &merchant,
+        &payment_id,
+        &customer,
+        &amount,
+        &amount,
+        &token,
+        &reason,
+        &0_u64,
+    );
 }
 
 #[test]
@@ -272,7 +301,7 @@ fn test_refund_requested_event_is_emitted() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     // Check that the event was emitted
@@ -306,7 +335,7 @@ fn test_refund_stored_with_requested_status() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -335,7 +364,7 @@ fn test_request_refund_without_reason() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -365,7 +394,7 @@ fn test_request_refund_with_reason() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -398,7 +427,7 @@ fn test_approve_requested_refund_successfully() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -432,7 +461,7 @@ fn test_reject_requested_refund_successfully() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -495,7 +524,7 @@ fn test_approve_already_approved_refund_should_fail() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -528,7 +557,7 @@ fn test_reject_already_rejected_refund_should_fail() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -561,7 +590,7 @@ fn test_approve_rejected_refund_should_fail() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -594,7 +623,7 @@ fn test_reject_approved_refund_should_fail() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -625,7 +654,7 @@ fn test_refund_approved_event_is_emitted() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -659,7 +688,7 @@ fn test_refund_rejected_event_is_emitted() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -692,7 +721,7 @@ fn test_approve_correct_refund_among_multiple() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let refund_id2 = client.request_refund(
         &merchant,
@@ -702,7 +731,7 @@ fn test_approve_correct_refund_among_multiple() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let refund_id3 = client.request_refund(
         &merchant,
@@ -712,7 +741,7 @@ fn test_approve_correct_refund_among_multiple() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     client.approve_refund(&admin, &refund_id2);
@@ -751,7 +780,7 @@ fn test_reject_refund_with_empty_reason() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -785,7 +814,7 @@ fn test_reject_refund_with_detailed_reason() {
         &amount,
         &token,
         &reason,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -817,7 +846,7 @@ fn test_request_partial_refund_half_payment() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     let refund = client.get_refund(&refund_id);
@@ -849,7 +878,7 @@ fn test_multiple_partial_refunds_for_same_payment() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id1);
     client.process_refund(&admin, &refund_id1);
@@ -862,7 +891,7 @@ fn test_multiple_partial_refunds_for_same_payment() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let refund2 = client.get_refund(&refund_id2);
     assert_eq!(refund2.status, RefundStatus::Requested);
@@ -895,7 +924,7 @@ fn test_request_refund_exceeding_original_payment_should_fail() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 }
 
@@ -923,7 +952,7 @@ fn test_cumulative_refunds_exceeding_payment_should_fail() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id1);
     client.process_refund(&admin, &refund_id1);
@@ -936,7 +965,7 @@ fn test_cumulative_refunds_exceeding_payment_should_fail() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 }
 
@@ -963,7 +992,7 @@ fn test_status_queries_and_counts() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let r2 = client.request_refund(
         &merchant,
@@ -973,7 +1002,7 @@ fn test_status_queries_and_counts() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let r3 = client.request_refund(
         &merchant,
@@ -983,23 +1012,47 @@ fn test_status_queries_and_counts() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Requested), 3u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Approved), 0u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Rejected), 0u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Processed), 0u64);
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Requested),
+        3u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Approved),
+        0u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Rejected),
+        0u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Processed),
+        0u64
+    );
 
     client.approve_refund(&admin, &r1);
     client.reject_refund(&admin, &r2, &String::from_str(&env, "No"));
     client.approve_refund(&admin, &r3);
     client.process_refund(&admin, &r3);
 
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Requested), 0u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Approved), 1u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Rejected), 1u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Processed), 1u64);
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Requested),
+        0u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Approved),
+        1u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Rejected),
+        1u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Processed),
+        1u64
+    );
 
     let requested = client.get_refunds_by_status(&RefundStatus::Requested, &10u64, &0u64);
     assert_eq!(requested.len(), 0);
@@ -1039,7 +1092,7 @@ fn test_pagination_for_status_queries() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let r2 = client.request_refund(
         &merchant,
@@ -1049,7 +1102,7 @@ fn test_pagination_for_status_queries() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let r3 = client.request_refund(
         &merchant,
@@ -1059,7 +1112,7 @@ fn test_pagination_for_status_queries() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     let r4 = client.request_refund(
         &merchant,
@@ -1069,7 +1122,7 @@ fn test_pagination_for_status_queries() {
         &amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     let page = client.get_refunds_by_status(&RefundStatus::Requested, &2u64, &1u64);
@@ -1108,7 +1161,7 @@ fn test_refund_for_zero_amount_payment_should_fail() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 }
 
@@ -1135,7 +1188,7 @@ fn test_full_refund_is_allowed() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
 
     let refund = client.get_refund(&refund_id);
@@ -1151,7 +1204,10 @@ fn test_status_query_with_no_refunds() {
 
     let refunds = client.get_refunds_by_status(&RefundStatus::Approved, &10u64, &0u64);
     assert_eq!(refunds.len(), 0);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Approved), 0u64);
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Approved),
+        0u64
+    );
 }
 
 #[test]
@@ -1177,7 +1233,7 @@ fn test_can_refund_payment_helper() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id);
     client.process_refund(&admin, &refund_id);
@@ -1210,7 +1266,7 @@ fn test_can_refund_payment_helper_rejects_overflow() {
         &original_payment_amount,
         &token,
         &reason,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id);
     client.process_refund(&admin, &refund_id);
@@ -1249,7 +1305,7 @@ fn test_arbitration_quorum() {
         &1000i128,
         &token,
         &String::from_str(&env, "reason"),
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1300,7 +1356,7 @@ fn test_arbitration_deadline_enforcement() {
         &1000i128,
         &token,
         &String::from_str(&env, "reason"),
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1354,7 +1410,7 @@ fn test_arbitration_success_fee_distribution() {
         &1000i128,
         &token,
         &String::from_str(&env, "reason"),
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1421,7 +1477,7 @@ fn test_arbitration_arbitrator_cannot_vote() {
         &1000i128,
         &token,
         &String::from_str(&env, "reason"),
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1481,7 +1537,7 @@ fn test_arbitration_outcome_execution_approved() {
         &1000i128,
         &token,
         &String::from_str(&env, "reason"),
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1557,7 +1613,7 @@ fn test_arbitration_outcome_execution_rejected() {
         &1000i128,
         &token,
         &String::from_str(&env, "reason"),
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 

--- a/contracts/refund/src/test_policy.rs
+++ b/contracts/refund/src/test_policy.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{ testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String };
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String,
+};
 
 #[test]
 fn test_set_refund_policy_successfully() {
@@ -25,7 +27,7 @@ fn test_set_refund_policy_successfully() {
         &refund_window,
         &max_refund_percentage,
         &requires_admin_approval,
-        &auto_approve_below
+        &auto_approve_below,
     );
 
     let policy = client.get_refund_policy(&merchant);
@@ -62,7 +64,7 @@ fn test_set_refund_policy_with_invalid_percentage_should_fail() {
         &refund_window,
         &max_refund_percentage,
         &requires_admin_approval,
-        &auto_approve_below
+        &auto_approve_below,
     );
 }
 
@@ -128,7 +130,7 @@ fn test_admin_override_policy_successfully() {
         &1000i128,
         &token,
         &String::from_str(&env, "Test"),
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     // Then admin overrides policy
@@ -165,7 +167,7 @@ fn test_admin_override_policy_by_non_admin_should_fail() {
         &1000i128,
         &token,
         &String::from_str(&env, "Test"),
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     // Try to override with unauthorized user
@@ -194,7 +196,7 @@ fn test_refund_window_expired_should_fail() {
         &(24u64 * 60u64 * 60u64), // 1 day
         &10000u32,
         &true,
-        &0i128
+        &0i128,
     );
 
     // Simulate payment created 2 days ago
@@ -209,7 +211,7 @@ fn test_refund_window_expired_should_fail() {
         &1000i128,
         &token,
         &String::from_str(&env, "Too late"),
-        &payment_created_at
+        &payment_created_at,
     );
 
     assert_eq!(result, Err(Ok(Error::RefundWindowExpired)));
@@ -235,7 +237,7 @@ fn test_refund_percentage_exceeds_policy_should_fail() {
         &(30u64 * 24u64 * 60u64 * 60u64),
         &5000u32, // 50%
         &true,
-        &0i128
+        &0i128,
     );
 
     // Try to request 75% refund
@@ -247,7 +249,7 @@ fn test_refund_percentage_exceeds_policy_should_fail() {
         &1000i128,
         &token,
         &String::from_str(&env, "Too much"),
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     assert_eq!(result, Err(Ok(Error::RefundExceedsPolicy)));
@@ -272,8 +274,8 @@ fn test_auto_approve_below_threshold() {
         &merchant,
         &(30u64 * 24u64 * 60u64 * 60u64),
         &10000u32,
-        &false, // No admin approval required
-        &500i128 // Auto-approve below 500
+        &false,   // No admin approval required
+        &500i128, // Auto-approve below 500
     );
 
     // Request refund for 300 (should be auto-approved)
@@ -285,7 +287,7 @@ fn test_auto_approve_below_threshold() {
         &1000i128,
         &token,
         &String::from_str(&env, "Small refund"),
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     // Check that AutoApproved event was emitted (before next contract call clears events)
@@ -311,7 +313,13 @@ fn test_refund_with_inactive_policy_should_fail() {
 
     env.mock_all_auths();
     // Set a policy
-    client.set_refund_policy(&merchant, &(30u64 * 24u64 * 60u64 * 60u64), &10000u32, &true, &0i128);
+    client.set_refund_policy(
+        &merchant,
+        &(30u64 * 24u64 * 60u64 * 60u64),
+        &10000u32,
+        &true,
+        &0i128,
+    );
 
     // Deactivate it
     client.deactivate_refund_policy(&merchant);
@@ -325,7 +333,7 @@ fn test_refund_with_inactive_policy_should_fail() {
         &1000i128,
         &token,
         &String::from_str(&env, "Inactive policy"),
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     assert_eq!(result, Err(Ok(Error::PolicyInactive)));
@@ -356,7 +364,7 @@ fn test_refund_without_merchant_policy_uses_default() {
         &1000i128,
         &token,
         &String::from_str(&env, "Default policy"),
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);

--- a/contracts/refund/src/test_process.rs
+++ b/contracts/refund/src/test_process.rs
@@ -1,9 +1,6 @@
 #![cfg(test)]
 use super::{RefundContract, RefundContractClient, RefundStatus};
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env, String,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 #[test]
 fn test_initialize() {
@@ -44,8 +41,16 @@ fn test_approve_refund() {
     let reason = String::from_str(&env, "reason");
 
     env.mock_all_auths();
-    let refund_id =
-        client.request_refund(&merchant, &payment_id, &customer, &amount, &1000, &token, &reason, &0_u64);
+    let refund_id = client.request_refund(
+        &merchant,
+        &payment_id,
+        &customer,
+        &amount,
+        &1000,
+        &token,
+        &reason,
+        &0_u64,
+    );
 
     // Approve
     client.approve_refund(&admin, &refund_id);


### PR DESCRIPTION
Implemented in contracts/payment/src/lib.rs (line 1453) and contracts/payment/src/test.rs (line 4426). I kept the repo’s existing tier model (Standard -> Silver -> Gold -> Platinum) and added the requested behavior on top of it: configurable tier thresholds, get_merchant_tier, manually_set_merchant_tier, get_tier_thresholds, set_tier_thresholds, and automatic tier checks after every complete_payment().

The automatic logic now always records merchant volume after completion, upgrades only when the calculated tier rank increases, and never auto-downgrades. Threshold updates are validated to be strictly ascending before they’re saved. I also added coverage for threshold crossing, invalid threshold ordering, no auto-downgrade, manual override, and upgrades even when no fee is collected. Soroban payment snapshots under contracts/payment/test_snapshots/test/ were updated for the affected payment flows.

Verification: cargo test -p payments now passes all fee-tier work, with 142 tests passing overall. The only remaining failures are 4 pre-existing conditional-payment tests unrelated to this feature: test_complete_conditional_payment_success, test_create_conditional_payment_timestamp_after, test_create_conditional_payment_oracle_price, and test_create_conditional_payment_cross_contract_state.

I left unrelated existing changes in escrow and refund untouched.

closes #90 