### PR TITLE
Add scheduled payments, oracle refresh, conditional invoke, and analytics range APIs

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -2,7 +2,7 @@
 use escrow::EscrowContractClient;
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, token, Address, Bytes,
-    BytesN, Env, String, Vec,
+    BytesN, Env, IntoVal, String, Symbol, Vec,
 };
 
 #[derive(Clone)]
@@ -54,6 +54,13 @@ pub enum DataKey {
     LargePaymentProposal(u64),
     LargePaymentThreshold,
     LargePaymentCounter,
+    ScheduledPayment(u64),
+    ScheduledPaymentCounter,
+    OracleRateConfig(Currency),
+    MerchantAnalyticsBucket(Address, u64),
+    PlatformAnalyticsDaily(u64),
+    GlobalMerchantList(u64),
+    GlobalMerchantCount,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -176,6 +183,12 @@ pub enum Error {
     ContractPaused = 43,
     FunctionPaused = 44,
     InvalidTierThresholds = 45,
+    PaymentNotYetDue = 54,
+    ScheduledPaymentCancelled = 55,
+    OracleFeedStale = 58,
+    OracleNotConfigured = 59,
+    ConditionEvaluationFailed = 62,
+    ConditionRuntimeNotMet = 63,
     PaymentRequiresMultiSig = 64,
     InsufficientPaymentApprovals = 65,
     PaymentProposalExpired = 66,
@@ -432,6 +445,40 @@ pub struct ConditionalPayment {
     pub condition: ConditionType,
     pub condition_met: bool,
     pub evaluated_at: Option<u64>,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ScheduledPayment {
+    pub payment_id: u64,
+    pub customer: Address,
+    pub merchant: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub scheduled_at: u64,
+    pub executed: bool,
+    pub cancelled: bool,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct OracleRateConfig {
+    pub oracle_address: Address,
+    pub currency: Currency,
+    pub price_feed_id: BytesN<32>,
+    pub max_staleness_seconds: u64,
+    pub enabled: bool,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct AnalyticsBucket {
+    pub bucket_start: u64,
+    pub bucket_end: u64,
+    pub total_payments: u64,
+    pub total_volume: i128,
+    pub total_refunds: i128,
+    pub failed_count: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1107,6 +1154,119 @@ impl PaymentContract {
         )
     }
 
+    pub fn schedule_payment(
+        env: Env,
+        customer: Address,
+        merchant: Address,
+        token: Address,
+        amount: i128,
+        scheduled_at: u64,
+    ) -> Result<u64, Error> {
+        Self::require_not_paused(&env, "schedule_payment")?;
+        customer.require_auth();
+        if amount <= 0 {
+            return Err(Error::InvalidStatus);
+        }
+        let now = env.ledger().timestamp();
+        if scheduled_at <= now {
+            return Err(Error::PaymentNotYetDue);
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer_from(&contract_address, &customer, &contract_address, &amount);
+
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ScheduledPaymentCounter)
+            .unwrap_or(0);
+        let payment_id = counter + 1;
+        let scheduled = ScheduledPayment {
+            payment_id,
+            customer,
+            merchant,
+            token,
+            amount,
+            scheduled_at,
+            executed: false,
+            cancelled: false,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::ScheduledPayment(payment_id), &scheduled);
+        env.storage()
+            .instance()
+            .set(&DataKey::ScheduledPaymentCounter, &payment_id);
+        Ok(payment_id)
+    }
+
+    pub fn execute_scheduled_payment(env: Env, payment_id: u64) -> Result<(), Error> {
+        Self::require_not_paused(&env, "execute_scheduled_payment")?;
+        let mut scheduled: ScheduledPayment = env
+            .storage()
+            .instance()
+            .get(&DataKey::ScheduledPayment(payment_id))
+            .ok_or(Error::PaymentNotFound)?;
+        if scheduled.cancelled {
+            return Err(Error::ScheduledPaymentCancelled);
+        }
+        if scheduled.executed {
+            return Err(Error::AlreadyProcessed);
+        }
+        if env.ledger().timestamp() < scheduled.scheduled_at {
+            return Err(Error::PaymentNotYetDue);
+        }
+
+        let token_client = token::Client::new(&env, &scheduled.token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&contract_address, &scheduled.merchant, &scheduled.amount);
+        scheduled.executed = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScheduledPayment(payment_id), &scheduled);
+        Ok(())
+    }
+
+    pub fn cancel_scheduled_payment(
+        env: Env,
+        caller: Address,
+        payment_id: u64,
+    ) -> Result<(), Error> {
+        Self::require_not_paused(&env, "cancel_scheduled_payment")?;
+        caller.require_auth();
+        let mut scheduled: ScheduledPayment = env
+            .storage()
+            .instance()
+            .get(&DataKey::ScheduledPayment(payment_id))
+            .ok_or(Error::PaymentNotFound)?;
+        if scheduled.executed {
+            return Err(Error::AlreadyProcessed);
+        }
+        if scheduled.cancelled {
+            return Err(Error::ScheduledPaymentCancelled);
+        }
+        if caller != scheduled.customer {
+            return Err(Error::Unauthorized);
+        }
+
+        let token_client = token::Client::new(&env, &scheduled.token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&contract_address, &scheduled.customer, &scheduled.amount);
+        scheduled.cancelled = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScheduledPayment(payment_id), &scheduled);
+        Ok(())
+    }
+
+    pub fn get_scheduled_payment(env: Env, payment_id: u64) -> Result<ScheduledPayment, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::ScheduledPayment(payment_id))
+            .ok_or(Error::PaymentNotFound)
+    }
+
     fn do_create_payment(
         env: &Env,
         customer: Address,
@@ -1218,6 +1378,18 @@ impl PaymentContract {
         }
         if merchant_count == 0 {
             analytics.unique_merchants += 1;
+            let global_count: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::GlobalMerchantCount)
+                .unwrap_or(0);
+            env.storage().instance().set(
+                &DataKey::GlobalMerchantList(global_count),
+                &payment.merchant.clone(),
+            );
+            env.storage()
+                .instance()
+                .set(&DataKey::GlobalMerchantCount, &(global_count + 1));
         }
         env.storage()
             .instance()
@@ -1336,6 +1508,17 @@ impl PaymentContract {
             &DataKey::CustomerAnalytics(payment.customer.clone()),
             &c_analytics,
         );
+
+        PaymentContract::update_merchant_bucket(
+            env,
+            payment.merchant.clone(),
+            current_timestamp,
+            1,
+            amount,
+            0,
+            0,
+        );
+        PaymentContract::update_platform_daily_bucket(env, current_timestamp, amount, 0, 0);
 
         (PaymentCreated {
             payment_id,
@@ -1769,6 +1952,10 @@ impl PaymentContract {
         })
         .publish(env);
 
+        let now = env.ledger().timestamp();
+        PaymentContract::update_merchant_bucket(env, payment.merchant.clone(), now, 0, 0, 0, 0);
+        PaymentContract::update_platform_daily_bucket(env, now, 0, 0, 0);
+
         Ok(())
     }
 
@@ -1876,6 +2063,18 @@ impl PaymentContract {
             amount: payment.amount,
         })
         .publish(env);
