### PR TITLE
feat(payment): Implement recurring payment failure recovery with retry backoff

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -176,6 +176,7 @@ pub enum Error {
     ContractPaused = 43,
     FunctionPaused = 44,
     InvalidTierThresholds = 45,
+    RetryTooEarly = 46,
     PaymentRequiresMultiSig = 64,
     InsufficientPaymentApprovals = 65,
     PaymentProposalExpired = 66,
@@ -356,7 +357,7 @@ pub struct SubscriptionSuspended {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DunningResolved {
     pub subscription_id: u64,
-    pub admin: Address,
+    pub resolved_at: u64,
 }
 
 #[derive(Clone)]
@@ -382,21 +383,19 @@ pub struct AddressRateLimit {
 #[derive(Clone)]
 #[contracttype]
 pub struct DunningConfig {
-    pub grace_period: u64,
-    pub retry_intervals: Vec<u64>,
-    pub max_dunning_attempts: u32,
-    pub suspend_after_attempts: u32,
+    pub initial_backoff_seconds: u64,
+    pub max_retries: u32,
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub struct DunningState {
     pub subscription_id: u64,
-    pub attempts: u32,
+    pub retry_count: u32,
     pub next_retry_at: u64,
-    pub grace_period_ends_at: u64,
-    pub suspended: bool,
-    pub last_failure_reason: String,
+    pub backoff_seconds: u64,
+    pub max_retries: u32,
+    pub last_failed_at: u64,
 }
 
 #[derive(Clone)]
@@ -2297,12 +2296,100 @@ impl PaymentContract {
             .get(&DataKey::Subscription(subscription_id))
             .unwrap();
 
-        // Must be Active
+        let now = env.ledger().timestamp();
+
+        // InDunning path: enforce on-chain backoff before retrying
+        if sub.status == SubscriptionStatus::InDunning {
+            let mut dunning: DunningState = env
+                .storage()
+                .instance()
+                .get(&DataKey::DunningState(subscription_id))
+                .ok_or(Error::DunningNotFound)?;
+
+            if now < dunning.next_retry_at {
+                return Err(Error::RetryTooEarly);
+            }
+
+            let token_client = token::Client::new(&env, &sub.token);
+            let contract_address = env.current_contract_address();
+            let transfer_ok = token_client
+                .try_transfer_from(&contract_address, &sub.customer, &sub.merchant, &sub.amount)
+                .is_ok();
+
+            if transfer_ok {
+                sub.payment_count += 1;
+                sub.retry_count = 0;
+                sub.next_payment_at = now + sub.interval;
+                sub.status = SubscriptionStatus::Active;
+
+                if sub.ends_at > 0 && sub.next_payment_at >= sub.ends_at {
+                    sub.status = SubscriptionStatus::Expired;
+                }
+
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Subscription(subscription_id), &sub);
+                env.storage()
+                    .instance()
+                    .remove(&DataKey::DunningState(subscription_id));
+
+                (DunningResolved {
+                    subscription_id,
+                    resolved_at: now,
+                })
+                .publish(&env);
+
+                (RecurringPaymentExecuted {
+                    subscription_id,
+                    payment_count: sub.payment_count,
+                    amount: sub.amount,
+                    next_payment_at: sub.next_payment_at,
+                })
+                .publish(&env);
+            } else {
+                dunning.retry_count += 1;
+                dunning.last_failed_at = now;
+
+                if dunning.retry_count >= dunning.max_retries {
+                    sub.status = SubscriptionStatus::Suspended;
+                    env.storage()
+                        .instance()
+                        .set(&DataKey::Subscription(subscription_id), &sub);
+                    env.storage()
+                        .instance()
+                        .set(&DataKey::DunningState(subscription_id), &dunning);
+
+                    (SubscriptionSuspended {
+                        subscription_id,
+                        reason: String::from_str(&env, "Maximum retries exceeded"),
+                    })
+                    .publish(&env);
+
+                    return Err(Error::MaxRetriesExceeded);
+                }
+
+                // Exponential backoff: backoff_seconds * 2^retry_count
+                dunning.next_retry_at = now + (dunning.backoff_seconds << dunning.retry_count);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::DunningState(subscription_id), &dunning);
+
+                (RecurringPaymentFailed {
+                    subscription_id,
+                    retry_count: dunning.retry_count as u64,
+                })
+                .publish(&env);
+
+                return Err(Error::TransferFailed);
+            }
+
+            return Ok(());
+        }
+
+        // Must be Active for the normal payment path
         if sub.status != SubscriptionStatus::Active {
             return Err(Error::SubscriptionNotActive);
         }
-
-        let now = env.ledger().timestamp();
 
         // Check subscription has not ended
         if sub.ends_at > 0 && now >= sub.ends_at {
@@ -2645,18 +2732,8 @@ impl PaymentContract {
             .instance()
             .get(&DataKey::DunningConfig)
             .unwrap_or(DunningConfig {
-                grace_period: 7 * 24 * 60 * 60, // 7 days
-                retry_intervals: Vec::from_array(
-                    &env,
-                    [
-                        60 * 60,          // 1 hour
-                        6 * 60 * 60,      // 6 hours
-                        24 * 60 * 60,     // 1 day
-                        3 * 24 * 60 * 60, // 3 days
-                    ],
-                ),
-                max_dunning_attempts: 5,
-                suspend_after_attempts: 4,
+                initial_backoff_seconds: 3600, // 1 hour
+                max_retries: 5,
             })
     }
 
@@ -2688,7 +2765,7 @@ impl PaymentContract {
             return Err(Error::SubscriptionNotInDunning);
         }
 
-        let mut dunning_state: DunningState = env
+        let mut dunning: DunningState = env
             .storage()
             .instance()
             .get(&DataKey::DunningState(subscription_id))
@@ -2696,31 +2773,9 @@ impl PaymentContract {
 
         let now = env.ledger().timestamp();
 
-        // Check if retry is due
-        if now < dunning_state.next_retry_at {
-            return Err(Error::RetryNotDue);
-        }
-
-        // Check if grace period has expired
-        if now > dunning_state.grace_period_ends_at {
-            // Move to suspended state
-            sub.status = SubscriptionStatus::Suspended;
-            dunning_state.suspended = true;
-
-            env.storage()
-                .instance()
-                .set(&DataKey::Subscription(subscription_id), &sub);
-            env.storage()
-                .instance()
-                .set(&DataKey::DunningState(subscription_id), &dunning_state);
-
-            (SubscriptionSuspended {
-                subscription_id,
-                reason: String::from_str(&env, "Grace period expired"),
-            })
-            .publish(&env);
-
-            return Err(Error::GracePeriodExpired);
+        // Enforce backoff window
+        if now < dunning.next_retry_at {
+            return Err(Error::RetryTooEarly);
         }
 
         // Attempt the payment
@@ -2732,13 +2787,11 @@ impl PaymentContract {
             .is_ok();
 
         if transfer_ok {
-            // Payment successful - resolve dunning
             sub.payment_count += 1;
             sub.retry_count = 0;
             sub.next_payment_at = now + sub.interval;
             sub.status = SubscriptionStatus::Active;
 
-            // Auto-expire when duration is reached
             if sub.ends_at > 0 && sub.next_payment_at >= sub.ends_at {
                 sub.status = SubscriptionStatus::Expired;
             }
@@ -2746,11 +2799,15 @@ impl PaymentContract {
             env.storage()
                 .instance()
                 .set(&DataKey::Subscription(subscription_id), &sub);
-
-            // Remove dunning state
             env.storage()
                 .instance()
                 .remove(&DataKey::DunningState(subscription_id));
+
+            (DunningResolved {
+                subscription_id,
+                resolved_at: now,
+            })
+            .publish(&env);
 
             (RecurringPaymentExecuted {
                 subscription_id,
@@ -2762,59 +2819,46 @@ impl PaymentContract {
 
             Ok(())
         } else {
-            // Payment failed - update dunning state
-            dunning_state.attempts += 1;
+            dunning.retry_count += 1;
+            dunning.last_failed_at = now;
 
-            let config = PaymentContract::get_dunning_config(env.clone());
-
-            if dunning_state.attempts >= config.max_dunning_attempts {
-                // Max attempts reached - suspend subscription
+            if dunning.retry_count >= dunning.max_retries {
                 sub.status = SubscriptionStatus::Suspended;
-                dunning_state.suspended = true;
-
                 env.storage()
                     .instance()
                     .set(&DataKey::Subscription(subscription_id), &sub);
                 env.storage()
                     .instance()
-                    .set(&DataKey::DunningState(subscription_id), &dunning_state);
+                    .set(&DataKey::DunningState(subscription_id), &dunning);
 
                 (SubscriptionSuspended {
                     subscription_id,
-                    reason: String::from_str(&env, "Maximum dunning attempts exceeded"),
+                    reason: String::from_str(&env, "Maximum retries exceeded"),
                 })
                 .publish(&env);
 
                 return Err(Error::MaxRetriesExceeded);
-            } else if dunning_state.attempts >= config.suspend_after_attempts {
-                // Suspend after configured attempts
-                sub.status = SubscriptionStatus::Suspended;
-                dunning_state.suspended = true;
-
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Subscription(subscription_id), &sub);
-                env.storage()
-                    .instance()
-                    .set(&DataKey::DunningState(subscription_id), &dunning_state);
-
-                (SubscriptionSuspended {
-                    subscription_id,
-                    reason: String::from_str(&env, "Suspend threshold reached"),
-                })
-                .publish(&env);
-
-                (DunningRetryScheduled {
-                    subscription_id,
-                    retry_at: dunning_state.next_retry_at,
-                })
-                .publish(&env);
-
-                return Err(Error::TransferFailed);
-            } else {
-                // This should not happen, but handle gracefully
-                return Err(Error::TransferFailed);
             }
+
+            // Exponential backoff: backoff_seconds * 2^retry_count
+            dunning.next_retry_at = now + (dunning.backoff_seconds << dunning.retry_count);
+            env.storage()
+                .instance()
+                .set(&DataKey::DunningState(subscription_id), &dunning);
+
+            (DunningRetryScheduled {
+                subscription_id,
+                retry_at: dunning.next_retry_at,
+            })
+            .publish(&env);
+
+            (RecurringPaymentFailed {
+                subscription_id,
+                retry_count: dunning.retry_count as u64,
+            })
+            .publish(&env);
+
+            Err(Error::TransferFailed)
         }
     }
 
@@ -2867,7 +2911,7 @@ impl PaymentContract {
 
         (DunningResolved {
             subscription_id,
-            admin,
+            resolved_at: env.ledger().timestamp(),
         })
         .publish(&env);
 
@@ -2875,23 +2919,19 @@ impl PaymentContract {
     }
 
     /// Internal function to enter dunning for a subscription.
-    fn enter_dunning(env: &Env, subscription_id: u64, reason: String) {
+    fn enter_dunning(env: &Env, subscription_id: u64, _reason: String) {
         let config = PaymentContract::get_dunning_config(env.clone());
         let now = env.ledger().timestamp();
 
-        let first_interval = if config.retry_intervals.len() > 0 {
-            config.retry_intervals.get(0).unwrap()
-        } else {
-            3600u64
-        };
-
+        // retry_count = 0: first retry uses backoff * 2^0 = backoff (1x)
+        // each subsequent failure increments retry_count, giving backoff * 2^retry_count
         let dunning_state = DunningState {
             subscription_id,
-            attempts: 1,
-            next_retry_at: now + first_interval,
-            grace_period_ends_at: now + config.grace_period,
-            suspended: false,
-            last_failure_reason: reason,
+            retry_count: 0,
+            next_retry_at: now + config.initial_backoff_seconds,
+            backoff_seconds: config.initial_backoff_seconds,
+            max_retries: config.max_retries,
+            last_failed_at: now,
         };
 
         env.storage()

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -3099,10 +3099,8 @@ fn setup_dunning_contract(
     client.set_dunning_config(
         &admin,
         &(DunningConfig {
-            grace_period: 86400, // 1 day
-            retry_intervals: Vec::from_array(env, [3600u64, 7200u64, 14400u64]), // 1h, 2h, 4h
-            max_dunning_attempts: 4,
-            suspend_after_attempts: 3,
+            initial_backoff_seconds: 3600, // 1 hour
+            max_retries: 4,
         })
     );
 
@@ -3115,10 +3113,195 @@ fn test_set_and_get_dunning_config() {
     let (client, _admin, _, _, _) = setup_dunning_contract(&env);
 
     let config = client.get_dunning_config();
-    assert_eq!(config.grace_period, 86400);
-    assert_eq!(config.retry_intervals.len(), 3);
-    assert_eq!(config.max_dunning_attempts, 4);
-    assert_eq!(config.suspend_after_attempts, 3);
+    assert_eq!(config.initial_backoff_seconds, 3600);
+    assert_eq!(config.max_retries, 4);
+}
+
+// Helper: create a subscription that will always fail (no customer funds).
+fn setup_failing_subscription(
+    env: &Env,
+    client: &PaymentContractClient<'_>,
+    customer: &Address,
+    merchant: &Address,
+) -> (u64, Address) {
+    let token_admin = Address::generate(env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    env.ledger().set_timestamp(1000);
+
+    let sub_id = client.create_subscription(
+        customer,
+        merchant,
+        &500i128,
+        &token_address,
+        &Currency::USDC,
+        &86400u64, // 1-day interval
+        &0u64,
+        &3u64,
+        &String::from_str(env, ""),
+        &0u64,
+    );
+    (sub_id, token_address)
+}
+
+#[test]
+fn test_dunning_retry_too_early_returns_error() {
+    let env = Env::default();
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.set_dunning_config(
+        &admin,
+        &(DunningConfig {
+            initial_backoff_seconds: 3600,
+            max_retries: 4,
+        }),
+    );
+
+    let (sub_id, _token) = setup_failing_subscription(&env, &client, &customer, &merchant);
+
+    // Advance to payment due time and trigger the first failure → enters dunning
+    env.ledger().set_timestamp(1000 + 86400 + 1);
+    let _ = client.try_execute_recurring_payment(&sub_id);
+
+    let dunning = client.get_dunning_state(&sub_id).unwrap();
+    assert_eq!(dunning.retry_count, 0);
+    let next_retry = dunning.next_retry_at;
+
+    // Calling before next_retry_at must return RetryTooEarly
+    env.ledger().set_timestamp(next_retry - 1);
+    let result = client.try_execute_recurring_payment(&sub_id);
+    assert_eq!(result, Err(Ok(Error::RetryTooEarly)));
+}
+
+#[test]
+fn test_dunning_exponential_backoff_doubles() {
+    let env = Env::default();
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let backoff = 3600u64;
+    client.set_dunning_config(
+        &admin,
+        &(DunningConfig {
+            initial_backoff_seconds: backoff,
+            max_retries: 5,
+        }),
+    );
+
+    let (sub_id, _token) = setup_failing_subscription(&env, &client, &customer, &merchant);
+
+    // Initial failure → enter dunning, retry_count = 0, next_retry_at = now + backoff (1x)
+    env.ledger().set_timestamp(1000 + 86400 + 1);
+    let _ = client.try_execute_recurring_payment(&sub_id);
+    let d1 = client.get_dunning_state(&sub_id).unwrap();
+    assert_eq!(d1.retry_count, 0);
+
+    // First retry failure → retry_count = 1, wait = backoff * 2^1 = backoff * 2 (doubles)
+    env.ledger().set_timestamp(d1.next_retry_at + 1);
+    let _ = client.try_execute_recurring_payment(&sub_id);
+    let d2 = client.get_dunning_state(&sub_id).unwrap();
+    assert_eq!(d2.retry_count, 1);
+    // next_retry_at = now + (backoff_seconds << 1) = now + backoff * 2
+    let expected_wait = backoff << 1u32;
+    assert_eq!(d2.next_retry_at, d1.next_retry_at + 1 + expected_wait);
+}
+
+#[test]
+fn test_dunning_max_retries_suspends_subscription() {
+    let env = Env::default();
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.set_dunning_config(
+        &admin,
+        &(DunningConfig {
+            initial_backoff_seconds: 60,
+            max_retries: 3,
+        }),
+    );
+
+    let (sub_id, _token) = setup_failing_subscription(&env, &client, &customer, &merchant);
+
+    // Initial failure → enter dunning (retry_count = 0)
+    env.ledger().set_timestamp(1000 + 86400 + 1);
+    let _ = client.try_execute_recurring_payment(&sub_id);
+
+    // Exhaust retries: retry_count goes 0 → 1 → 2 → 3, suspension fires at 3 >= max_retries(3)
+    for _ in 0..3 {
+        let d = client.get_dunning_state(&sub_id).unwrap();
+        env.ledger().set_timestamp(d.next_retry_at + 1);
+        let _ = client.try_execute_recurring_payment(&sub_id);
+    }
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Suspended);
+
+    let last = client.try_execute_recurring_payment(&sub_id);
+    assert_eq!(last, Err(Ok(Error::SubscriptionNotActive)));
+}
+
+#[test]
+fn test_dunning_successful_retry_fires_dunning_resolved() {
+    let env = Env::default();
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.set_dunning_config(
+        &admin,
+        &(DunningConfig {
+            initial_backoff_seconds: 3600,
+            max_retries: 4,
+        }),
+    );
+
+    // Start with no funds so first payment fails
+    let (sub_id, token_address) =
+        setup_failing_subscription(&env, &client, &customer, &merchant);
+
+    env.ledger().set_timestamp(1000 + 86400 + 1);
+    let _ = client.try_execute_recurring_payment(&sub_id);
+
+    let dunning = client.get_dunning_state(&sub_id).unwrap();
+    assert_eq!(dunning.retry_count, 0);
+
+    // Fund the customer so the retry succeeds
+    let asset_client = token::StellarAssetClient::new(&env, &token_address);
+    asset_client.mint(&customer, &100_000i128);
+
+    env.ledger().set_timestamp(dunning.next_retry_at + 1);
+    client.execute_recurring_payment(&sub_id);
+
+    // Dunning state should be cleared
+    assert!(client.get_dunning_state(&sub_id).is_none());
+
+    // Subscription should be Active again
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+    assert_eq!(sub.retry_count, 0);
+
 }
 
 #[test]


### PR DESCRIPTION
execute_recurring_payment() now handles InDunning
subscriptions directly instead of returning SubscriptionNotActive,
enforcing on-chain exponential backoff before each retry attempt.

Structs:
- DunningConfig: replaced grace_period/retry_intervals/max_dunning_attempts/
  suspend_after_attempts with initial_backoff_seconds + max_retries
- DunningState: replaced attempts/grace_period_ends_at/suspended/
  last_failure_reason with retry_count/backoff_seconds/max_retries/
  last_failed_at (next_retry_at retained)
- DunningResolved event: admin field replaced with resolved_at timestamp
  so the event fires correctly from both programmatic and admin resolution

New error: RetryTooEarly = 46, returned when a retry is attempted
before the backoff window expires

Backoff sequence (retry_count starts at 0 on dunning entry):
  initial_backoff * 2^0 -> 2^1 -> 2^2 -> ... -> suspend at max_retries

Tests: 4 new cases covering backoff enforcement, exponential doubling,
max-retry suspension, and successful retry resolution (DunningResolved)

closes #114 
