### PR TITLE
feat(payment): Add payment blacklist

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -25,6 +25,8 @@ pub enum DataKey {
     MerchantSubscriptionCount(Address),
     RateLimitConfig,
     AddressRateLimit(Address),
+    AddressFlagReason(Address),
+    AddressAllowlist(Address),
     DunningConfig,
     DunningState(u64),
     EscrowedPayment(u64),
@@ -152,7 +154,8 @@ pub enum Error {
     BatchPartialFailure = 19,
     RateLimitExceeded = 20,
     DailyVolumeExceeded = 21,
-    AddressFlagged = 22,
+    AddressFlagged = 60,
+    AddressAlreadyFlagged = 61,
     AmountExceedsLimit = 23,
     DunningNotFound = 24,
     SubscriptionNotInDunning = 25,
@@ -1125,6 +1128,13 @@ impl PaymentContract {
         // Validate metadata size
         if metadata.len() > MAX_METADATA_SIZE {
             return Err(Error::MetadataTooLarge);
+        }
+
+        // Enforce sanctions/flag checks at creation entry point.
+        if PaymentContract::is_address_flagged(env.clone(), customer.clone())
+            && !PaymentContract::is_allowlisted(env, &customer)
+        {
+            return Err(Error::AddressFlagged);
         }
 
         // Check rate limits and anti-fraud before processing
@@ -2998,10 +3008,16 @@ impl PaymentContract {
                 last_payment_at: 0,
                 flagged: false,
             });
+        if rate_limit.flagged {
+            return Err(Error::AddressAlreadyFlagged);
+        }
         rate_limit.flagged = true;
         env.storage()
             .instance()
             .set(&DataKey::AddressRateLimit(address.clone()), &rate_limit);
+        env.storage()
+            .instance()
+            .set(&DataKey::AddressFlagReason(address.clone()), &reason);
         (AddressFlagged { address, reason }).publish(&env);
         Ok(())
     }
@@ -3029,11 +3045,71 @@ impl PaymentContract {
                 last_payment_at: 0,
                 flagged: false,
             });
+        if !rate_limit.flagged {
+            return Err(Error::InvalidStatus);
+        }
         rate_limit.flagged = false;
         env.storage()
             .instance()
             .set(&DataKey::AddressRateLimit(address.clone()), &rate_limit);
+        env.storage()
+            .instance()
+            .remove(&DataKey::AddressFlagReason(address.clone()));
         (AddressUnflagged { address }).publish(&env);
+        Ok(())
+    }
+
+    pub fn is_address_flagged(env: Env, address: Address) -> bool {
+        let rate_limit: AddressRateLimit = env
+            .storage()
+            .instance()
+            .get(&DataKey::AddressRateLimit(address.clone()))
+            .unwrap_or(AddressRateLimit {
+                address,
+                payment_count: 0,
+                window_start: 0,
+                daily_volume: 0,
+                last_payment_at: 0,
+                flagged: false,
+            });
+        rate_limit.flagged
+    }
+
+    pub fn get_flag_reason(env: Env, address: Address) -> Option<String> {
+        env.storage()
+            .instance()
+            .get(&DataKey::AddressFlagReason(address))
+    }
+
+    pub fn add_to_allowlist(env: Env, admin: Address, address: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::AddressAllowlist(address), &true);
+        Ok(())
+    }
+
+    pub fn remove_from_allowlist(env: Env, admin: Address, address: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .remove(&DataKey::AddressAllowlist(address));
         Ok(())
     }
 
@@ -3063,8 +3139,8 @@ impl PaymentContract {
                 flagged: false,
             });
 
-        // Block flagged addresses immediately.
-        if rate_limit.flagged {
+        // Block flagged addresses unless explicitly allowlisted.
+        if rate_limit.flagged && !PaymentContract::is_allowlisted(env, address) {
             return Err(Error::AddressFlagged);
         }
 
@@ -3124,6 +3200,13 @@ impl PaymentContract {
             .set(&DataKey::AddressRateLimit(address.clone()), &rate_limit);
 
         Ok(())
+    }
+
+    fn is_allowlisted(env: &Env, address: &Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::AddressAllowlist(address.clone()))
+            .unwrap_or(false)
     }
 
     fn invoke_escrow_create(

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -88,23 +88,13 @@ fn test_flag_address_blocks_payments() {
     let token = Address::generate(&env);
     let meta = String::from_str(&env, "");
 
-    // Set a permissive config so the only gate is the flag.
-    client.set_rate_limit_config(
-        &admin,
-        &(RateLimitConfig {
-            max_payments_per_window: 100,
-            window_duration: 100_000,
-            max_payment_amount: 0,
-            max_daily_volume: 0,
-        })
-    );
-
     // Flag the customer.
     client.flag_address(&admin, &customer, &String::from_str(&env, "velocity attack"));
     let rl = client.get_address_rate_limit(&customer);
     assert!(rl.flagged);
+    assert!(client.is_address_flagged(&customer));
 
-    // Payment must fail because address is flagged.
+    // Payment must fail because address is flagged, even without rate-limit config.
     let result = client.try_create_payment(
         &customer,
         &merchant,
@@ -114,7 +104,7 @@ fn test_flag_address_blocks_payments() {
         &0,
         &meta
     );
-    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), Error::AddressFlagged);
 }
 
 #[test]
@@ -142,9 +132,69 @@ fn test_unflag_address_allows_payments() {
 
     let rl = client.get_address_rate_limit(&customer);
     assert!(!rl.flagged);
+    assert!(!client.is_address_flagged(&customer));
 
     // Payment must succeed after unflag.
     client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+}
+
+#[test]
+fn test_allowlist_bypasses_flag_check() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = String::from_str(&env, "");
+
+    client.flag_address(&admin, &customer, &String::from_str(&env, "sanctions review"));
+    client.add_to_allowlist(&admin, &customer);
+
+    // Allowlisted addresses can still initiate new payments even when flagged.
+    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+}
+
+#[test]
+fn test_unflag_requires_current_flag() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+
+    let result = client.try_unflag_address(&admin, &customer);
+    assert_eq!(result.unwrap_err().unwrap(), Error::InvalidStatus);
+}
+
+#[test]
+fn test_flag_reason_stored_and_cleared_on_unflag() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let reason = String::from_str(&env, "regulatory hold");
+
+    client.flag_address(&admin, &customer, &reason);
+    assert_eq!(client.get_flag_reason(&customer), Some(reason));
+
+    client.unflag_address(&admin, &customer);
+    assert_eq!(client.get_flag_reason(&customer), None);
+}
+
+#[test]
+fn test_flag_address_fails_if_already_flagged() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+
+    client.flag_address(&admin, &customer, &String::from_str(&env, "first reason"));
+    let result = client.try_flag_address(
+        &admin,
+        &customer,
+        &String::from_str(&env, "second reason")
+    );
+    assert_eq!(result.unwrap_err().unwrap(), Error::AddressAlreadyFlagged);
 }
 
 #[test]


### PR DESCRIPTION
closes #117 

---

**Description**
AddressFlagged/AddressUnflagged events exist but the flagging system does not prevent flagged addresses from initiating new payments. Enforcing the flag at create_payment() entry point blocks sanctioned addresses from using the platform.

**Acceptance Criteria**
- Flagged customer addresses cannot initiate new payments; existing payments are unaffected
- Allowlisted addresses bypass flag checks entirely
- `unflag_address()` requires the address to currently be flagged
- Flag reason is stored and retrievable for compliance reporting
- Add tests for blocked payment, allowlist bypass, and unflag restoration