+
+        let now = env.ledger().timestamp();
+        PaymentContract::update_merchant_bucket(
+            env,
+            payment.merchant.clone(),
+            now,
+            0,
+            0,
+            payment.amount,
+            0,
+        );
+        PaymentContract::update_platform_daily_bucket(env, now, 0, payment.amount, 0);
 
         Ok(())
     }
@@ -2020,6 +2219,17 @@ impl PaymentContract {
         })
         .publish(env);
 
+        PaymentContract::update_merchant_bucket(
+            env,
+            payment.merchant.clone(),
+            timestamp,
+            0,
+            0,
+            0,
+            1,
+        );
+        PaymentContract::update_platform_daily_bucket(env, timestamp, 0, 0, 1);
+
         Ok(())
     }
 
@@ -2147,6 +2357,64 @@ impl PaymentContract {
             .instance()
             .get(&DataKey::ConversionRate(currency))
             .unwrap_or(1_0000000)
+    }
+
+    pub fn set_oracle_rate_config(
+        env: Env,
+        admin: Address,
+        config: OracleRateConfig,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let multisig: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::OracleRateConfig(config.currency.clone()), &config);
+        Ok(())
+    }
+
+    pub fn get_oracle_rate_config(env: Env, currency: Currency) -> Option<OracleRateConfig> {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleRateConfig(currency))
+    }
+
+    pub fn refresh_conversion_rate(env: Env, currency: Currency) -> Result<i128, Error> {
+        let cfg: OracleRateConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleRateConfig(currency.clone()))
+            .ok_or(Error::OracleNotConfigured)?;
+
+        if !cfg.enabled {
+            return Ok(PaymentContract::get_conversion_rate(env, currency));
+        }
+
+        let args = (cfg.price_feed_id.clone(),).into_val(&env);
+        let fetched = env
+            .try_invoke_contract::<(i128, u64), Error>(
+                &cfg.oracle_address,
+                &Symbol::new(&env, "get_price"),
+                args,
+            )
+            .map_err(|_| Error::OracleCallFailed)?
+            .map_err(|_| Error::OracleCallFailed)?;
+
+        let now = env.ledger().timestamp();
+        if now.saturating_sub(fetched.1) > cfg.max_staleness_seconds {
+            return Err(Error::OracleFeedStale);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ConversionRate(currency), &fetched.0);
+        Ok(fetched.0)
     }
 
     // ── RECURRING / SUBSCRIPTION METHODS ────────────────────────────────────
