### PR TITLE
feat: #90 feat(payment): Add merchant fee tier automatic upgrade base…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ target
 .soroban
 .stellar
 .claude
+.codex
 
 **/test_snapshots/**

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -34,6 +34,7 @@ pub enum DataKey {
     ProposalCounter,
     FeeConfig,
     MerchantFeeRecord(Address),
+    TierThresholds,
     AccumulatedFees,
     // Analytics
     PaymentAnalyticsKey,
@@ -167,6 +168,7 @@ pub enum Error {
     OracleCallFailed = 42,
     ContractPaused = 43,
     FunctionPaused = 44,
+    InvalidTierThresholds = 45,
 }
 
 #[contractevent]
@@ -462,9 +464,8 @@ pub struct BatchResult {
 #[contracttype]
 pub enum FeeTier {
     Standard,
-    Silver,   // > 10,000 XLM volume
-    Gold,     // > 100,000 XLM volume
-    Platinum, // > 1,000,000 XLM volume
+    Premium,    // >= configured premium volume
+    Enterprise, // >= configured enterprise volume
 }
 
 #[derive(Clone)]
@@ -672,9 +673,8 @@ const DEFAULT_MAX_RETRIES: u64 = 3;
 const SECONDS_PER_DAY: u64 = 86400;
 
 // Fee tier volume thresholds (raw token units)
-const SILVER_VOLUME_THRESHOLD: i128 = 10_000;
-const GOLD_VOLUME_THRESHOLD: i128 = 100_000;
-const PLATINUM_VOLUME_THRESHOLD: i128 = 1_000_000;
+const PREMIUM_VOLUME_THRESHOLD: i128 = 10_000;
+const ENTERPRISE_VOLUME_THRESHOLD: i128 = 100_000;
 
 #[contractimpl]
 impl PaymentContract {
@@ -1534,11 +1534,11 @@ impl PaymentContract {
         }
 
         // Deduct platform fee (if configured) and get net amount for merchant
-        let net_amount = PaymentContract::deduct_fee(
+        let (net_amount, fee_amount) = PaymentContract::deduct_fee(
             env,
             payment_id,
             payment.amount,
-            &payment.merchant,
+            payment.merchant.clone(),
             &payment.token,
             &payment.customer,
         );
@@ -1557,6 +1557,12 @@ impl PaymentContract {
         env.storage()
             .instance()
             .set(&DataKey::Payment(payment_id), &payment);
+        PaymentContract::update_merchant_fee_record_post_completion(
+            env,
+            payment.merchant.clone(),
+            payment.amount,
+            fee_amount,
+        );
 
         // Update analytics
         let mut analytics: PaymentAnalytics = env
@@ -3100,15 +3106,65 @@ impl PaymentContract {
 
     /// Returns the fee record for a given merchant.
     pub fn get_merchant_fee_record(env: Env, merchant: Address) -> MerchantFeeRecord {
+        PaymentContract::get_or_default_merchant_fee_record(&env, merchant)
+    }
+
+    /// Returns only the current tier for a given merchant.
+    pub fn get_merchant_tier(env: Env, merchant: Address) -> FeeTier {
+        PaymentContract::get_or_default_merchant_fee_record(&env, merchant).fee_tier
+    }
+
+    /// Admin manually sets merchant tier (supports explicit downgrade/override).
+    pub fn manually_set_merchant_tier(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+        tier: FeeTier,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut record = PaymentContract::get_or_default_merchant_fee_record(&env, merchant.clone());
+        record.fee_tier = tier;
         env.storage()
             .instance()
-            .get(&DataKey::MerchantFeeRecord(merchant.clone()))
-            .unwrap_or(MerchantFeeRecord {
-                merchant,
-                total_fees_paid: 0,
-                total_volume: 0,
-                fee_tier: FeeTier::Standard,
-            })
+            .set(&DataKey::MerchantFeeRecord(merchant), &record);
+        Ok(())
+    }
+
+    /// Returns tier thresholds as (tier, minimum-volume) pairs.
+    pub fn get_tier_thresholds(env: Env) -> Vec<(FeeTier, i128)> {
+        PaymentContract::get_stored_or_default_thresholds(&env)
+    }
+
+    /// Admin sets ascending tier thresholds.
+    pub fn set_tier_thresholds(
+        env: Env,
+        admin: Address,
+        thresholds: Vec<(FeeTier, i128)>,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+
+        PaymentContract::validate_thresholds(&thresholds)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::TierThresholds, &thresholds);
+        Ok(())
     }
 
     /// Returns the total fees accumulated in the contract.
@@ -3166,34 +3222,24 @@ impl PaymentContract {
         env: &Env,
         payment_id: u64,
         amount: i128,
-        merchant: &Address,
+        merchant: Address,
         token: &Address,
         customer: &Address,
-    ) -> i128 {
+    ) -> (i128, i128) {
         let config: Option<FeeConfig> = env.storage().instance().get(&DataKey::FeeConfig);
         let config = match config {
             None => {
-                return amount;
+                return (amount, 0);
             }
             Some(c) if !c.active => {
-                return amount;
+                return (amount, 0);
             }
             Some(c) if c.fee_token != *token => {
-                return amount;
+                return (amount, 0);
             }
             Some(c) => c,
         };
-
-        let mut record: MerchantFeeRecord = env
-            .storage()
-            .instance()
-            .get(&DataKey::MerchantFeeRecord(merchant.clone()))
-            .unwrap_or(MerchantFeeRecord {
-                merchant: merchant.clone(),
-                total_fees_paid: 0,
-                total_volume: 0,
-                fee_tier: FeeTier::Standard,
-            });
+        let record = PaymentContract::get_or_default_merchant_fee_record(env, merchant.clone());
 
         let fee = PaymentContract::compute_fee_amount(
             amount,
@@ -3204,7 +3250,7 @@ impl PaymentContract {
         );
 
         if fee <= 0 {
-            return amount;
+            return (amount, 0);
         }
 
         let net_amount = amount - fee;
@@ -3224,34 +3270,14 @@ impl PaymentContract {
             .instance()
             .set(&DataKey::AccumulatedFees, &(accumulated + fee));
 
-        // Update merchant record and check for tier upgrades
-        let old_tier = record.fee_tier.clone();
-        record.total_fees_paid += fee;
-        record.total_volume += amount;
-
-        let new_tier = PaymentContract::get_tier_for_volume(record.total_volume);
-        if new_tier != old_tier {
-            record.fee_tier = new_tier.clone();
-            (MerchantTierUpgraded {
-                merchant: merchant.clone(),
-                old_tier,
-                new_tier,
-            })
-            .publish(env);
-        }
-
-        env.storage()
-            .instance()
-            .set(&DataKey::MerchantFeeRecord(merchant.clone()), &record);
-
         (FeeCollected {
             payment_id,
             fee_amount: fee,
-            merchant: merchant.clone(),
+            merchant,
         })
         .publish(env);
 
-        net_amount
+        (net_amount, fee)
     }
 
     /// Computes the fee amount applying tier discount and min/max clamping.
@@ -3287,22 +3313,136 @@ impl PaymentContract {
     fn get_tier_discount_bps(tier: &FeeTier) -> u32 {
         match tier {
             FeeTier::Standard => 0,
-            FeeTier::Silver => 500,    // 5% discount on fee
-            FeeTier::Gold => 1500,     // 15% discount on fee
-            FeeTier::Platinum => 3000, // 30% discount on fee
+            FeeTier::Premium => 750,     // 7.5% discount on fee
+            FeeTier::Enterprise => 2000, // 20% discount on fee
         }
     }
 
-    fn get_tier_for_volume(volume: i128) -> FeeTier {
-        if volume > PLATINUM_VOLUME_THRESHOLD {
-            FeeTier::Platinum
-        } else if volume > GOLD_VOLUME_THRESHOLD {
-            FeeTier::Gold
-        } else if volume > SILVER_VOLUME_THRESHOLD {
-            FeeTier::Silver
+    fn get_or_default_merchant_fee_record(env: &Env, merchant: Address) -> MerchantFeeRecord {
+        env.storage()
+            .instance()
+            .get(&DataKey::MerchantFeeRecord(merchant.clone()))
+            .unwrap_or(MerchantFeeRecord {
+                merchant,
+                total_fees_paid: 0,
+                total_volume: 0,
+                fee_tier: FeeTier::Standard,
+            })
+    }
+
+    fn default_tier_thresholds_for_volume() -> [(FeeTier, i128); 2] {
+        [
+            (FeeTier::Premium, PREMIUM_VOLUME_THRESHOLD),
+            (FeeTier::Enterprise, ENTERPRISE_VOLUME_THRESHOLD),
+        ]
+    }
+
+    fn get_stored_or_default_thresholds(env: &Env) -> Vec<(FeeTier, i128)> {
+        env.storage()
+            .instance()
+            .get(&DataKey::TierThresholds)
+            .unwrap_or_else(|| {
+                let defaults = PaymentContract::default_tier_thresholds_for_volume();
+                Vec::from_array(env, defaults)
+            })
+    }
+
+    fn tier_rank(tier: &FeeTier) -> u32 {
+        match tier {
+            FeeTier::Standard => 0,
+            FeeTier::Premium => 1,
+            FeeTier::Enterprise => 2,
+        }
+    }
+
+    fn calculate_tier(env: &Env, total_volume: i128) -> FeeTier {
+        let thresholds = PaymentContract::get_stored_or_default_thresholds(env);
+        let mut premium_threshold = PREMIUM_VOLUME_THRESHOLD;
+        let mut enterprise_threshold = ENTERPRISE_VOLUME_THRESHOLD;
+        for pair in thresholds.iter() {
+            match pair.0 {
+                FeeTier::Standard => {}
+                FeeTier::Premium => premium_threshold = pair.1,
+                FeeTier::Enterprise => enterprise_threshold = pair.1,
+            }
+        }
+
+        if total_volume >= enterprise_threshold {
+            FeeTier::Enterprise
+        } else if total_volume >= premium_threshold {
+            FeeTier::Premium
         } else {
             FeeTier::Standard
         }
+    }
+
+    fn validate_thresholds(thresholds: &Vec<(FeeTier, i128)>) -> Result<(), Error> {
+        if thresholds.len() < 2 || thresholds.len() > 3 {
+            return Err(Error::InvalidTierThresholds);
+        }
+
+        let mut has_premium = false;
+        let mut has_enterprise = false;
+        let mut prev_rank: Option<u32> = None;
+        let mut prev_value: Option<i128> = None;
+
+        for pair in thresholds.iter() {
+            let rank = PaymentContract::tier_rank(&pair.0);
+            if let Some(r) = prev_rank {
+                if rank <= r {
+                    return Err(Error::InvalidTierThresholds);
+                }
+            }
+            if let Some(v) = prev_value {
+                if pair.1 <= v {
+                    return Err(Error::InvalidTierThresholds);
+                }
+            }
+            if pair.1 < 0 {
+                return Err(Error::InvalidTierThresholds);
+            }
+
+            match pair.0 {
+                FeeTier::Premium => has_premium = true,
+                FeeTier::Enterprise => has_enterprise = true,
+                FeeTier::Standard => {}
+            }
+            prev_rank = Some(rank);
+            prev_value = Some(pair.1);
+        }
+
+        if !has_premium || !has_enterprise {
+            return Err(Error::InvalidTierThresholds);
+        }
+        Ok(())
+    }
+
+    fn update_merchant_fee_record_post_completion(
+        env: &Env,
+        merchant: Address,
+        amount: i128,
+        fee_amount: i128,
+    ) {
+        let mut record = PaymentContract::get_or_default_merchant_fee_record(env, merchant.clone());
+        record.total_volume += amount;
+        record.total_fees_paid += fee_amount;
+
+        // Automatic tier changes are monotonic upgrades only.
+        let old_tier = record.fee_tier.clone();
+        let computed_tier = PaymentContract::calculate_tier(env, record.total_volume);
+        if PaymentContract::tier_rank(&computed_tier) > PaymentContract::tier_rank(&record.fee_tier) {
+            record.fee_tier = computed_tier.clone();
+            (MerchantTierUpgraded {
+                merchant: merchant.clone(),
+                old_tier,
+                new_tier: computed_tier,
+            })
+            .publish(env);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantFeeRecord(merchant), &record);
     }
 
     // ── BATCH PAYMENT OPERATIONS ──────────────────────────────────────────────

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -3861,7 +3861,7 @@ fn test_fee_max_clamping() {
 }
 
 #[test]
-fn test_merchant_tier_upgrade_to_silver() {
+fn test_merchant_tier_upgrade_to_premium() {
     let env = Env::default();
     let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
 
@@ -3882,8 +3882,7 @@ fn test_merchant_tier_upgrade_to_silver() {
     };
     client.set_fee_config(&admin, &fee_config);
 
-    // First payment: 10_001 volume → crosses Silver threshold (> 10_000)
-    let amount = 10_001_i128;
+    let amount = 10_000_i128;
     token_client.mint(&customer, &amount);
     token_user_client.approve(&customer, &contract_id, &amount, &200);
 
@@ -3899,12 +3898,13 @@ fn test_merchant_tier_upgrade_to_silver() {
     client.complete_payment(&admin, &payment_id);
 
     let record = client.get_merchant_fee_record(&merchant);
-    assert_eq!(record.fee_tier, FeeTier::Silver);
+    assert_eq!(record.fee_tier, FeeTier::Premium);
     assert_eq!(record.total_volume, amount);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Premium);
 }
 
 #[test]
-fn test_merchant_tier_upgrade_to_gold() {
+fn test_merchant_tier_upgrade_to_enterprise() {
     let env = Env::default();
     let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
 
@@ -3925,7 +3925,7 @@ fn test_merchant_tier_upgrade_to_gold() {
     };
     client.set_fee_config(&admin, &fee_config);
 
-    let amount = 100_001_i128;
+    let amount = 100_000_i128;
     token_client.mint(&customer, &amount);
     token_user_client.approve(&customer, &contract_id, &amount, &200);
 
@@ -3941,11 +3941,49 @@ fn test_merchant_tier_upgrade_to_gold() {
     client.complete_payment(&admin, &payment_id);
 
     let record = client.get_merchant_fee_record(&merchant);
-    assert_eq!(record.fee_tier, FeeTier::Gold);
+    assert_eq!(record.fee_tier, FeeTier::Enterprise);
 }
 
 #[test]
-fn test_merchant_tier_upgrade_to_platinum() {
+fn test_auto_tier_upgrade_runs_on_complete_payment_even_without_fee_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // No fee config set, but tier check must still run after completion.
+    let amount = 10_000_i128;
+    token_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &contract_id, &amount, &200);
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, "")
+    );
+    client.complete_payment(&admin, &payment_id);
+
+    let record = client.get_merchant_fee_record(&merchant);
+    assert_eq!(record.fee_tier, FeeTier::Premium);
+}
+
+#[test]
+fn test_auto_tier_upgrade_never_downgrades() {
     let env = Env::default();
     let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
 
@@ -3956,33 +3994,136 @@ fn test_merchant_tier_upgrade_to_platinum() {
     let merchant = Address::generate(&env);
     let treasury = Address::generate(&env);
 
-    let fee_config = FeeConfig {
-        fee_bps: 30,
+    client.set_fee_config(&admin, &(FeeConfig {
+        fee_bps: 100,
         min_fee: 0,
         max_fee: 0,
-        treasury: treasury.clone(),
+        treasury,
         fee_token: token_contract_id.clone(),
         active: true,
-    };
-    client.set_fee_config(&admin, &fee_config);
+    }));
 
-    let amount = 1_000_001_i128;
-    token_client.mint(&customer, &amount);
-    token_user_client.approve(&customer, &contract_id, &amount, &200);
+    // Lower initial thresholds so first completion reaches Enterprise quickly.
+    client.set_tier_thresholds(
+        &admin,
+        &soroban_sdk::vec![
+            &env,
+            (FeeTier::Premium, 100_i128),
+            (FeeTier::Enterprise, 200_i128),
+        ],
+    );
 
-    let payment_id = client.create_payment(
+    token_client.mint(&customer, &500);
+    token_user_client.approve(&customer, &contract_id, &500, &200);
+
+    let first = client.create_payment(
         &customer,
         &merchant,
-        &amount,
+        &250,
         &token_contract_id,
         &Currency::USDC,
         &0,
         &String::from_str(&env, "")
     );
-    client.complete_payment(&admin, &payment_id);
+    client.complete_payment(&admin, &first);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
 
-    let record = client.get_merchant_fee_record(&merchant);
-    assert_eq!(record.fee_tier, FeeTier::Platinum);
+    // Increase thresholds above existing volume. Auto path must not downgrade tier.
+    client.set_tier_thresholds(
+        &admin,
+        &soroban_sdk::vec![
+            &env,
+            (FeeTier::Premium, 1_000_i128),
+            (FeeTier::Enterprise, 2_000_i128),
+        ],
+    );
+
+    let second = client.create_payment(
+        &customer,
+        &merchant,
+        &10,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, "")
+    );
+    client.complete_payment(&admin, &second);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
+}
+
+#[test]
+fn test_manual_override_allows_downgrade() {
+    let env = Env::default();
+    let (client, admin, contract_id, token_contract_id, _) = setup_fee_contract(&env);
+
+    let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    token_client.mint(&customer, &120_000);
+    token_user_client.approve(&customer, &contract_id, &120_000, &200);
+
+    let first = client.create_payment(
+        &customer,
+        &merchant,
+        &100_000,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, "")
+    );
+    client.complete_payment(&admin, &first);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
+
+    client.manually_set_merchant_tier(&admin, &merchant, &FeeTier::Standard);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Standard);
+
+    // Subsequent completion can auto-upgrade back up based on cumulative volume.
+    let second = client.create_payment(
+        &customer,
+        &merchant,
+        &1_000,
+        &token_contract_id,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, "")
+    );
+    client.complete_payment(&admin, &second);
+    assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
+}
+
+#[test]
+fn test_set_tier_thresholds_validates_ascending_order() {
+    let env = Env::default();
+    let (client, admin, _, _, _) = setup_fee_contract(&env);
+
+    let result = client.try_set_tier_thresholds(
+        &admin,
+        &soroban_sdk::vec![
+            &env,
+            (FeeTier::Premium, 200_i128),
+            (FeeTier::Enterprise, 100_i128),
+        ],
+    );
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), Error::InvalidTierThresholds);
+}
+
+#[test]
+fn test_set_and_get_tier_thresholds() {
+    let env = Env::default();
+    let (client, admin, _, _, _) = setup_fee_contract(&env);
+
+    let updated = soroban_sdk::vec![
+        &env,
+        (FeeTier::Premium, 25_000_i128),
+        (FeeTier::Enterprise, 250_000_i128),
+    ];
+
+    client.set_tier_thresholds(&admin, &updated);
+    let stored = client.get_tier_thresholds();
+    assert_eq!(stored, updated);
 }
 
 #[test]
@@ -4007,9 +4148,9 @@ fn test_tier_discount_reduces_fee() {
     };
     client.set_fee_config(&admin, &fee_config);
 
-    // First: push merchant to Silver (volume > 10_000)
-    let vol_amount = 10_001_i128;
-    let fee1 = (10_001_i128 * 1000) / 10_000; // = 1000 (Standard, no discount)
+    // First: push merchant to Premium (volume >= 10,000)
+    let vol_amount = 10_000_i128;
+    let fee1 = (10_000_i128 * 1000) / 10_000; // = 1000 (Standard, no discount)
     token_client.mint(&customer, &(vol_amount + 10_000));
     token_user_client.approve(&customer, &contract_id, &(vol_amount + 10_000), &200);
 
@@ -4024,12 +4165,12 @@ fn test_tier_discount_reduces_fee() {
     );
     client.complete_payment(&admin, &pid1);
 
-    // Merchant should now be Silver (500 bps discount = 5% off fee)
+    // Merchant should now be Premium (750 bps discount = 7.5% off fee)
     let record = client.get_merchant_fee_record(&merchant);
-    assert_eq!(record.fee_tier, FeeTier::Silver);
+    assert_eq!(record.fee_tier, FeeTier::Premium);
 
-    // Second payment: effective_bps = 1000 - (1000 * 500 / 10000) = 1000 - 50 = 950
-    // fee = 10_000 * 950 / 10_000 = 950
+    // Second payment: effective_bps = 1000 - (1000 * 750 / 10000) = 1000 - 75 = 925
+    // fee = 10_000 * 925 / 10_000 = 925
     let amount2 = 10_000_i128;
     let pid2 = client.create_payment(
         &customer,
@@ -4042,8 +4183,8 @@ fn test_tier_discount_reduces_fee() {
     );
     client.complete_payment(&admin, &pid2);
 
-    // fee1 = 1000 (Standard), fee2 = 950 (Silver with 5% discount)
-    let expected_fee2: i128 = 950;
+    // fee1 = 1000 (Standard), fee2 = 925 (Premium with 7.5% discount)
+    let expected_fee2: i128 = 925;
     let total_fees = fee1 + expected_fee2;
     assert_eq!(client.get_accumulated_fees(), total_fees);
 


### PR DESCRIPTION
Implemented end-to-end for #90 in the payment contract.

Updated logic and APIs are in place in lib.rs:

Auto tier check now runs on every complete_payment() path, after completion bookkeeping (lib.rs (line 1537), lib.rs (line 3420)).
Auto tier changes are upgrade-only (no automatic downgrade).
Added:
get_merchant_tier (lib.rs (line 3113))
manually_set_merchant_tier (lib.rs (line 3118))
get_tier_thresholds (lib.rs (line 3143))
set_tier_thresholds with ascending validation (lib.rs (line 3148), lib.rs (line 3379))
Tier model updated to Standard -> Premium -> Enterprise with configurable thresholds.
Tests were updated/added in test.rs:

Threshold crossing tests (test.rs (line 3864), test.rs (line 3907))
Auto-check on completion even without fee config (test.rs (line 3948))
No-downgrade rule (test.rs (line 3986))
Manual override test (test.rs (line 4055))
Threshold ordering validation + get/set thresholds (test.rs (line 4097), test.rs (line 4114))
About .codex and snapshots:

.codex is auto-recreated by the environment, so I added it to ignore list in .gitignore (line 8) to keep it out of pushes.
test_snapshots are already ignored (.gitignore (line 10)).
Current changed files are only:
.gitignore
contracts/payment/src/lib.rs
contracts/payment/src/test.rs

closes #90 