### PR TITLE
feat(refund): implement default refund policy with merchant override …

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -251,6 +251,19 @@ pub struct RefundPolicyDeactivated {
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefaultRefundPolicySet {
+    pub set_by: Address,
+    pub refund_window: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefaultRefundPolicyRemoved {
+    pub removed_by: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PolicyOverrideApplied {
     pub refund_id: u64,
     pub admin: Address,
@@ -438,15 +451,19 @@ impl RefundContract {
         let counter: u64 = env.storage().instance().get(&DataKey::RefundCounter).unwrap_or(0);
         let refund_id = counter + 1;
 
-        // Determine initial status based on policy
-        let initial_status = if let Some(policy) = Self::get_refund_policy(&env, merchant.clone()) {
-            if !policy.requires_admin_approval && amount <= policy.auto_approve_below {
-                RefundStatus::Approved
+        // Determine initial status based on policy (merchant → global default → Requested)
+        let initial_status = {
+            let policy_opt = Self::get_refund_policy(&env, merchant.clone())
+                .or_else(|| Self::get_default_refund_policy_inner(&env));
+            if let Some(policy) = policy_opt {
+                if !policy.requires_admin_approval && amount <= policy.auto_approve_below {
+                    RefundStatus::Approved
+                } else {
+                    RefundStatus::Requested
+                }
             } else {
                 RefundStatus::Requested
             }
-        } else {
-            RefundStatus::Requested
         };
 
         // Create Refund struct
@@ -1098,6 +1115,66 @@ impl RefundContract {
         env.storage().instance().get(&DataKey::RefundPolicy(merchant))
     }
 
+    // ── Issue #93: Default refund policy management ────────────────────────
+
+    /// Set the global default refund policy. Admin-only.
+    pub fn set_default_refund_policy(
+        env: Env,
+        admin: Address,
+        policy: RefundPolicy,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::DefaultRefundPolicy, &policy);
+        (DefaultRefundPolicySet {
+            set_by: admin,
+            refund_window: policy.refund_window,
+        })
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Get the global default refund policy (returns None if not set).
+    pub fn get_default_refund_policy(env: Env) -> Option<RefundPolicy> {
+        env.storage()
+            .instance()
+            .get(&DataKey::DefaultRefundPolicy)
+    }
+
+    /// Internal helper used by request_refund / validate_against_policy.
+    fn get_default_refund_policy_inner(env: &Env) -> Option<RefundPolicy> {
+        env.storage()
+            .instance()
+            .get(&DataKey::DefaultRefundPolicy)
+    }
+
+    /// Remove the global default refund policy. Admin-only.
+    pub fn remove_default_refund_policy(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .remove(&DataKey::DefaultRefundPolicy);
+        (DefaultRefundPolicyRemoved { removed_by: admin }).publish(&env);
+        Ok(())
+    }
+
     pub fn deactivate_refund_policy(env: Env, merchant: Address) -> Result<(), Error> {
         // Require merchant authentication
         merchant.require_auth();
@@ -1164,24 +1241,10 @@ impl RefundContract {
         original_amount: i128,
         payment_created_at: u64
     ) -> Result<(), Error> {
-        // Get merchant-specific policy or default
-        let policy: RefundPolicy = if
-            let Some(merchant_policy) = Self::get_refund_policy(env, merchant.clone())
-        {
-            merchant_policy
-        } else {
-            env.storage()
-                .instance()
-                .get(&DataKey::DefaultRefundPolicy)
-                .unwrap_or_else(|| RefundPolicy {
-                    merchant: merchant.clone(),
-                    refund_window: 30 * 24 * 60 * 60, // 30 days
-                    max_refund_percentage: 10000, // 100%
-                    requires_admin_approval: true,
-                    auto_approve_below: 0,
-                    active: true,
-                })
-        };
+        // Fallback chain: merchant policy → global default → PolicyNotFound
+        let policy: RefundPolicy = Self::get_refund_policy(env, merchant.clone())
+            .or_else(|| Self::get_default_refund_policy_inner(env))
+            .ok_or(Error::PolicyNotFound)?;
 
         // Check if policy is active
         if !policy.active {

--- a/contracts/refund/src/test_policy.rs
+++ b/contracts/refund/src/test_policy.rs
@@ -405,3 +405,208 @@ fn test_refund_policy_deactivated_event_emitted() {
     let events = env.events().all();
     assert!(events.len() > 0);
 }
+
+// ── Issue #93: Default refund policy tests ────────────────────────────────
+
+#[test]
+fn test_set_default_refund_policy_by_admin_succeeds() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    let policy = RefundPolicy {
+        merchant: admin.clone(),
+        refund_window: 7 * 24 * 60 * 60, // 7 days
+        max_refund_percentage: 5000,       // 50 %
+        requires_admin_approval: true,
+        auto_approve_below: 0,
+        active: true,
+    };
+
+    client.set_default_refund_policy(&admin, &policy);
+
+    let stored = client.get_default_refund_policy();
+    assert!(stored.is_some());
+    let stored = stored.unwrap();
+    assert_eq!(stored.refund_window, 7 * 24 * 60 * 60);
+    assert_eq!(stored.max_refund_percentage, 5000);
+}
+
+#[test]
+#[should_panic]
+fn test_set_default_refund_policy_by_non_admin_fails() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    let policy = RefundPolicy {
+        merchant: attacker.clone(),
+        refund_window: 7 * 24 * 60 * 60,
+        max_refund_percentage: 10000,
+        requires_admin_approval: true,
+        auto_approve_below: 0,
+        active: true,
+    };
+
+    // attacker != stored admin → should panic with Unauthorized
+    client.set_default_refund_policy(&attacker, &policy);
+}
+
+#[test]
+fn test_remove_default_refund_policy_by_admin_succeeds() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    // A default policy is set by initialize(); remove it
+    client.remove_default_refund_policy(&admin);
+
+    let stored = client.get_default_refund_policy();
+    assert!(stored.is_none());
+}
+
+#[test]
+#[should_panic]
+fn test_remove_default_refund_policy_by_non_admin_fails() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    client.remove_default_refund_policy(&attacker);
+}
+
+#[test]
+fn test_request_refund_uses_global_default_when_no_merchant_policy() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    // Replace the default with a custom global policy (no admin approval, auto-approve <= 200)
+    let default_policy = RefundPolicy {
+        merchant: admin.clone(),
+        refund_window: 30 * 24 * 60 * 60,
+        max_refund_percentage: 10000,
+        requires_admin_approval: false,
+        auto_approve_below: 200,
+        active: true,
+    };
+    client.set_default_refund_policy(&admin, &default_policy);
+
+    // No merchant-specific policy set; amount (100) <= auto_approve_below (200) → auto-approved
+    let refund_id = client.request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &100i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "Uses global default"),
+        &env.ledger().timestamp(),
+    );
+
+    let refund = client.get_refund(&refund_id);
+    assert_eq!(refund.status, RefundStatus::Approved);
+}
+
+#[test]
+fn test_request_refund_returns_policy_not_found_when_no_policy_at_all() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    // Remove the default policy that initialize() set, and set NO merchant policy
+    client.remove_default_refund_policy(&admin);
+
+    let result = client.try_request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &500i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "No policy at all"),
+        &env.ledger().timestamp(),
+    );
+
+    assert_eq!(result, Err(Ok(Error::PolicyNotFound)));
+}
+
+#[test]
+fn test_default_policy_change_does_not_affect_pending_refunds() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    // Submit a refund using the current default (set by initialize())
+    let refund_id = client.request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &500i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "Pending refund"),
+        &env.ledger().timestamp(),
+    );
+
+    // Verify it is in Requested state (default requires admin approval)
+    let refund_before = client.get_refund(&refund_id);
+    assert_eq!(refund_before.status, RefundStatus::Requested);
+
+    // Now admin changes the global default policy
+    let new_default = RefundPolicy {
+        merchant: admin.clone(),
+        refund_window: 7 * 24 * 60 * 60,
+        max_refund_percentage: 5000,
+        requires_admin_approval: false,
+        auto_approve_below: 1000,
+        active: true,
+    };
+    client.set_default_refund_policy(&admin, &new_default);
+
+    // The already-stored refund must NOT be retroactively changed
+    let refund_after = client.get_refund(&refund_id);
+    assert_eq!(refund_after.status, RefundStatus::Requested);
+}


### PR DESCRIPTION
Closes #93

## Summary

`DefaultRefundPolicy` was stored as a key in contract storage but never systematically used as a fallback when a merchant had no explicit policy. This PR formalises the fallback chain so all merchant accounts behave consistently:


## Changes

### `contracts/refund/src/lib.rs`

**New contract events**
- `DefaultRefundPolicySet` — emitted when admin sets/updates the global default policy
- `DefaultRefundPolicyRemoved` — emitted when admin removes the global default policy

**New public functions**
```rust
// Set the global default refund policy. Admin-only.
pub fn set_default_refund_policy(env: Env, admin: Address, policy: RefundPolicy) -> Result<(), Error>

// Get the global default refund policy (returns None if not set).
pub fn get_default_refund_policy(env: Env) -> Option<RefundPolicy>

// Remove the global default refund policy. Admin-only.
pub fn remove_default_refund_policy(env: Env, admin: Address) -> Result<(), Error>