@@ -3999,11 +4267,16 @@ impl PaymentContract {
                 // For now, return false to indicate oracle call failed
                 return Err(Error::OracleCallFailed);
             }
-            ConditionType::CrossContractState(_target_contract, _expected_state_hash) => {
-                // Mock cross-contract state check
-                // In real implementation, this would call the target contract and compare state
-                // For now, return false to indicate check failed
-                false
+            ConditionType::CrossContractState(target_contract, expected_state_hash) => {
+                let fetched = env
+                    .try_invoke_contract::<BytesN<32>, Error>(
+                        target_contract,
+                        &Symbol::new(&env, "get_state_hash"),
+                        Vec::new(&env),
+                    )
+                    .map_err(|_| Error::ConditionEvaluationFailed)?
+                    .map_err(|_| Error::ConditionEvaluationFailed)?;
+                fetched == *expected_state_hash
             }
         };
 
@@ -4076,6 +4349,29 @@ impl PaymentContract {
         PaymentContract::do_complete_payment(&env, payment_id)?;
 
         Ok(())
+    }
+
+    pub fn execute_if_condition_met(env: Env, payment_id: u64) -> Result<(), Error> {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::ConditionalPayment(payment_id))
+        {
+            return Err(Error::PaymentNotFound);
+        }
+        let payment = PaymentContract::get_payment(&env, payment_id);
+        if payment.status == PaymentStatus::Completed {
+            return Ok(());
+        }
+        if payment.status != PaymentStatus::Pending {
+            return Err(Error::InvalidStatus);
+        }
+
+        let condition_met = PaymentContract::evaluate_condition(env.clone(), payment_id)?;
+        if !condition_met {
+            return Err(Error::ConditionNotMet);
+        }
+        PaymentContract::do_complete_payment(&env, payment_id)
     }
 
     pub fn get_conditional_payment(env: Env, payment_id: u64) -> Result<ConditionalPayment, Error> {
@@ -4188,6 +4484,162 @@ impl PaymentContract {
             .instance()
             .get(&DataKey::CustomerMonthlyVolume(customer, month_timestamp))
             .unwrap_or(0)
+    }
+
+    pub fn get_merchant_analytics_range(
+        env: Env,
+        merchant: Address,
+        from: u64,
+        to: u64,
+    ) -> Result<Vec<AnalyticsBucket>, Error> {
+        if from >= to {
+            return Err(Error::InvalidStatus);
+        }
+        let mut out = Vec::new(&env);
+        let mut bucket_start = PaymentContract::hour_bucket_start(from);
+        while bucket_start < to {
+            if let Some(bucket) = env
+                .storage()
+                .instance()
+                .get::<DataKey, AnalyticsBucket>(&DataKey::MerchantAnalyticsBucket(
+                    merchant.clone(),
+                    bucket_start,
+                ))
+            {
+                out.push_back(bucket);
+            }
+            bucket_start += 3600;
+        }
+        Ok(out)
+    }
+
+    pub fn get_platform_analytics_daily(env: Env, day_timestamp: u64) -> AnalyticsBucket {
+        let day_start = PaymentContract::day_bucket_start(day_timestamp);
+        env.storage()
+            .instance()
+            .get(&DataKey::PlatformAnalyticsDaily(day_start))
+            .unwrap_or(AnalyticsBucket {
+                bucket_start: day_start,
+                bucket_end: day_start + 86400,
+                total_payments: 0,
+                total_volume: 0,
+                total_refunds: 0,
+                failed_count: 0,
+            })
+    }
+
+    pub fn get_top_merchants_by_volume(env: Env, limit: u32) -> Vec<(Address, i128)> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::GlobalMerchantCount)
+            .unwrap_or(0);
+        let mut pairs: Vec<(Address, i128)> = Vec::new(&env);
+        for i in 0..count {
+            if let Some(merchant) = env
+                .storage()
+                .instance()
+                .get::<DataKey, Address>(&DataKey::GlobalMerchantList(i))
+            {
+                let analytics = PaymentContract::get_merchant_analytics(env.clone(), merchant.clone());
+                pairs.push_back((merchant, analytics.total_volume));
+            }
+        }
+
+        let result_len = core::cmp::min(pairs.len(), limit);
+        let mut result: Vec<(Address, i128)> = Vec::new(&env);
+        let mut selected: Vec<bool> = Vec::new(&env);
+        for _ in 0..pairs.len() {
+            selected.push_back(false);
+        }
+        for _ in 0..result_len {
+            let mut best_idx: u32 = 0;
+            let mut best_vol: i128 = i128::MIN;
+            for j in 0..pairs.len() {
+                if !selected.get(j).unwrap_or(true) {
+                    let vol = pairs.get(j).map(|(_, v)| v).unwrap_or(0);
+                    if vol > best_vol {
+                        best_vol = vol;
+                        best_idx = j;
+                    }
+                }
+            }
+            if best_vol != i128::MIN {
+                result.push_back(pairs.get(best_idx).unwrap());
+                selected.set(best_idx, true);
+            }
+        }
+        result
+    }
+
+    fn hour_bucket_start(ts: u64) -> u64 {
+        (ts / 3600) * 3600
+    }
+
+    fn day_bucket_start(ts: u64) -> u64 {
+        (ts / 86400) * 86400
+    }
+
+    fn update_merchant_bucket(
+        env: &Env,
+        merchant: Address,
+        ts: u64,
+        payment_delta: u64,
+        volume_delta: i128,
+        refund_delta: i128,
+        failed_delta: u64,
+    ) {
+        let bucket_start = PaymentContract::hour_bucket_start(ts);
+        let mut bucket: AnalyticsBucket = env
+            .storage()
+            .instance()
+            .get(&DataKey::MerchantAnalyticsBucket(merchant.clone(), bucket_start))
+            .unwrap_or(AnalyticsBucket {
+                bucket_start,
+                bucket_end: bucket_start + 3600,
+                total_payments: 0,
+                total_volume: 0,
+                total_refunds: 0,
+                failed_count: 0,
+            });
+        bucket.total_payments += payment_delta;
+        bucket.total_volume += volume_delta;
+        bucket.total_refunds += refund_delta;
+        bucket.failed_count += failed_delta;
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantAnalyticsBucket(merchant, bucket_start), &bucket);
+    }
+
+    fn update_platform_daily_bucket(
+        env: &Env,
+        ts: u64,
+        volume_delta: i128,
+        refund_delta: i128,
+        failed_delta: u64,
+    ) {
+        let day_start = PaymentContract::day_bucket_start(ts);
+        let mut bucket: AnalyticsBucket = env
+            .storage()
+            .instance()
+            .get(&DataKey::PlatformAnalyticsDaily(day_start))
+            .unwrap_or(AnalyticsBucket {
+                bucket_start: day_start,
+                bucket_end: day_start + 86400,
+                total_payments: 0,
+                total_volume: 0,
+                total_refunds: 0,
+                failed_count: 0,
+            });
+        if volume_delta > 0 {
+            bucket.total_payments += 1;
+        }
+        bucket.total_volume += volume_delta;
+        bucket.total_refunds += refund_delta;
+        bucket.failed_count += failed_delta;
+        env.storage()
+            .instance()
+            .set(&DataKey::PlatformAnalyticsDaily(day_start), &bucket);
     }
 
     fn default_customer_analytics() -> CustomerAnalytics {
@@ -4714,3 +5166,6 @@ mod test_analytics;
 
 #[cfg(test)]
 mod test_trial;
+
+#[cfg(test)]
+mod test_issue_113_115_119_120;

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -4760,14 +4760,9 @@ fn test_evaluate_condition_cross_contract_state_false() {
         &condition
     );
 
-    // Cross-contract state conditions should return false (mock implementation)
-    let result = client.evaluate_condition(&payment_id);
-    assert!(!result);
-
-    // Verify result was cached
-    let conditional_payment = client.get_conditional_payment(&payment_id);
-    assert!(!conditional_payment.condition_met);
-    assert!(conditional_payment.evaluated_at.is_some());
+    // Cross-contract invoke failures should return a typed error.
+    let result = client.try_evaluate_condition(&payment_id);
+    assert_eq!(result.err(), Some(Ok(Error::ConditionEvaluationFailed)));
 }
 
 #[test]

--- a/contracts/payment/src/test_issue_113_115_119_120.rs
+++ b/contracts/payment/src/test_issue_113_115_119_120.rs
@@ -1,0 +1,226 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, String};
+
+fn setup() -> (Env, PaymentContractClient<'static>, Address) {
+    let env = Env::default();
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+#[contract]
+struct MockOracleContract;
+
+#[contractimpl]
+impl MockOracleContract {
+    pub fn get_price(_env: Env, _feed_id: BytesN<32>) -> (i128, u64) {
+        (123_0000000, 1_000)
+    }
+}
+
+#[contract]
+struct FreshStateContract;
+
+#[contractimpl]
+impl FreshStateContract {
+    pub fn get_state_hash(_env: Env) -> BytesN<32> {
+        BytesN::from_array(&_env, &[7; 32])
+    }
+}
+
+#[test]
+fn test_schedule_payment_flow_and_guards() {
+    let (env, client, _admin) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_address = env.register_stellar_asset_contract(token_admin.clone());
+    let token_client = token::Client::new(&env, &token_address);
+    let token_asset = token::StellarAssetClient::new(&env, &token_address);
+    token_asset.mint(&customer, &5_000);
+
+    env.ledger().set_timestamp(100);
+    let payment_id = client
+        .schedule_payment(&customer, &merchant, &token_address, &1_000, &150)
+        .unwrap();
+    assert_eq!(token_client.balance(&customer), 4_000);
+    assert_eq!(token_client.balance(&client.address), 1_000);
+
+    let early = client.try_execute_scheduled_payment(&payment_id);
+    assert_eq!(early.err(), Some(Ok(Error::PaymentNotYetDue)));
+
+    env.ledger().set_timestamp(151);
+    client.execute_scheduled_payment(&payment_id).unwrap();
+    assert_eq!(token_client.balance(&merchant), 1_000);
+
+    let second = client.try_execute_scheduled_payment(&payment_id);
+    assert_eq!(second.err(), Some(Ok(Error::AlreadyProcessed)));
+}
+
+#[test]
+fn test_cancel_scheduled_payment_refunds_customer() {
+    let (env, client, _admin) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_address = env.register_stellar_asset_contract(token_admin.clone());
+    let token_client = token::Client::new(&env, &token_address);
+    let token_asset = token::StellarAssetClient::new(&env, &token_address);
+    token_asset.mint(&customer, &2_000);
+
+    env.ledger().set_timestamp(50);
+    let payment_id = client
+        .schedule_payment(&customer, &merchant, &token_address, &1_200, &90)
+        .unwrap();
+    client
+        .cancel_scheduled_payment(&customer, &payment_id)
+        .unwrap();
+
+    let scheduled = client.get_scheduled_payment(&payment_id).unwrap();
+    assert!(scheduled.cancelled);
+    assert_eq!(token_client.balance(&customer), 2_000);
+    assert_eq!(token_client.balance(&client.address), 0);
+}
+
+#[test]
+fn test_oracle_refresh_and_manual_fallback() {
+    let (env, client, admin) = setup();
+    env.ledger().set_timestamp(1_005);
+    client
+        .set_conversion_rate(&admin, &Currency::BTC, &90_0000000)
+        .unwrap();
+
+    let oracle_id = env.register(MockOracleContract, ());
+    let feed = BytesN::from_array(&env, &[1; 32]);
+    let cfg = OracleRateConfig {
+        oracle_address: oracle_id,
+        currency: Currency::BTC,
+        price_feed_id: feed,
+        max_staleness_seconds: 20,
+        enabled: true,
+    };
+    client.set_oracle_rate_config(&admin, &cfg).unwrap();
+    let refreshed = client.refresh_conversion_rate(&Currency::BTC).unwrap();
+    assert_eq!(refreshed, 123_0000000);
+
+    let stale_cfg = OracleRateConfig {
+        oracle_address: cfg.oracle_address.clone(),
+        currency: Currency::ETH,
+        price_feed_id: cfg.price_feed_id.clone(),
+        max_staleness_seconds: 1,
+        enabled: true,
+    };
+    client.set_oracle_rate_config(&admin, &stale_cfg).unwrap();
+    let stale = client.try_refresh_conversion_rate(&Currency::ETH);
+    assert_eq!(stale.err(), Some(Ok(Error::OracleFeedStale)));
+
+    let disabled_cfg = OracleRateConfig {
+        oracle_address: cfg.oracle_address,
+        currency: Currency::USDC,
+        price_feed_id: cfg.price_feed_id,
+        max_staleness_seconds: 100,
+        enabled: false,
+    };
+    client
+        .set_conversion_rate(&admin, &Currency::USDC, &1_0000000)
+        .unwrap();
+    client.set_oracle_rate_config(&admin, &disabled_cfg).unwrap();
+    let fallback = client.refresh_conversion_rate(&Currency::USDC).unwrap();
+    assert_eq!(fallback, 1_0000000);
+}
+
+#[test]
+fn test_cross_contract_condition_success_and_failure() {
+    let (env, client, admin) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = String::from_str(&env, "cond");
+
+    let good_id = env.register(FreshStateContract, ());
+    let good_hash = BytesN::from_array(&env, &[7; 32]);
+    let condition = ConditionType::CrossContractState(good_id, good_hash);
+    let payment_id = client
+        .create_conditional_payment(
+            &customer,
+            &merchant,
+            &100,
+            &token,
+            &Currency::USDC,
+            &300,
+            &meta,
+            &condition,
+        )
+        .unwrap();
+    client
+        .execute_if_condition_met(&payment_id)
+        .expect("should execute when state matches");
+    client
+        .execute_if_condition_met(&payment_id)
+        .expect("idempotent re-execution should succeed");
+
+    let bad_target = Address::generate(&env);
+    let bad_cond = ConditionType::CrossContractState(bad_target, BytesN::from_array(&env, &[9; 32]));
+    let payment_id2 = client
+        .create_conditional_payment(
+            &customer,
+            &merchant,
+            &50,
+            &token,
+            &Currency::USDC,
+            &300,
+            &meta,
+            &bad_cond,
+        )
+        .unwrap();
+    let eval = client.try_evaluate_condition(&payment_id2);
+    assert_eq!(eval.err(), Some(Ok(Error::ConditionEvaluationFailed)));
+
+    let _ = admin;
+}
+
+#[test]
+fn test_analytics_range_and_top_merchants() {
+    let (env, client, _admin) = setup();
+    let customer = Address::generate(&env);
+    let merchant_a = Address::generate(&env);
+    let merchant_b = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = String::from_str(&env, "");
+
+    env.ledger().set_timestamp(3_600);
+    let p1 = client
+        .create_payment(&customer, &merchant_a, &1_000, &token, &Currency::USDC, &0, &meta)
+        .unwrap();
+    let _ = client.cancel_payment(&customer, &p1);
+
+    env.ledger().set_timestamp(7_200);
+    let _ = client
+        .create_payment(&customer, &merchant_b, &5_000, &token, &Currency::USDC, &0, &meta)
+        .unwrap();
+
+    let range = client
+        .get_merchant_analytics_range(&merchant_a, &3_600, &10_800)
+        .unwrap();
+    assert_eq!(range.len(), 1);
+    assert_eq!(range.get(0).unwrap().total_volume, 1_000);
+    assert_eq!(range.get(0).unwrap().failed_count, 1);
+
+    let reversed = client.try_get_merchant_analytics_range(&merchant_a, &10_800, &3_600);
+    assert!(reversed.is_err());
+
+    let top = client.get_top_merchants_by_volume(&1);
+    assert_eq!(top.len(), 1);
+    assert_eq!(top.get(0).unwrap().0, merchant_b);
+    assert_eq!(top.get(0).unwrap().1, 5_000);
+
+    let daily = client.get_platform_analytics_daily(&7_250);
+    assert!(daily.total_payments >= 1);
+    assert!(daily.total_volume >= 5_000);
+}


### PR DESCRIPTION
## Summary
- add scheduled payment lifecycle APIs (`schedule_payment`, `execute_scheduled_payment`, `cancel_scheduled_payment`, `get_scheduled_payment`) with escrow-at-create behavior and due-time/cancel guards
- add oracle conversion config and refresh flow (`set_oracle_rate_config`, `refresh_conversion_rate`, `get_oracle_rate_config`) with stale-feed enforcement and manual-rate fallback when oracle is disabled
- implement cross-contract condition checks via `env.try_invoke_contract` for `ConditionType::CrossContractState`, add `execute_if_condition_met`, and return typed `ConditionEvaluationFailed` on invoke failures
- add merchant/platform analytics buckets and query APIs (`get_merchant_analytics_range`, `get_platform_analytics_daily`, `get_top_merchants_by_volume`) and update buckets atomically on create/refund/cancel transitions
- add focused tests covering scheduling, oracle freshness/fallback, cross-contract condition success/failure/idempotency, and analytics range/ranking behavior

## Validation
- attempted `cargo test -p payments` and `cargo check -p payments --lib`
- blocked by pre-existing syntax error in upstream `contracts/escrow/src/test.rs` (unexpected closing delimiter)

Closes #113
Closes #115
Closes #119
Closes #120

Made with [Cursor](https://cursor.com)