### PR TITLE
Feature/81 cross contract escrow state verification

### DIFF
--- a/contracts/escrow/src/beneficiary_transfer_test.rs
+++ b/contracts/escrow/src/beneficiary_transfer_test.rs
@@ -4,7 +4,14 @@ use super::*;
 use soroban_sdk::testutils::Ledger;
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
-fn setup() -> (Env, EscrowContractClient<'static>, Address, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    EscrowContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/collateral_test.rs
+++ b/contracts/escrow/src/collateral_test.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
 use crate::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, token};
 use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
 
 #[test]
 fn test_dispute_collateral_deposit_and_return() {
@@ -21,13 +21,17 @@ fn test_dispute_collateral_deposit_and_return() {
     env.ledger().set_timestamp(1000);
 
     // Setup collateral config
-    client.set_dispute_config(&admin, &DisputeConfig {
-        collateral_token: token.clone(),
-        collateral_amount: 100,
-        collateral_enabled: true,
-    });
+    client.set_dispute_config(
+        &admin,
+        &DisputeConfig {
+            collateral_token: token.clone(),
+            collateral_amount: 100,
+            collateral_enabled: true,
+        },
+    );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &9999_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &9999_u64, &0_u64);
 
     // Mint and transfer escrow amount to contract
     token_admin_client.mint(&customer, &1000);
@@ -35,7 +39,7 @@ fn test_dispute_collateral_deposit_and_return() {
 
     // Mint collateral to customer
     token_admin_client.mint(&customer, &100);
-    
+
     // Dispute requires collateral
     client.dispute_escrow(&customer, &escrow_id);
 
@@ -70,13 +74,17 @@ fn test_dispute_collateral_forfeiture() {
 
     env.ledger().set_timestamp(1000);
 
-    client.set_dispute_config(&admin, &DisputeConfig {
-        collateral_token: token.clone(),
-        collateral_amount: 50,
-        collateral_enabled: true,
-    });
+    client.set_dispute_config(
+        &admin,
+        &DisputeConfig {
+            collateral_token: token.clone(),
+            collateral_amount: 50,
+            collateral_enabled: true,
+        },
+    );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &9999_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &9999_u64, &0_u64);
 
     // Mint and transfer escrow amount to contract
     token_admin_client.mint(&customer, &1000);
@@ -109,20 +117,24 @@ fn test_dispute_without_collateral_when_disabled() {
     env.ledger().set_timestamp(1000);
 
     // Collateral disabled
-    client.set_dispute_config(&admin, &DisputeConfig {
-        collateral_token: token.clone(),
-        collateral_amount: 100,
-        collateral_enabled: false,
-    });
+    client.set_dispute_config(
+        &admin,
+        &DisputeConfig {
+            collateral_token: token.clone(),
+            collateral_amount: 100,
+            collateral_enabled: false,
+        },
+    );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &9999_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &9999_u64, &0_u64);
 
     // Dispute without having any collateral token
     client.dispute_escrow(&customer, &escrow_id);
 
     let escrow = client.get_escrow(&escrow_id);
     assert_eq!(escrow.status, EscrowStatus::Disputed);
-    
+
     // get_dispute_collateral should fail
     let res = client.try_get_dispute_collateral(&escrow_id);
     assert!(res.is_err());

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -174,7 +174,6 @@ pub enum Error {
     SameBeneficiary = 43,
 }
 
-
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CollateralDeposited {
@@ -424,7 +423,6 @@ pub struct ReputationDecayConfig {
     pub min_score: i128,
     pub max_score: i128,
 }
-
 
 #[derive(Clone)]
 #[contracttype]
@@ -879,14 +877,23 @@ impl EscrowContract {
         AdminAdded { admin }.publish(&env);
     }
 
-    pub fn set_escrow_fee_config(env: Env, admin: Address, config: EscrowFeeConfig) -> Result<(), Error> {
+    pub fn set_escrow_fee_config(
+        env: Env,
+        admin: Address,
+        config: EscrowFeeConfig,
+    ) -> Result<(), Error> {
         admin.require_auth();
         let multisig = Self::get_multisig_config(env.clone());
         if !multisig.admins.contains(&admin) {
             return Err(Error::NotAnAdmin);
         }
-        env.storage().instance().set(&DataKey::EscrowFeeConfigKey, &config);
-        EscrowFeeConfigUpdated { fee_bps: config.fee_bps }.publish(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowFeeConfigKey, &config);
+        EscrowFeeConfigUpdated {
+            fee_bps: config.fee_bps,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -908,25 +915,37 @@ impl EscrowContract {
             .unwrap_or(0)
     }
 
-    pub fn withdraw_escrow_fees(env: Env, admin: Address, token: Address, to: Address) -> Result<i128, Error> {
+    pub fn withdraw_escrow_fees(
+        env: Env,
+        admin: Address,
+        token: Address,
+        to: Address,
+    ) -> Result<i128, Error> {
         admin.require_auth();
         let multisig = Self::get_multisig_config(env.clone());
         if !multisig.admins.contains(&admin) {
             return Err(Error::NotAnAdmin);
         }
 
-        let amount: i128 = env.storage().instance().get(&DataKey::AccumulatedEscrowFees(token.clone())).unwrap_or(0);
+        let amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AccumulatedEscrowFees(token.clone()))
+            .unwrap_or(0);
         if amount == 0 {
             return Ok(0);
         }
 
         Self::transfer_if_token_contract(&env, &token, &to, amount)?;
-        env.storage().instance().set(&DataKey::AccumulatedEscrowFees(token.clone()), &0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::AccumulatedEscrowFees(token.clone()), &0i128);
 
         EscrowFeesWithdrawn {
             amount,
             withdrawn_by: admin,
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(amount)
     }
@@ -1236,7 +1255,11 @@ impl EscrowContract {
         let current_timestamp = env.ledger().timestamp();
 
         let fee_config = Self::get_escrow_fee_config(env.clone());
-        let fee_bps = if fee_config.enabled { fee_config.fee_bps } else { 0 };
+        let fee_bps = if fee_config.enabled {
+            fee_config.fee_bps
+        } else {
+            0
+        };
 
         let escrow = Escrow {
             id: escrow_id,
@@ -1680,7 +1703,11 @@ impl EscrowContract {
 
         // Check if this is being called from execute_queued_action
 
-        if let Some(config) = env.storage().instance().get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig) {
+        if let Some(config) = env
+            .storage()
+            .instance()
+            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig)
+        {
             if config.admins.contains(&admin) && early_release {
                 // Admin force release requires time-lock
                 return Err(Error::Unauthorized);
@@ -1742,16 +1769,23 @@ impl EscrowContract {
             )?;
 
             if fee_config.fee_recipient == env.current_contract_address() {
-                let mut acc: i128 = env.storage().instance().get(&DataKey::AccumulatedEscrowFees(escrow.token.clone())).unwrap_or(0);
+                let mut acc: i128 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::AccumulatedEscrowFees(escrow.token.clone()))
+                    .unwrap_or(0);
                 acc += fee_amount;
-                env.storage().instance().set(&DataKey::AccumulatedEscrowFees(escrow.token.clone()), &acc);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::AccumulatedEscrowFees(escrow.token.clone()), &acc);
             }
 
             EscrowFeeCollected {
                 escrow_id,
                 fee_amount,
                 recipient: fee_config.fee_recipient.clone(),
-            }.publish(&env);
+            }
+            .publish(&env);
         }
 
         EscrowContract::transfer_if_token_contract(
@@ -1826,7 +1860,9 @@ impl EscrowContract {
             EscrowStatus::Locked | EscrowStatus::Disputed => {
                 escrow.status = EscrowStatus::Resolved;
             }
-            EscrowStatus::Released | EscrowStatus::Resolved | EscrowStatus::Cancelled => return Err(Error::AlreadyProcessed),
+            EscrowStatus::Released | EscrowStatus::Resolved | EscrowStatus::Cancelled => {
+                return Err(Error::AlreadyProcessed)
+            }
         }
 
         env.storage()
@@ -1869,7 +1905,11 @@ impl EscrowContract {
         let config = Self::get_dispute_config(env.clone());
         if config.collateral_enabled && config.collateral_amount > 0 {
             let token_client = token::Client::new(&env, &config.collateral_token);
-            token_client.transfer(&caller, &env.current_contract_address(), &config.collateral_amount);
+            token_client.transfer(
+                &caller,
+                &env.current_contract_address(),
+                &config.collateral_amount,
+            );
 
             let collateral = DisputeCollateral {
                 escrow_id,
@@ -1878,13 +1918,16 @@ impl EscrowContract {
                 token: config.collateral_token.clone(),
                 deposited_at: env.ledger().timestamp(),
             };
-            env.storage().instance().set(&DataKey::DisputeCollateral(escrow_id), &collateral);
-            
+            env.storage()
+                .instance()
+                .set(&DataKey::DisputeCollateral(escrow_id), &collateral);
+
             CollateralDeposited {
                 escrow_id,
                 party: caller.clone(),
                 amount: config.collateral_amount,
-            }.publish(&env);
+            }
+            .publish(&env);
         }
 
         match escrow.status {
@@ -2088,7 +2131,11 @@ impl EscrowContract {
         admin.require_auth();
         Self::require_not_paused(&env, "resolve_dispute")?;
 
-        if let Some(config) = env.storage().instance().get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig) {
+        if let Some(config) = env
+            .storage()
+            .instance()
+            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig)
+        {
             if !config.admins.contains(&admin) {
                 return Err(Error::NotAnAdmin);
             }
@@ -2137,7 +2184,11 @@ impl EscrowContract {
         Self::transfer_if_token_contract(&env, &escrow.token, recipient, escrow.amount)?;
 
         // Handle collateral distribution
-        if let Some(collateral) = env.storage().instance().get::<DataKey, DisputeCollateral>(&DataKey::DisputeCollateral(escrow_id)) {
+        if let Some(collateral) = env
+            .storage()
+            .instance()
+            .get::<DataKey, DisputeCollateral>(&DataKey::DisputeCollateral(escrow_id))
+        {
             let winner = if release_to_merchant {
                 escrow.merchant.clone()
             } else {
@@ -2152,15 +2203,19 @@ impl EscrowContract {
                     escrow_id,
                     party: collateral.disputing_party,
                     amount: collateral.amount,
-                }.publish(&env);
+                }
+                .publish(&env);
             } else {
                 CollateralForfeited {
                     escrow_id,
                     party: collateral.disputing_party,
                     amount: collateral.amount,
-                }.publish(&env);
+                }
+                .publish(&env);
             }
-            env.storage().instance().remove(&DataKey::DisputeCollateral(escrow_id));
+            env.storage()
+                .instance()
+                .remove(&DataKey::DisputeCollateral(escrow_id));
         }
 
         let (winner, loser) = if release_to_merchant {
@@ -2328,6 +2383,63 @@ impl EscrowContract {
             .instance()
             .get(&DataKey::MerchantEscrowCount(merchant))
             .unwrap_or(0)
+    }
+
+    // ── STATE VERIFICATION INTERFACE ──────────────────────────────────────────
+
+    /// Returns true if the escrow exists and its status is Released.
+    pub fn is_escrow_released(env: Env, escrow_id: u64) -> bool {
+        env.storage()
+            .instance()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+            .map(|e| e.status == EscrowStatus::Released)
+            .unwrap_or(false)
+    }
+
+    /// Returns true if the escrow exists and its status is Disputed.
+    pub fn is_escrow_disputed(env: Env, escrow_id: u64) -> bool {
+        env.storage()
+            .instance()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+            .map(|e| e.status == EscrowStatus::Disputed)
+            .unwrap_or(false)
+    }
+
+    /// Returns the current status of an escrow, or EscrowNotFound if it does not exist.
+    pub fn get_escrow_status(env: Env, escrow_id: u64) -> Result<EscrowStatus, Error> {
+        env.storage()
+            .instance()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+            .map(|e| e.status)
+            .ok_or(Error::EscrowNotFound)
+    }
+
+    /// Returns the (customer, merchant) address pair for an escrow, or EscrowNotFound.
+    pub fn get_escrow_parties(env: Env, escrow_id: u64) -> Result<(Address, Address), Error> {
+        env.storage()
+            .instance()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+            .map(|e| (e.customer, e.merchant))
+            .ok_or(Error::EscrowNotFound)
+    }
+
+    /// Returns the locked amount for an escrow, or EscrowNotFound.
+    pub fn get_escrow_amount(env: Env, escrow_id: u64) -> Result<i128, Error> {
+        env.storage()
+            .instance()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+            .map(|e| e.amount)
+            .ok_or(Error::EscrowNotFound)
+    }
+
+    /// Returns true if `address` is the customer or merchant of the given escrow.
+    /// Returns false for non-existent escrow IDs or unrelated addresses.
+    pub fn verify_escrow_participant(env: Env, escrow_id: u64, address: Address) -> bool {
+        env.storage()
+            .instance()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+            .map(|e| e.customer == address || e.merchant == address)
+            .unwrap_or(false)
     }
 
     // ── REPUTATION METHODS ───────────────────────────────────────────────────
@@ -2550,7 +2662,11 @@ impl EscrowContract {
         let escrow_id = counter + 1;
 
         let fee_config = Self::get_escrow_fee_config(env.clone());
-        let fee_bps = if fee_config.enabled { fee_config.fee_bps } else { 0 };
+        let fee_bps = if fee_config.enabled {
+            fee_config.fee_bps
+        } else {
+            0
+        };
 
         let escrow = Escrow {
             id: escrow_id,
@@ -3133,16 +3249,23 @@ impl EscrowContract {
                     )?;
 
                     if fee_config.fee_recipient == env.current_contract_address() {
-                        let mut acc: i128 = env.storage().instance().get(&DataKey::AccumulatedEscrowFees(escrow.token.clone())).unwrap_or(0);
+                        let mut acc: i128 = env
+                            .storage()
+                            .instance()
+                            .get(&DataKey::AccumulatedEscrowFees(escrow.token.clone()))
+                            .unwrap_or(0);
                         acc += fee_amount;
-                        env.storage().instance().set(&DataKey::AccumulatedEscrowFees(escrow.token.clone()), &acc);
+                        env.storage()
+                            .instance()
+                            .set(&DataKey::AccumulatedEscrowFees(escrow.token.clone()), &acc);
                     }
 
                     EscrowFeeCollected {
                         escrow_id,
                         fee_amount,
                         recipient: fee_config.fee_recipient.clone(),
-                    }.publish(env);
+                    }
+                    .publish(env);
                 }
 
                 EscrowContract::transfer_if_token_contract(
@@ -3854,23 +3977,35 @@ impl EscrowContract {
             })
     }
 
-    pub fn set_insurance_config(env: Env, admin: Address, config: InsuranceConfig) -> Result<(), Error> {
+    pub fn set_insurance_config(
+        env: Env,
+        admin: Address,
+        config: InsuranceConfig,
+    ) -> Result<(), Error> {
         admin.require_auth();
         let multisig = Self::get_multisig_config(env.clone());
         if !multisig.admins.contains(&admin) {
             return Err(Error::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::InsuranceConfig, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceConfig, &config);
         Ok(())
     }
 
-    pub fn set_watchdog_config(env: Env, admin: Address, config: WatchdogConfig) -> Result<(), Error> {
+    pub fn set_watchdog_config(
+        env: Env,
+        admin: Address,
+        config: WatchdogConfig,
+    ) -> Result<(), Error> {
         admin.require_auth();
         let multisig = Self::get_multisig_config(env.clone());
         if !multisig.admins.contains(&admin) {
             return Err(Error::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::WatchdogConfig, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::WatchdogConfig, &config);
         Ok(())
     }
 
@@ -3887,17 +4022,29 @@ impl EscrowContract {
     }
 
     pub fn opt_into_insurance(env: Env, escrow_id: u64) -> Result<(), Error> {
-        let config: InsuranceConfig = env.storage().instance().get(&DataKey::InsuranceConfig).ok_or(Error::Unauthorized)?;
-        if !config.enabled { return Err(Error::Unauthorized); }
+        let config: InsuranceConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceConfig)
+            .ok_or(Error::Unauthorized)?;
+        if !config.enabled {
+            return Err(Error::Unauthorized);
+        }
 
         let mut escrow = Self::get_escrow(&env, escrow_id);
-        if escrow.status != EscrowStatus::Locked { return Err(Error::InvalidStatus); }
+        if escrow.status != EscrowStatus::Locked {
+            return Err(Error::InvalidStatus);
+        }
 
         let premium = (escrow.amount * config.premium_bps) / 10000;
-        if premium == 0 { return Ok(()); }
+        if premium == 0 {
+            return Ok(());
+        }
 
         escrow.amount -= premium;
-        env.storage().instance().set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
 
         let mut pool = Self::get_insurance_pool(env.clone());
         pool.token = escrow.token.clone();
@@ -3908,21 +4055,39 @@ impl EscrowContract {
         Ok(())
     }
 
-    pub fn file_insurance_claim(env: Env, admin: Address, escrow_id: u64, amount: i128) -> Result<u64, Error> {
+    pub fn file_insurance_claim(
+        env: Env,
+        admin: Address,
+        escrow_id: u64,
+        amount: i128,
+    ) -> Result<u64, Error> {
         admin.require_auth();
         let multisig = Self::get_multisig_config(env.clone());
-        if !multisig.admins.contains(&admin) { return Err(Error::Unauthorized); }
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
 
         let escrow = Self::get_escrow(&env, escrow_id);
         if escrow.status != EscrowStatus::Resolved && escrow.status != EscrowStatus::Cancelled {
             return Err(Error::NotClaimable);
         }
 
-        let config: InsuranceConfig = env.storage().instance().get(&DataKey::InsuranceConfig).ok_or(Error::Unauthorized)?;
+        let config: InsuranceConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceConfig)
+            .ok_or(Error::Unauthorized)?;
         let max_coverage = (escrow.amount * config.max_coverage_bps) / 10000;
-        if amount > max_coverage { return Err(Error::Unauthorized); }
+        if amount > max_coverage {
+            return Err(Error::Unauthorized);
+        }
 
-        let counter: u64 = env.storage().instance().get(&DataKey::InsuranceClaimCounter).unwrap_or(0) + 1;
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceClaimCounter)
+            .unwrap_or(0)
+            + 1;
         let claim = InsuranceClaim {
             claim_id: counter,
             escrow_id,
@@ -3932,8 +4097,12 @@ impl EscrowContract {
             paid_at: None,
         };
 
-        env.storage().instance().set(&DataKey::InsuranceClaim(counter), &claim);
-        env.storage().instance().set(&DataKey::InsuranceClaimCounter, &counter);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceClaim(counter), &claim);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceClaimCounter, &counter);
 
         Ok(counter)
     }
@@ -3941,13 +4110,23 @@ impl EscrowContract {
     pub fn approve_claim(env: Env, admin: Address, claim_id: u64) -> Result<(), Error> {
         admin.require_auth();
         let multisig = Self::get_multisig_config(env.clone());
-        if !multisig.admins.contains(&admin) { return Err(Error::Unauthorized); }
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
 
-        let mut claim: InsuranceClaim = env.storage().instance().get(&DataKey::InsuranceClaim(claim_id)).ok_or(Error::EscrowNotFound)?;
-        if claim.approved { return Err(Error::AlreadyProcessed); }
+        let mut claim: InsuranceClaim = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsuranceClaim(claim_id))
+            .ok_or(Error::EscrowNotFound)?;
+        if claim.approved {
+            return Err(Error::AlreadyProcessed);
+        }
 
         let mut pool = Self::get_insurance_pool(env.clone());
-        if pool.balance < claim.amount { return Err(Error::Underfunded); }
+        if pool.balance < claim.amount {
+            return Err(Error::Underfunded);
+        }
 
         Self::transfer_if_token_contract(&env, &pool.token, &claim.claimant, claim.amount)?;
 
@@ -3957,7 +4136,9 @@ impl EscrowContract {
 
         claim.approved = true;
         claim.paid_at = Some(env.ledger().timestamp());
-        env.storage().instance().set(&DataKey::InsuranceClaim(claim_id), &claim);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsuranceClaim(claim_id), &claim);
 
         Ok(())
     }
@@ -4003,7 +4184,7 @@ impl EscrowContract {
 
         let config = Self::get_watchdog_config(env.clone());
         let mut escrow = Self::get_escrow(&env, escrow_id);
-        
+
         let released_to = if config.favor_customer_on_release {
             escrow.customer.clone()
         } else {
@@ -4016,7 +4197,9 @@ impl EscrowContract {
             EscrowStatus::Released
         };
 
-        env.storage().instance().set(&DataKey::Escrow(escrow_id), &escrow);
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
 
         Self::transfer_if_token_contract(&env, &escrow.token, &released_to, escrow.amount)?;
 
@@ -4024,7 +4207,8 @@ impl EscrowContract {
             escrow_id,
             released_to: released_to.clone(),
             triggered_by: env.current_contract_address(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -4040,18 +4224,30 @@ impl EscrowContract {
         if !ms.admins.contains(&admin) {
             return Err(Error::NotAnAdmin);
         }
-        env.storage().instance().set(&DataKey::ReputationDecayConfig, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReputationDecayConfig, &config);
         Ok(())
     }
 
-    pub fn set_dispute_config(env: Env, admin: Address, config: DisputeConfig) -> Result<(), Error> {
+    pub fn set_dispute_config(
+        env: Env,
+        admin: Address,
+        config: DisputeConfig,
+    ) -> Result<(), Error> {
         admin.require_auth();
-        if let Some(ms) = env.storage().instance().get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig) {
+        if let Some(ms) = env
+            .storage()
+            .instance()
+            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig)
+        {
             if !ms.admins.contains(&admin) {
                 return Err(Error::NotAnAdmin);
             }
         }
-        env.storage().instance().set(&DataKey::DisputeConfigKey, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::DisputeConfigKey, &config);
         Ok(())
     }
 
@@ -4266,9 +4462,10 @@ impl EscrowContract {
             authorised_by: caller,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::BeneficiaryTransferHistory(escrow_id, count), &transfer);
+        env.storage().instance().set(
+            &DataKey::BeneficiaryTransferHistory(escrow_id, count),
+            &transfer,
+        );
         env.storage()
             .instance()
             .set(&DataKey::BeneficiaryTransferCount(escrow_id), &(count + 1));
@@ -4527,10 +4724,7 @@ impl EscrowContract {
         Ok(())
     }
 
-    pub fn get_multi_party_dispute(
-        env: Env,
-        escrow_id: u64,
-    ) -> Result<MultiPartyDispute, Error> {
+    pub fn get_multi_party_dispute(env: Env, escrow_id: u64) -> Result<MultiPartyDispute, Error> {
         env.storage()
             .instance()
             .get(&DataKey::MultiPartyDisputeKey(escrow_id))
@@ -4539,7 +4733,11 @@ impl EscrowContract {
 
     // ── BATCH ESCROW CREATION ─────────────────────────────────────────────
 
-    pub fn create_escrow_batch(env: Env, admin: Address, entries: Vec<EscrowBatchEntry>) -> Vec<BatchEscrowResult> {
+    pub fn create_escrow_batch(
+        env: Env,
+        admin: Address,
+        entries: Vec<EscrowBatchEntry>,
+    ) -> Vec<BatchEscrowResult> {
         admin.require_auth();
         let config = Self::get_multisig_config(env.clone());
         if !config.admins.contains(&admin) {
@@ -4600,7 +4798,11 @@ impl EscrowContract {
         results
     }
 
-    fn try_create_single_escrow(env: &Env, entry: &EscrowBatchEntry, index: u32) -> Result<u64, u32> {
+    fn try_create_single_escrow(
+        env: &Env,
+        entry: &EscrowBatchEntry,
+        index: u32,
+    ) -> Result<u64, u32> {
         // Validate inputs similar to create_escrow
         if entry.amount <= 0 {
             return Err(Error::InvalidStatus as u32); // Using InvalidStatus as generic error
@@ -4620,7 +4822,11 @@ impl EscrowContract {
         let escrow_id = counter + 1;
 
         let fee_config = Self::get_escrow_fee_config(env.clone());
-        let fee_bps = if fee_config.enabled { fee_config.fee_bps } else { 0 };
+        let fee_bps = if fee_config.enabled {
+            fee_config.fee_bps
+        } else {
+            0
+        };
 
         let escrow = Escrow {
             id: escrow_id,
@@ -4635,7 +4841,7 @@ impl EscrowContract {
             last_activity_at: current_timestamp,
             escalation_level: 0,
             min_hold_period: 0, // Default for batch
-            fee_bps: 0, // Default fee
+            fee_bps: 0,         // Default fee
         };
 
         env.storage()
@@ -4726,9 +4932,7 @@ impl EscrowContract {
         if limit == 0 || limit > 1000 {
             return Err(Error::InvalidStatus); // Using InvalidStatus for invalid limit
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::BatchLimit, &limit);
+        env.storage().instance().set(&DataKey::BatchLimit, &limit);
         Ok(())
     }
 
@@ -4780,8 +4984,10 @@ impl EscrowAnalytics {
     }
 }
 
-
 mod test;
+
+#[cfg(test)]
+mod verification_test;
 
 #[cfg(test)]
 mod timelock_test;

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -2371,7 +2371,8 @@ fn test_multisig_resolve_dispute_via_proposal() {
 
 fn setup_token(env: &Env) -> Address {
     let token_admin = Address::generate(env);
-    env.register_stellar_asset_contract_v2(token_admin).address()
+    env.register_stellar_asset_contract_v2(token_admin)
+        .address()
 }
 
 #[test]
@@ -2395,8 +2396,14 @@ fn test_create_multi_token_escrow_success() {
     token_b_admin.mint(&customer, &500);
 
     let mut tokens = Vec::new(&env);
-    tokens.push_back(TokenEntry { token: token_a.clone(), amount: 1000 });
-    tokens.push_back(TokenEntry { token: token_b.clone(), amount: 500 });
+    tokens.push_back(TokenEntry {
+        token: token_a.clone(),
+        amount: 1000,
+    });
+    tokens.push_back(TokenEntry {
+        token: token_b.clone(),
+        amount: 500,
+    });
 
     let escrow_id = client.create_multi_token_escrow(&customer, &merchant, &tokens, &1000_u64);
 
@@ -2442,8 +2449,14 @@ fn test_create_multi_token_escrow_duplicate_token() {
     token_a_admin.mint(&customer, &2000);
 
     let mut tokens = Vec::new(&env);
-    tokens.push_back(TokenEntry { token: token_a.clone(), amount: 500 });
-    tokens.push_back(TokenEntry { token: token_a.clone(), amount: 500 });
+    tokens.push_back(TokenEntry {
+        token: token_a.clone(),
+        amount: 500,
+    });
+    tokens.push_back(TokenEntry {
+        token: token_a.clone(),
+        amount: 500,
+    });
 
     let result = client.try_create_multi_token_escrow(&customer, &merchant, &tokens, &1000_u64);
     assert_eq!(result, Err(Ok(Error::DuplicateToken)));
@@ -2464,7 +2477,10 @@ fn test_create_multi_token_escrow_too_many_tokens() {
         let tok = setup_token(&env);
         let admin = token::StellarAssetClient::new(&env, &tok);
         admin.mint(&customer, &10);
-        tokens.push_back(TokenEntry { token: tok, amount: 10 });
+        tokens.push_back(TokenEntry {
+            token: tok,
+            amount: 10,
+        });
     }
 
     let result = client.try_create_multi_token_escrow(&customer, &merchant, &tokens, &1000_u64);
@@ -2486,13 +2502,14 @@ fn test_insurance_system() {
     client.initialize(&admin);
 
     let config = InsuranceConfig {
-        premium_bps: 100, // 1%
+        premium_bps: 100,       // 1%
         max_coverage_bps: 5000, // 50%
         enabled: true,
     };
     client.set_insurance_config(&admin, &config);
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &10000_i128, &token, &2000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &10000_i128, &token, &2000_u64, &0_u64);
     client.opt_into_insurance(&escrow_id);
 
     let escrow = client.get_escrow(&escrow_id);
@@ -2502,12 +2519,12 @@ fn test_insurance_system() {
     assert_eq!(pool.balance, 100);
 
     client.refund_escrow(&customer, &escrow_id);
-    
+
     let claim_id = client.file_insurance_claim(&admin, &escrow_id, &100_i128);
     assert_eq!(claim_id, 1);
 
     client.approve_claim(&admin, &claim_id);
-    
+
     let final_pool = client.get_insurance_pool();
     assert_eq!(final_pool.balance, 0);
     assert_eq!(final_pool.total_claims_paid, 100);
@@ -2540,9 +2557,18 @@ fn test_timelock_execute_after_expiry_returns_error() {
     token_c_admin.mint(&customer, &250);
 
     let mut tokens = Vec::new(&env);
-    tokens.push_back(TokenEntry { token: token_a.clone(), amount: 1000 });
-    tokens.push_back(TokenEntry { token: token_b.clone(), amount: 500 });
-    tokens.push_back(TokenEntry { token: token_c.clone(), amount: 250 });
+    tokens.push_back(TokenEntry {
+        token: token_a.clone(),
+        amount: 1000,
+    });
+    tokens.push_back(TokenEntry {
+        token: token_b.clone(),
+        amount: 500,
+    });
+    tokens.push_back(TokenEntry {
+        token: token_c.clone(),
+        amount: 250,
+    });
 
     env.ledger().set_timestamp(500);
     let escrow_id = client.create_multi_token_escrow(&customer, &merchant, &tokens, &1000_u64);
@@ -2577,7 +2603,10 @@ fn test_release_multi_token_escrow_before_timestamp() {
     token_a_admin.mint(&customer, &100);
 
     let mut tokens = Vec::new(&env);
-    tokens.push_back(TokenEntry { token: token_a.clone(), amount: 100 });
+    tokens.push_back(TokenEntry {
+        token: token_a.clone(),
+        amount: 100,
+    });
 
     env.ledger().set_timestamp(500);
     let escrow_id = client.create_multi_token_escrow(&customer, &merchant, &tokens, &1000_u64);
@@ -2603,9 +2632,16 @@ fn test_release_multi_token_escrow_double_release() {
     client.initialize(&admin);
 
     // Set a short timelock (1 hour delay, 1 hour grace)
-    client.set_timelock_config(&admin, &TimeLockConfig { delay: 3600, grace_period: 3600 });
+    client.set_timelock_config(
+        &admin,
+        &TimeLockConfig {
+            delay: 3600,
+            grace_period: 3600,
+        },
+    );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &500_i128, &token, &9999_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &9999_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id);
 
     let action_id = client.queue_action(
@@ -2637,7 +2673,10 @@ fn test_timelock_execute_after_delay_succeeds() {
     token_a_admin.mint(&customer, &100);
 
     let mut tokens = Vec::new(&env);
-    tokens.push_back(TokenEntry { token: token_a.clone(), amount: 100 });
+    tokens.push_back(TokenEntry {
+        token: token_a.clone(),
+        amount: 100,
+    });
 
     env.ledger().set_timestamp(500);
     let escrow_id = client.create_multi_token_escrow(&customer, &merchant, &tokens, &1000_u64);
@@ -2670,11 +2709,17 @@ fn test_get_multi_token_escrow_not_found() {
     env.ledger().set_timestamp(1000);
     client.initialize(&admin);
 
-
     // Set a 1-hour timelock, 24-hour grace period
-    client.set_timelock_config(&admin, &TimeLockConfig { delay: 3600, grace_period: 86400 });
+    client.set_timelock_config(
+        &admin,
+        &TimeLockConfig {
+            delay: 3600,
+            grace_period: 86400,
+        },
+    );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &500_i128, &token, &9999_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &9999_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id);
 
     let action_id = client.queue_action(
@@ -2708,13 +2753,12 @@ fn test_single_token_escrow_still_works_after_multi_token_addition() {
 
     client.initialize(&admin);
     env.ledger().set_timestamp(500);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
     env.ledger().set_timestamp(1001);
     client.release_escrow(&admin, &escrow_id, &false);
 
-    let escrow = env.as_contract(&contract_id, || {
-        EscrowContract::get_escrow(&env, escrow_id)
-    });
+    let escrow = env.as_contract(&contract_id, || EscrowContract::get_escrow(&env, escrow_id));
     assert_eq!(escrow.status, EscrowStatus::Released);
 }
 
@@ -3354,20 +3398,24 @@ fn test_insurance_underfunded() {
     env.mock_all_auths();
     client.initialize(&admin);
 
-    client.set_insurance_config(&admin, &InsuranceConfig {
-        premium_bps: 10,
-        max_coverage_bps: 1000,
-        enabled: true,
-    });
+    client.set_insurance_config(
+        &admin,
+        &InsuranceConfig {
+            premium_bps: 10,
+            max_coverage_bps: 1000,
+            enabled: true,
+        },
+    );
 
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &2000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &2000_u64, &0_u64);
     client.opt_into_insurance(&escrow_id);
 
     client.refund_escrow(&customer, &escrow_id);
-    
+
     let claim_id = client.file_insurance_claim(&admin, &escrow_id, &50_i128);
     let result = client.try_approve_claim(&admin, &claim_id);
-    
+
     assert!(result.is_err());
 }
 
@@ -3412,21 +3460,25 @@ fn test_release_milestone_success() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     env.mock_all_auths();
-    
-    client.set_watchdog_config(&admin, &WatchdogConfig {
-        inactivity_release_seconds: 100,
-        enabled: true,
-        favor_customer_on_release: false, // releases to merchant
-    });
+
+    client.set_watchdog_config(
+        &admin,
+        &WatchdogConfig {
+            inactivity_release_seconds: 100,
+            enabled: true,
+            favor_customer_on_release: false, // releases to merchant
+        },
+    );
 
     env.ledger().set_timestamp(1000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1100_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1100_u64, &0_u64);
 
     // After release_timestamp (1100) + inactivity (100) = 1200
     env.ledger().set_timestamp(1201);
-    
+
     assert!(client.is_watchdog_eligible(&escrow_id));
     client.trigger_watchdog_release(&escrow_id);
 
@@ -3556,18 +3608,22 @@ fn test_release_unapproved_milestone_fails() {
     // Attempt release without approval
     env.ledger().set_timestamp(2500);
     let result = client.try_release_milestone(&escrow_id, &1_u64);
-    client.set_watchdog_config(&admin, &WatchdogConfig {
-        inactivity_release_seconds: 100,
-        enabled: true,
-        favor_customer_on_release: false,
-    });
+    client.set_watchdog_config(
+        &admin,
+        &WatchdogConfig {
+            inactivity_release_seconds: 100,
+            enabled: true,
+            favor_customer_on_release: false,
+        },
+    );
 
     env.ledger().set_timestamp(1000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1100_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1100_u64, &0_u64);
     client.dispute_escrow(&customer, &escrow_id);
 
     env.ledger().set_timestamp(1201);
-    
+
     assert!(!client.is_watchdog_eligible(&escrow_id));
     let result = client.try_trigger_watchdog_release(&escrow_id);
     assert!(result.is_err());
@@ -3607,18 +3663,22 @@ fn test_watchdog_premature_trigger() {
 
     // Duplicate release attempt must fail
     let result = client.try_release_milestone(&escrow_id, &1_u64);
-    client.set_watchdog_config(&admin, &WatchdogConfig {
-        inactivity_release_seconds: 1000,
-        enabled: true,
-        favor_customer_on_release: false,
-    });
+    client.set_watchdog_config(
+        &admin,
+        &WatchdogConfig {
+            inactivity_release_seconds: 1000,
+            enabled: true,
+            favor_customer_on_release: false,
+        },
+    );
 
     env.ledger().set_timestamp(1000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &2000_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &2000_u64, &0_u64);
 
     // Before inactivity window (2000 + 1000 = 3000)
     env.ledger().set_timestamp(2500);
-    
+
     assert!(!client.is_watchdog_eligible(&escrow_id));
     let result = client.try_trigger_watchdog_release(&escrow_id);
     assert!(result.is_err());
@@ -3819,17 +3879,21 @@ fn test_non_admin_cannot_approve_milestone() {
 
     let result = client.try_approve_milestone(&non_admin, &escrow_id, &1_u64);
     assert!(result.is_err());
-    client.set_watchdog_config(&admin, &WatchdogConfig {
-        inactivity_release_seconds: 100,
-        enabled: true,
-        favor_customer_on_release: true, // releases to customer
-    });
+    client.set_watchdog_config(
+        &admin,
+        &WatchdogConfig {
+            inactivity_release_seconds: 100,
+            enabled: true,
+            favor_customer_on_release: true, // releases to customer
+        },
+    );
 
     env.ledger().set_timestamp(1000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &1000_i128, &token, &1100_u64, &0_u64);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1100_u64, &0_u64);
 
     env.ledger().set_timestamp(1201);
-    
+
     client.trigger_watchdog_release(&escrow_id);
 
     let escrow = client.get_escrow(&escrow_id);
@@ -3846,14 +3910,16 @@ fn test_escrow_fee_deduction_and_withdrawal() {
     let admin = Address::generate(&env);
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    
+
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let token_asset_client = token::StellarAssetClient::new(&env, &token_id);
     let token_user_client = token::Client::new(&env, &token_id);
 
     client.initialize(&admin);
-    
+
     token_asset_client.mint(&contract_id, &10000);
 
     let config = EscrowFeeConfig {
@@ -3864,7 +3930,14 @@ fn test_escrow_fee_deduction_and_withdrawal() {
     client.set_escrow_fee_config(&admin, &config);
 
     env.ledger().set_timestamp(1000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &10000_i128, &token_id, &2000_u64, &0_u64);
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token_id,
+        &2000_u64,
+        &0_u64,
+    );
 
     env.ledger().set_timestamp(2500);
     client.release_escrow(&admin, &escrow_id, &false);
@@ -3876,7 +3949,7 @@ fn test_escrow_fee_deduction_and_withdrawal() {
 
     let external_wallet = Address::generate(&env);
     let withdrawn = client.withdraw_escrow_fees(&admin, &token_id, &external_wallet);
-    
+
     assert_eq!(withdrawn, 500);
     assert_eq!(client.get_accumulated_escrow_fees(&token_id), 0);
     assert_eq!(token_user_client.balance(&external_wallet), 500);
@@ -3892,21 +3965,34 @@ fn test_escrow_fee_zero_bps_path() {
     let admin = Address::generate(&env);
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    
+
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let token_asset_client = token::StellarAssetClient::new(&env, &token_id);
     let token_user_client = token::Client::new(&env, &token_id);
 
     client.initialize(&admin);
-    
+
     token_asset_client.mint(&contract_id, &10000);
 
-    let config = EscrowFeeConfig { fee_bps: 0, fee_recipient: contract_id.clone(), enabled: false };
+    let config = EscrowFeeConfig {
+        fee_bps: 0,
+        fee_recipient: contract_id.clone(),
+        enabled: false,
+    };
     client.set_escrow_fee_config(&admin, &config);
 
     env.ledger().set_timestamp(1000);
-    let escrow_id = client.create_escrow(&customer, &merchant, &10000_i128, &token_id, &2000_u64, &0_u64);
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token_id,
+        &2000_u64,
+        &0_u64,
+    );
 
     env.ledger().set_timestamp(2500);
     client.release_escrow(&admin, &escrow_id, &false);
@@ -3929,15 +4015,25 @@ fn test_fee_config_snapshot_isolation() {
 
     client.initialize(&admin);
 
-    let config_initial = EscrowFeeConfig { fee_bps: 0, fee_recipient: contract_id.clone(), enabled: false };
+    let config_initial = EscrowFeeConfig {
+        fee_bps: 0,
+        fee_recipient: contract_id.clone(),
+        enabled: false,
+    };
     client.set_escrow_fee_config(&admin, &config_initial);
 
-    let escrow_id_before = client.create_escrow(&customer, &merchant, &10000_i128, &token, &2000_u64, &0_u64);
+    let escrow_id_before =
+        client.create_escrow(&customer, &merchant, &10000_i128, &token, &2000_u64, &0_u64);
 
-    let config_new = EscrowFeeConfig { fee_bps: 1000, fee_recipient: contract_id.clone(), enabled: true };
+    let config_new = EscrowFeeConfig {
+        fee_bps: 1000,
+        fee_recipient: contract_id.clone(),
+        enabled: true,
+    };
     client.set_escrow_fee_config(&admin, &config_new);
 
-    let escrow_id_after = client.create_escrow(&customer, &merchant, &10000_i128, &token, &2000_u64, &0_u64);
+    let escrow_id_after =
+        client.create_escrow(&customer, &merchant, &10000_i128, &token, &2000_u64, &0_u64);
 
     let escrow_1 = client.get_escrow(&escrow_id_before);
     let escrow_2 = client.get_escrow(&escrow_id_after);
@@ -4068,8 +4164,14 @@ fn test_batch_escrow_creation_partial_failure() {
     assert_eq!(results.get(1).unwrap().escrow_id, 0);
     assert_eq!(results.get(2).unwrap().escrow_id, 0);
     assert_eq!(results.get(0).unwrap().error_code, 0);
-    assert_eq!(results.get(1).unwrap().error_code, Error::InvalidStatus as u32);
-    assert_eq!(results.get(2).unwrap().error_code, Error::ReleaseNotYetAvailable as u32);
+    assert_eq!(
+        results.get(1).unwrap().error_code,
+        Error::InvalidStatus as u32
+    );
+    assert_eq!(
+        results.get(2).unwrap().error_code,
+        Error::ReleaseNotYetAvailable as u32
+    );
 }
 
 #[test]
@@ -4113,7 +4215,10 @@ fn test_batch_escrow_creation_too_large() {
 
     assert_eq!(results.len(), 1);
     assert!(!results.get(0).unwrap().success);
-    assert_eq!(results.get(0).unwrap().error_code, Error::BatchTooLarge as u32);
+    assert_eq!(
+        results.get(0).unwrap().error_code,
+        Error::BatchTooLarge as u32
+    );
 }
 
 #[test]
@@ -4203,8 +4308,7 @@ fn test_dispute_recommendation_favors_merchant() {
     );
 
     // Seed reputations: merchant wins a dispute → merchant=8000, customer=2000.
-    let seed_id =
-        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let seed_id = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &seed_id);
     client.resolve_dispute(&admin, &seed_id, &true);
 
@@ -4244,8 +4348,7 @@ fn test_dispute_recommendation_favors_customer() {
     );
 
     // Seed reputations: customer wins → customer=8000, merchant=2000.
-    let seed_id =
-        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let seed_id = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&merchant, &seed_id);
     client.resolve_dispute(&admin, &seed_id, &false);
 
@@ -4308,8 +4411,7 @@ fn test_dispute_recommendation_does_not_enforce_resolution() {
     );
 
     // Seed: merchant=8000, customer=2000.
-    let seed_id =
-        client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
+    let seed_id = client.create_escrow(&customer, &merchant, &500_i128, &token, &5000_u64, &0_u64);
     client.dispute_escrow(&customer, &seed_id);
     client.resolve_dispute(&admin, &seed_id, &true);
 

--- a/contracts/escrow/src/timelock_test.rs
+++ b/contracts/escrow/src/timelock_test.rs
@@ -29,12 +29,7 @@ mod timelock_tests {
         let token = Address::generate(&env);
         client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
 
-        let action_id = client.queue_action(
-            &admin,
-            &escrow_id,
-            &action_type,
-            &data,
-        );
+        let action_id = client.queue_action(&admin, &escrow_id, &action_type, &data);
 
         assert_eq!(action_id, 1);
 
@@ -60,12 +55,7 @@ mod timelock_tests {
         client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
         client.dispute_escrow(&customer, &escrow_id);
 
-        let action_id = client.queue_action(
-            &admin,
-            &escrow_id,
-            &action_type,
-            &data,
-        );
+        let action_id = client.queue_action(&admin, &escrow_id, &action_type, &data);
 
         // Try to execute immediately - should fail
         let result = client.try_execute_queued_action(&action_id);
@@ -87,12 +77,7 @@ mod timelock_tests {
         let token = Address::generate(&env);
         client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
 
-        let action_id = client.queue_action(
-            &admin,
-            &escrow_id,
-            &action_type,
-            &data,
-        );
+        let action_id = client.queue_action(&admin, &escrow_id, &action_type, &data);
 
         client.cancel_queued_action(&admin, &action_id);
 
@@ -107,7 +92,7 @@ mod timelock_tests {
         let (client, admin) = setup_test(&env);
 
         let config = TimeLockConfig {
-            delay: 7200,      // 2 hours
+            delay: 7200,        // 2 hours
             grace_period: 3600, // 1 hour
         };
 
@@ -135,7 +120,7 @@ mod timelock_tests {
         assert_eq!(result, Err(Ok(Error::InvalidStatus)));
         // Test delay too long (more than 7 days)
         let config = TimeLockConfig {
-            delay: 700000,    // > 7 days
+            delay: 700000, // > 7 days
             grace_period: 3600,
         };
 
@@ -143,4 +128,3 @@ mod timelock_tests {
         assert_eq!(result, Err(Ok(Error::InvalidStatus)));
     }
 }
-

--- a/contracts/escrow/src/verification_test.rs
+++ b/contracts/escrow/src/verification_test.rs
@@ -1,0 +1,262 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+fn setup() -> (Env, EscrowContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+// ── is_escrow_released ────────────────────────────────────────────────────────
+
+#[test]
+fn test_is_escrow_released_false_on_locked_escrow() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+
+    assert!(!client.is_escrow_released(&escrow_id));
+}
+
+#[test]
+fn test_is_escrow_released_true_after_release() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(2000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
+    client.release_escrow(&admin, &escrow_id, &true);
+
+    assert!(client.is_escrow_released(&escrow_id));
+}
+
+#[test]
+fn test_is_escrow_released_false_for_nonexistent_id() {
+    let (_env, client) = setup();
+    assert!(!client.is_escrow_released(&9999_u64));
+}
+
+// ── is_escrow_disputed ────────────────────────────────────────────────────────
+
+#[test]
+fn test_is_escrow_disputed_false_on_locked_escrow() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+
+    assert!(!client.is_escrow_disputed(&escrow_id));
+}
+
+#[test]
+fn test_is_escrow_disputed_true_after_dispute() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+    client.dispute_escrow(&customer, &escrow_id);
+
+    assert!(client.is_escrow_disputed(&escrow_id));
+}
+
+#[test]
+fn test_is_escrow_disputed_false_for_nonexistent_id() {
+    let (_env, client) = setup();
+    assert!(!client.is_escrow_disputed(&9999_u64));
+}
+
+// ── get_escrow_status ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_escrow_status_locked() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+
+    assert_eq!(client.get_escrow_status(&escrow_id), EscrowStatus::Locked);
+}
+
+#[test]
+fn test_get_escrow_status_released() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(2000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64);
+    client.release_escrow(&admin, &escrow_id, &true);
+
+    assert_eq!(client.get_escrow_status(&escrow_id), EscrowStatus::Released);
+}
+
+#[test]
+fn test_get_escrow_status_disputed() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+    client.dispute_escrow(&customer, &escrow_id);
+
+    assert_eq!(client.get_escrow_status(&escrow_id), EscrowStatus::Disputed);
+}
+
+#[test]
+fn test_get_escrow_status_resolved() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+    client.dispute_escrow(&customer, &escrow_id);
+    // release_to_merchant=false → funds go to customer → status becomes Resolved
+    client.resolve_dispute(&admin, &escrow_id, &false);
+
+    assert_eq!(client.get_escrow_status(&escrow_id), EscrowStatus::Resolved);
+}
+
+#[test]
+fn test_get_escrow_status_nonexistent_returns_error() {
+    let (_env, client) = setup();
+    let result = client.try_get_escrow_status(&9999_u64);
+    assert_eq!(result, Err(Ok(Error::EscrowNotFound)));
+}
+
+// ── get_escrow_parties ────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_escrow_parties_returns_correct_addresses() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+
+    let (returned_customer, returned_merchant) = client.get_escrow_parties(&escrow_id);
+    assert_eq!(returned_customer, customer);
+    assert_eq!(returned_merchant, merchant);
+}
+
+#[test]
+fn test_get_escrow_parties_nonexistent_returns_error() {
+    let (_env, client) = setup();
+    let result = client.try_get_escrow_parties(&9999_u64);
+    assert_eq!(result, Err(Ok(Error::EscrowNotFound)));
+}
+
+// ── get_escrow_amount ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_escrow_amount_returns_correct_value() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &2500_i128, &token, &5000_u64, &0_u64);
+
+    assert_eq!(client.get_escrow_amount(&escrow_id), 2500_i128);
+}
+
+#[test]
+fn test_get_escrow_amount_nonexistent_returns_error() {
+    let (_env, client) = setup();
+    let result = client.try_get_escrow_amount(&9999_u64);
+    assert_eq!(result, Err(Ok(Error::EscrowNotFound)));
+}
+
+// ── verify_escrow_participant ─────────────────────────────────────────────────
+
+#[test]
+fn test_verify_escrow_participant_customer_returns_true() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+
+    assert!(client.verify_escrow_participant(&escrow_id, &customer));
+}
+
+#[test]
+fn test_verify_escrow_participant_merchant_returns_true() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+
+    assert!(client.verify_escrow_participant(&escrow_id, &merchant));
+}
+
+#[test]
+fn test_verify_escrow_participant_unrelated_address_returns_false() {
+    let (env, client) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let unrelated = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &1000_i128, &token, &5000_u64, &0_u64);
+
+    assert!(!client.verify_escrow_participant(&escrow_id, &unrelated));
+}
+
+#[test]
+fn test_verify_escrow_participant_nonexistent_id_returns_false() {
+    let (env, client) = setup();
+    let address = Address::generate(&env);
+    assert!(!client.verify_escrow_participant(&9999_u64, &address));
+}

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -586,7 +586,7 @@ pub struct MerchantFeeRecord {
 #[contracttype]
 pub struct FeeWaiver {
     pub merchant: Address,
-    pub waiver_bps: u32,         // reduction in basis points
+    pub waiver_bps: u32, // reduction in basis points
     pub valid_until: u64,
     pub reason: String,
     pub granted_by: Address,
@@ -781,8 +781,8 @@ pub struct PaymentMetadataUpdated {
 #[contracttype]
 pub struct PaymentMetadata {
     pub payment_id: u64,
-    pub content_ref: String,        // IPFS CID or similar
-    pub content_hash: BytesN<32>,   // SHA-256 of plaintext for verification
+    pub content_ref: String,      // IPFS CID or similar
+    pub content_hash: BytesN<32>, // SHA-256 of plaintext for verification
     pub encrypted: bool,
     pub updated_at: u64,
     pub version: u32,
@@ -1474,7 +1474,8 @@ impl PaymentContract {
             });
         c_analytics.total_payments += 1;
         c_analytics.total_volume += amount;
-        c_analytics.avg_transaction_size = c_analytics.total_volume / (c_analytics.total_payments as i128);
+        c_analytics.avg_transaction_size =
+            c_analytics.total_volume / (c_analytics.total_payments as i128);
         if c_analytics.first_payment_at == 0 {
             c_analytics.first_payment_at = current_timestamp;
         }
@@ -1495,9 +1496,14 @@ impl PaymentContract {
         let peak_hour_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::CustomerHourCount(payment.customer.clone(), c_analytics.peak_hour))
+            .get(&DataKey::CustomerHourCount(
+                payment.customer.clone(),
+                c_analytics.peak_hour,
+            ))
             .unwrap_or(0);
-        if hour_count > peak_hour_count || (hour_count == peak_hour_count && hour == c_analytics.peak_hour) {
+        if hour_count > peak_hour_count
+            || (hour_count == peak_hour_count && hour == c_analytics.peak_hour)
+        {
             c_analytics.peak_hour = hour;
         }
 
@@ -1505,7 +1511,10 @@ impl PaymentContract {
         let prev_merchant_vol: i128 = env
             .storage()
             .instance()
-            .get(&DataKey::CustomerMerchantVolume(payment.customer.clone(), payment.merchant.clone()))
+            .get(&DataKey::CustomerMerchantVolume(
+                payment.customer.clone(),
+                payment.merchant.clone(),
+            ))
             .unwrap_or(0);
         if prev_merchant_vol == 0 {
             // New merchant for this customer — add to list
@@ -1538,7 +1547,10 @@ impl PaymentContract {
         let prev_monthly: i128 = env
             .storage()
             .instance()
-            .get(&DataKey::CustomerMonthlyVolume(payment.customer.clone(), month_bucket))
+            .get(&DataKey::CustomerMonthlyVolume(
+                payment.customer.clone(),
+                month_bucket,
+            ))
             .unwrap_or(0);
         env.storage().instance().set(
             &DataKey::CustomerMonthlyVolume(payment.customer.clone(), month_bucket),
@@ -1582,10 +1594,7 @@ impl PaymentContract {
     /// Used by the refund contract for cross-contract ownership verification (#143).
     /// Returns true if the payment exists, belongs to `customer`, and is Completed.
     pub fn check_payment_customer(env: Env, payment_id: u64, customer: Address) -> bool {
-        let payment: Option<Payment> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Payment(payment_id));
+        let payment: Option<Payment> = env.storage().instance().get(&DataKey::Payment(payment_id));
         match payment {
             Some(p) => p.customer == customer && p.status == PaymentStatus::Completed,
             None => false,
@@ -1845,7 +1854,7 @@ impl PaymentContract {
         // Check if payment requires multi-sig approval
         let payment = PaymentContract::get_payment(&env, payment_id);
         let threshold = PaymentContract::get_large_payment_threshold(env.clone());
-        
+
         if threshold > 0 && payment.amount > threshold {
             // Check if there's already a proposal for this payment
             if env
@@ -1856,7 +1865,7 @@ impl PaymentContract {
             {
                 return Err(Error::PaymentRequiresMultiSig);
             }
-            
+
             // Auto-create proposal for large payment
             let now = env.ledger().timestamp();
             let expires_at = now + config.proposal_ttl;
@@ -3719,10 +3728,11 @@ impl PaymentContract {
             }
             Some(c) => c,
         };
-        
+
         // Get effective fee BPS including tier discounts and waivers
-        let effective_fee_bps = PaymentContract::get_effective_fee_bps(env.clone(), merchant.clone());
-        
+        let effective_fee_bps =
+            PaymentContract::get_effective_fee_bps(env.clone(), merchant.clone());
+
         PaymentContract::compute_fee_amount(
             amount,
             effective_fee_bps,
@@ -3759,7 +3769,8 @@ impl PaymentContract {
             return Err(Error::Unauthorized);
         }
 
-        let mut record = PaymentContract::get_or_default_merchant_fee_record(&env, merchant.clone());
+        let mut record =
+            PaymentContract::get_or_default_merchant_fee_record(&env, merchant.clone());
         record.fee_tier = tier;
         env.storage()
             .instance()
@@ -4058,7 +4069,8 @@ impl PaymentContract {
         // Automatic tier changes are monotonic upgrades only.
         let old_tier = record.fee_tier.clone();
         let computed_tier = PaymentContract::calculate_tier(env, record.total_volume);
-        if PaymentContract::tier_rank(&computed_tier) > PaymentContract::tier_rank(&record.fee_tier) {
+        if PaymentContract::tier_rank(&computed_tier) > PaymentContract::tier_rank(&record.fee_tier)
+        {
             record.fee_tier = computed_tier.clone();
             (MerchantTierUpgraded {
                 merchant: merchant.clone(),
@@ -4169,7 +4181,7 @@ impl PaymentContract {
                 env.storage()
                     .instance()
                     .remove(&DataKey::FeeWaiver(merchant.clone()));
-                
+
                 (FeeWaiverExpired { merchant }).publish(&env);
                 None
             } else {
@@ -4197,7 +4209,8 @@ impl PaymentContract {
         // Get waiver discount
         let waiver = PaymentContract::get_fee_waiver(env.clone(), merchant);
         if let Some(w) = waiver {
-            let waiver_adjusted_bps = tier_adjusted_bps - (tier_adjusted_bps * w.waiver_bps) / 10000;
+            let waiver_adjusted_bps =
+                tier_adjusted_bps - (tier_adjusted_bps * w.waiver_bps) / 10000;
             waiver_adjusted_bps
         } else {
             tier_adjusted_bps
@@ -4596,7 +4609,10 @@ impl PaymentContract {
                 let vol: i128 = env
                     .storage()
                     .instance()
-                    .get(&DataKey::CustomerMerchantVolume(customer.clone(), merchant.clone()))
+                    .get(&DataKey::CustomerMerchantVolume(
+                        customer.clone(),
+                        merchant.clone(),
+                    ))
                     .unwrap_or(0);
                 pairs.push_back((merchant, vol));
             }
@@ -4630,11 +4646,7 @@ impl PaymentContract {
         result
     }
 
-    pub fn get_customer_monthly_volume(
-        env: Env,
-        customer: Address,
-        month_timestamp: u64,
-    ) -> i128 {
+    pub fn get_customer_monthly_volume(env: Env, customer: Address, month_timestamp: u64) -> i128 {
         env.storage()
             .instance()
             .get(&DataKey::CustomerMonthlyVolume(customer, month_timestamp))
@@ -4653,14 +4665,9 @@ impl PaymentContract {
         let mut out = Vec::new(&env);
         let mut bucket_start = PaymentContract::hour_bucket_start(from);
         while bucket_start < to {
-            if let Some(bucket) = env
-                .storage()
-                .instance()
-                .get::<DataKey, AnalyticsBucket>(&DataKey::MerchantAnalyticsBucket(
-                    merchant.clone(),
-                    bucket_start,
-                ))
-            {
+            if let Some(bucket) = env.storage().instance().get::<DataKey, AnalyticsBucket>(
+                &DataKey::MerchantAnalyticsBucket(merchant.clone(), bucket_start),
+            ) {
                 out.push_back(bucket);
             }
             bucket_start += 3600;
@@ -4696,7 +4703,8 @@ impl PaymentContract {
                 .instance()
                 .get::<DataKey, Address>(&DataKey::GlobalMerchantList(i))
             {
-                let analytics = PaymentContract::get_merchant_analytics(env.clone(), merchant.clone());
+                let analytics =
+                    PaymentContract::get_merchant_analytics(env.clone(), merchant.clone());
                 pairs.push_back((merchant, analytics.total_volume));
             }
         }
@@ -4748,7 +4756,10 @@ impl PaymentContract {
         let mut bucket: AnalyticsBucket = env
             .storage()
             .instance()
-            .get(&DataKey::MerchantAnalyticsBucket(merchant.clone(), bucket_start))
+            .get(&DataKey::MerchantAnalyticsBucket(
+                merchant.clone(),
+                bucket_start,
+            ))
             .unwrap_or(AnalyticsBucket {
                 bucket_start,
                 bucket_end: bucket_start + 3600,
@@ -4761,9 +4772,10 @@ impl PaymentContract {
         bucket.total_volume += volume_delta;
         bucket.total_refunds += refund_delta;
         bucket.failed_count += failed_delta;
-        env.storage()
-            .instance()
-            .set(&DataKey::MerchantAnalyticsBucket(merchant, bucket_start), &bucket);
+        env.storage().instance().set(
+            &DataKey::MerchantAnalyticsBucket(merchant, bucket_start),
+            &bucket,
+        );
     }
 
     fn update_platform_daily_bucket(
@@ -5096,9 +5108,13 @@ impl PaymentContract {
 
     // ── LARGE PAYMENT MULTI-SIG FUNCTIONS ─────────────────────────────────────
 
-    pub fn set_large_payment_threshold(env: Env, admin: Address, threshold: i128) -> Result<(), Error> {
+    pub fn set_large_payment_threshold(
+        env: Env,
+        admin: Address,
+        threshold: i128,
+    ) -> Result<(), Error> {
         admin.require_auth();
-        
+
         let config: MultiSigConfig = env
             .storage()
             .instance()
@@ -5129,7 +5145,11 @@ impl PaymentContract {
             .unwrap_or(0) // Default threshold of 0 disables multi-sig requirement
     }
 
-    pub fn propose_large_payment(env: Env, merchant: Address, payment_id: u64) -> Result<(), Error> {
+    pub fn propose_large_payment(
+        env: Env,
+        merchant: Address,
+        payment_id: u64,
+    ) -> Result<(), Error> {
         merchant.require_auth();
 
         // Verify payment exists and belongs to merchant
@@ -5195,7 +5215,11 @@ impl PaymentContract {
         Ok(())
     }
 
-    pub fn approve_large_payment(env: Env, approver: Address, payment_id: u64) -> Result<(), Error> {
+    pub fn approve_large_payment(
+        env: Env,
+        approver: Address,
+        payment_id: u64,
+    ) -> Result<(), Error> {
         approver.require_auth();
 
         let config: MultiSigConfig = env
@@ -5281,7 +5305,7 @@ impl PaymentContract {
         // Execute the payment
         let token_client = token::Client::new(&env, &payment.token);
         let contract_address = env.current_contract_address();
-        
+
         token_client.transfer(&contract_address, &payment.merchant, &payment.amount);
 
         payment.status = PaymentStatus::Completed;
@@ -5429,6 +5453,9 @@ mod test_analytics;
 #[cfg(test)]
 mod test_trial;
 
+mod test_issue_113_115_119_120;
 #[cfg(test)]
 mod test_metadata;
-mod test_issue_113_115_119_120;
+
+#[cfg(test)]
+mod test_cross_contract_escrow_verification;

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -1,9 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::testutils::{ Events, Ledger };
-use soroban_sdk::{ testutils::Address as _, token, Address, Env };
-use escrow::{ EscrowContract, EscrowContractClient, EscrowStatus };
+use escrow::{EscrowContract, EscrowContractClient, EscrowStatus};
+use soroban_sdk::testutils::{Events, Ledger};
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
 
 // ── RATE LIMITING / ANTI-FRAUD TESTS ────────────────────────────────────────
 
@@ -34,17 +34,41 @@ fn test_rate_limit_window_resets_after_duration() {
             window_duration: 100,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Advance past the window; counter should reset.
     env.ledger().set_timestamp(1200);
     // This third payment would fail if the window hadn't reset.
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     let rl = client.get_address_rate_limit(&customer);
     assert_eq!(rl.payment_count, 1); // only 1 payment in the new window
@@ -69,13 +93,29 @@ fn test_rate_limit_exceeded_within_window() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
     // Second payment in the same window — must panic.
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 }
 
 #[test]
@@ -89,7 +129,11 @@ fn test_flag_address_blocks_payments() {
     let meta = String::from_str(&env, "");
 
     // Flag the customer.
-    client.flag_address(&admin, &customer, &String::from_str(&env, "velocity attack"));
+    client.flag_address(
+        &admin,
+        &customer,
+        &String::from_str(&env, "velocity attack"),
+    );
     let rl = client.get_address_rate_limit(&customer);
     assert!(rl.flagged);
     assert!(client.is_address_flagged(&customer));
@@ -102,7 +146,7 @@ fn test_flag_address_blocks_payments() {
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
     assert_eq!(result.unwrap_err().unwrap(), Error::AddressFlagged);
 }
@@ -124,7 +168,7 @@ fn test_unflag_address_allows_payments() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     client.flag_address(&admin, &customer, &String::from_str(&env, "test"));
@@ -135,7 +179,15 @@ fn test_unflag_address_allows_payments() {
     assert!(!client.is_address_flagged(&customer));
 
     // Payment must succeed after unflag.
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 }
 
 #[test]
@@ -148,11 +200,23 @@ fn test_allowlist_bypasses_flag_check() {
     let token = Address::generate(&env);
     let meta = String::from_str(&env, "");
 
-    client.flag_address(&admin, &customer, &String::from_str(&env, "sanctions review"));
+    client.flag_address(
+        &admin,
+        &customer,
+        &String::from_str(&env, "sanctions review"),
+    );
     client.add_to_allowlist(&admin, &customer);
 
     // Allowlisted addresses can still initiate new payments even when flagged.
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 }
 
 #[test]
@@ -189,11 +253,8 @@ fn test_flag_address_fails_if_already_flagged() {
     let customer = Address::generate(&env);
 
     client.flag_address(&admin, &customer, &String::from_str(&env, "first reason"));
-    let result = client.try_flag_address(
-        &admin,
-        &customer,
-        &String::from_str(&env, "second reason")
-    );
+    let result =
+        client.try_flag_address(&admin, &customer, &String::from_str(&env, "second reason"));
     assert_eq!(result.unwrap_err().unwrap(), Error::AddressAlreadyFlagged);
 }
 
@@ -211,7 +272,7 @@ fn test_flag_unflag_events_emitted() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     client.flag_address(&admin, &customer, &String::from_str(&env, "fraud"));
@@ -239,11 +300,19 @@ fn test_rate_limit_breach_event_emitted() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &50, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Second attempt should fail due to the per-window limit.
     let result = client.try_create_payment(
@@ -253,7 +322,7 @@ fn test_rate_limit_breach_event_emitted() {
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
     assert!(result.is_err());
 
@@ -280,11 +349,19 @@ fn test_amount_exceeds_limit() {
             window_duration: 100_000,
             max_payment_amount: 100,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     // Within limit — must succeed.
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Over limit — must fail.
     let result = client.try_create_payment(
@@ -294,7 +371,7 @@ fn test_amount_exceeds_limit() {
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
     assert!(result.is_err());
 }
@@ -317,28 +394,45 @@ fn test_daily_volume_limit() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 200,
-        })
+        }),
     );
 
     env.ledger().set_timestamp(1000);
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
-
-    // Third payment would exceed daily volume.
-    let result = client.try_create_payment(
+    client.create_payment(
         &customer,
         &merchant,
-        &1,
+        &100,
         &token,
         &Currency::USDC,
         &0,
-        &meta
+        &meta,
     );
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+
+    // Third payment would exceed daily volume.
+    let result =
+        client.try_create_payment(&customer, &merchant, &1, &token, &Currency::USDC, &0, &meta);
     assert!(result.is_err());
 
     // Advance a full day — daily volume resets.
     env.ledger().set_timestamp(1000 + 86400 + 1);
-    client.create_payment(&customer, &merchant, &100, &token, &Currency::USDC, &0, &meta);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 }
 
 #[test]
@@ -362,7 +456,7 @@ fn test_create_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
     assert_eq!(payment_id, 1);
 
@@ -397,7 +491,7 @@ fn test_get_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment = client.get_payment(&payment_id);
@@ -427,7 +521,9 @@ fn test_complete_payment_success() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -451,7 +547,7 @@ fn test_complete_payment_success() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -465,7 +561,9 @@ fn test_complete_payment_event_emission() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -489,7 +587,7 @@ fn test_complete_payment_event_emission() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -503,7 +601,10 @@ fn test_complete_payment_event_emission() {
             payment_event_count += 1;
         }
     }
-    assert_eq!(payment_event_count, 1, "PaymentCompleted must be emitted exactly once");
+    assert_eq!(
+        payment_event_count, 1,
+        "PaymentCompleted must be emitted exactly once"
+    );
 
     // PaymentCompleted is the last event emitted by complete_payment
     let last_event = all_events.last().unwrap();
@@ -533,7 +634,7 @@ fn test_refund_payment_success() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment
@@ -567,14 +668,18 @@ fn test_refund_payment_event_emission() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.refund_payment(&admin, &payment_id);
 
     // Verify PaymentRefunded event is emitted exactly once
     let events = env.events().all();
-    assert_eq!(events.len(), 1, "PaymentRefunded must be emitted exactly once");
+    assert_eq!(
+        events.len(),
+        1,
+        "PaymentRefunded must be emitted exactly once"
+    );
     let event = events.get(0).unwrap();
     assert_eq!(event.0, contract_id);
 }
@@ -635,7 +740,7 @@ fn test_complete_already_completed_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Complete the payment first time
@@ -669,7 +774,7 @@ fn test_refund_already_refunded_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment first time
@@ -703,7 +808,7 @@ fn test_complete_refunded_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment first
@@ -735,7 +840,7 @@ fn test_refund_completed_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Complete the payment first
@@ -751,7 +856,9 @@ fn test_multiple_payments_correct_modification() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -776,7 +883,7 @@ fn test_multiple_payments_correct_modification() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment_id2 = client.create_payment(
         &customer2,
@@ -785,7 +892,7 @@ fn test_multiple_payments_correct_modification() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id1);
@@ -817,7 +924,7 @@ fn test_customer_cancel_pending_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Customer cancels their pending payment
@@ -849,7 +956,7 @@ fn test_merchant_cancel_pending_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Merchant cancels the pending payment
@@ -898,7 +1005,7 @@ fn test_cancel_payment_unauthorized() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Try to cancel as unauthorized user
@@ -914,7 +1021,9 @@ fn test_cancel_completed_payment() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -938,7 +1047,7 @@ fn test_cancel_completed_payment() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -969,7 +1078,7 @@ fn test_cancel_refunded_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Refund the payment first
@@ -1001,7 +1110,7 @@ fn test_cancel_already_cancelled_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Cancel the payment first time
@@ -1033,14 +1142,18 @@ fn test_cancel_payment_event_emission() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.cancel_payment(&customer, &payment_id);
 
     // Verify PaymentCancelled event is emitted exactly once
     let events = env.events().all();
-    assert_eq!(events.len(), 1, "PaymentCancelled must be emitted exactly once");
+    assert_eq!(
+        events.len(),
+        1,
+        "PaymentCancelled must be emitted exactly once"
+    );
     let event = events.get(0).unwrap();
     assert_eq!(event.0, contract_id);
 }
@@ -1066,7 +1179,7 @@ fn test_cancel_multiple_payments_correct_modification() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment_id2 = client.create_payment(
         &customer2,
@@ -1075,7 +1188,7 @@ fn test_cancel_multiple_payments_correct_modification() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Cancel first payment
@@ -1110,7 +1223,7 @@ fn test_get_payments_by_customer_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer,
@@ -1119,7 +1232,7 @@ fn test_get_payments_by_customer_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id3 = client.create_payment(
         &customer,
@@ -1128,7 +1241,7 @@ fn test_get_payments_by_customer_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_customer(&customer, &10, &0);
@@ -1159,7 +1272,7 @@ fn test_get_payments_by_merchant_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer2,
@@ -1168,7 +1281,7 @@ fn test_get_payments_by_merchant_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id3 = client.create_payment(
         &customer1,
@@ -1177,7 +1290,7 @@ fn test_get_payments_by_merchant_multiple() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_merchant(&merchant, &10, &0);
@@ -1208,7 +1321,7 @@ fn test_customer_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_customer(&customer), 1);
 
@@ -1219,7 +1332,7 @@ fn test_customer_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_customer(&customer), 2);
 
@@ -1230,7 +1343,7 @@ fn test_customer_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_customer(&customer), 3);
 }
@@ -1256,7 +1369,7 @@ fn test_merchant_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_merchant(&merchant), 1);
 
@@ -1267,7 +1380,7 @@ fn test_merchant_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_merchant(&merchant), 2);
 
@@ -1278,7 +1391,7 @@ fn test_merchant_payment_count() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     assert_eq!(client.get_payment_count_by_merchant(&merchant), 3);
 }
@@ -1304,7 +1417,7 @@ fn test_pagination_first_page() {
             &token,
             &Currency::USDC,
             &0,
-            &String::from_str(&env, "")
+            &String::from_str(&env, ""),
         );
     }
 
@@ -1335,7 +1448,7 @@ fn test_pagination_second_page() {
             &token,
             &Currency::USDC,
             &0,
-            &String::from_str(&env, "")
+            &String::from_str(&env, ""),
         );
     }
 
@@ -1365,7 +1478,7 @@ fn test_pagination_limit_larger_than_total() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1374,7 +1487,7 @@ fn test_pagination_limit_larger_than_total() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1383,7 +1496,7 @@ fn test_pagination_limit_larger_than_total() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_customer(&customer, &100, &0);
@@ -1410,7 +1523,7 @@ fn test_pagination_offset_beyond_available() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1419,7 +1532,7 @@ fn test_pagination_offset_beyond_available() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.create_payment(
         &customer,
@@ -1428,7 +1541,7 @@ fn test_pagination_offset_beyond_available() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments = client.get_payments_by_customer(&customer, &5, &10);
@@ -1486,7 +1599,7 @@ fn test_payments_not_mixed_between_customers() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer1,
@@ -1495,7 +1608,7 @@ fn test_payments_not_mixed_between_customers() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Create payments for customer2
@@ -1506,7 +1619,7 @@ fn test_payments_not_mixed_between_customers() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments1 = client.get_payments_by_customer(&customer1, &10, &0);
@@ -1540,7 +1653,7 @@ fn test_payments_not_mixed_between_merchants() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer,
@@ -1549,7 +1662,7 @@ fn test_payments_not_mixed_between_merchants() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     // Create payments for merchant2
@@ -1560,7 +1673,7 @@ fn test_payments_not_mixed_between_merchants() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payments1 = client.get_payments_by_merchant(&merchant1, &10, &0);
@@ -1597,7 +1710,7 @@ fn test_create_payment_with_expiration_duration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment = client.get_payment(&payment_id);
@@ -1625,7 +1738,7 @@ fn test_create_payment_no_expiration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment = client.get_payment(&payment_id);
@@ -1653,10 +1766,11 @@ fn test_is_payment_expired_true() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     assert!(client.is_payment_expired(&payment_id));
 }
@@ -1682,7 +1796,7 @@ fn test_is_payment_expired_false_not_yet() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 10);
@@ -1711,7 +1825,7 @@ fn test_is_payment_expired_false_no_expiration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 1000);
@@ -1751,10 +1865,11 @@ fn test_expire_pending_payment_success() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     let result = client.try_expire_payment(&payment_id);
     assert!(result.is_ok());
@@ -1797,7 +1912,7 @@ fn test_expire_payment_before_expiration() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 10);
@@ -1827,7 +1942,7 @@ fn test_expire_payment_no_expiration_set() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     env.ledger().set_timestamp(env.ledger().timestamp() + 1000);
 
@@ -1859,11 +1974,12 @@ fn test_expire_completed_payment() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 }
@@ -1893,11 +2009,12 @@ fn test_expire_refunded_payment() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.refund_payment(&admin, &payment_id);
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 }
@@ -1924,11 +2041,12 @@ fn test_expire_cancelled_payment() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.cancel_payment(&customer, &payment_id);
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 }
@@ -1954,11 +2072,12 @@ fn test_payment_expired_event_emitted() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let _expected_expires_at = env.ledger().timestamp() + expiration_duration;
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.expire_payment(&payment_id);
 
@@ -1989,7 +2108,7 @@ fn test_multiple_payments_different_expiration_times() {
         &token,
         &Currency::USDC,
         &10,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let initial_timestamp1 = env.ledger().timestamp();
 
@@ -2000,7 +2119,7 @@ fn test_multiple_payments_different_expiration_times() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment_id3 = client.create_payment(
@@ -2010,7 +2129,7 @@ fn test_multiple_payments_different_expiration_times() {
         &token,
         &Currency::USDC,
         &30,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let initial_timestamp3 = env.ledger().timestamp();
 
@@ -2058,10 +2177,11 @@ fn test_complete_expired_payment_fails() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.complete_payment(&admin, &payment_id);
 }
@@ -2091,10 +2211,11 @@ fn test_refund_expired_payment_fails() {
         &token,
         &Currency::USDC,
         &expiration_duration,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
-    env.ledger().set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + expiration_duration + 1);
 
     client.refund_payment(&admin, &payment_id);
 }
@@ -2106,7 +2227,9 @@ fn test_complete_payment_transfers_tokens_to_merchant() {
 
     // Register a real mock token contract
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2134,7 +2257,7 @@ fn test_complete_payment_transfers_tokens_to_merchant() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2150,7 +2273,9 @@ fn test_complete_payment_status_is_completed_after_transfer() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2174,7 +2299,7 @@ fn test_complete_payment_status_is_completed_after_transfer() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2190,7 +2315,9 @@ fn test_complete_payment_fails_without_allowance() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
 
     let contract_id = env.register(PaymentContract, ());
@@ -2213,7 +2340,7 @@ fn test_complete_payment_fails_without_allowance() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2226,7 +2353,9 @@ fn test_complete_payment_fails_insufficient_balance() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
     let contract_id = env.register(PaymentContract, ());
@@ -2249,7 +2378,7 @@ fn test_complete_payment_fails_insufficient_balance() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2261,7 +2390,9 @@ fn test_complete_payment_partial_allowance_with_exact_amount() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2286,7 +2417,7 @@ fn test_complete_payment_partial_allowance_with_exact_amount() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.complete_payment(&admin, &payment_id);
@@ -2318,7 +2449,7 @@ fn test_create_payment_with_metadata() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -2347,7 +2478,7 @@ fn test_create_payment_with_empty_metadata() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -2377,7 +2508,7 @@ fn test_create_payment_metadata_too_large() {
         &token,
         &Currency::USDC,
         &0,
-        &large_metadata
+        &large_metadata,
     );
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().unwrap(), Error::MetadataTooLarge);
@@ -2406,7 +2537,7 @@ fn test_create_payment_metadata_at_max_size() {
         &token,
         &Currency::USDC,
         &0,
-        &max_metadata
+        &max_metadata,
     );
 
     let payment = client.get_payment(&payment_id);
@@ -2434,7 +2565,7 @@ fn test_update_payment_notes_success() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Customer requested express delivery");
@@ -2466,7 +2597,7 @@ fn test_update_payment_notes_multiple_times() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes1 = String::from_str(&env, "First note");
@@ -2501,7 +2632,7 @@ fn test_update_payment_notes_unauthorized() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Unauthorized note");
@@ -2531,7 +2662,7 @@ fn test_update_payment_notes_customer_cannot_update() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Customer trying to add notes");
@@ -2577,7 +2708,7 @@ fn test_update_payment_notes_too_large() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     // Create notes larger than MAX_NOTES_SIZE (1024)
@@ -2608,7 +2739,7 @@ fn test_update_payment_notes_at_max_size() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     // Create notes exactly at MAX_NOTES_SIZE (1024)
@@ -2626,7 +2757,9 @@ fn test_metadata_persists_through_payment_lifecycle() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -2651,7 +2784,7 @@ fn test_metadata_persists_through_payment_lifecycle() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     // Add notes
@@ -2689,7 +2822,7 @@ fn test_metadata_included_in_query_responses() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata1
+        &metadata1,
     );
     let id2 = client.create_payment(
         &customer,
@@ -2698,7 +2831,7 @@ fn test_metadata_included_in_query_responses() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata2
+        &metadata2,
     );
 
     // Query by customer
@@ -2735,7 +2868,7 @@ fn test_notes_persist_after_cancellation() {
         &token,
         &Currency::USDC,
         &0,
-        &metadata
+        &metadata,
     );
 
     let notes = String::from_str(&env, "Customer requested cancellation");
@@ -2769,7 +2902,7 @@ fn test_create_payment_with_xlm_currency() {
         &token,
         &Currency::XLM,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::XLM);
@@ -2794,7 +2927,7 @@ fn test_create_payment_with_btc_currency() {
         &token,
         &Currency::BTC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::BTC);
@@ -2819,7 +2952,7 @@ fn test_create_payment_with_eth_currency() {
         &token,
         &Currency::ETH,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::ETH);
@@ -2844,7 +2977,7 @@ fn test_create_payment_with_usdt_currency() {
         &token,
         &Currency::USDT,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let payment = client.get_payment(&payment_id);
     assert_eq!(payment.currency, Currency::USDT);
@@ -2934,7 +3067,7 @@ fn test_multiple_currencies_in_payments() {
         &token,
         &Currency::XLM,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id2 = client.create_payment(
         &customer,
@@ -2943,7 +3076,7 @@ fn test_multiple_currencies_in_payments() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let id3 = client.create_payment(
         &customer,
@@ -2952,7 +3085,7 @@ fn test_multiple_currencies_in_payments() {
         &token,
         &Currency::BTC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let p1 = client.get_payment(&id1);
@@ -2989,7 +3122,7 @@ fn test_partial_refund_success() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &300);
@@ -3022,7 +3155,7 @@ fn test_multiple_partial_refunds() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &200);
@@ -3056,7 +3189,7 @@ fn test_partial_refund_becomes_full_refund() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &600);
@@ -3090,7 +3223,7 @@ fn test_partial_refund_exceeds_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let result = client.try_partial_refund(&admin, &payment_id, &1500);
@@ -3121,7 +3254,7 @@ fn test_partial_refund_cumulative_exceeds_payment() {
         &token,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     client.partial_refund(&admin, &payment_id, &700);
@@ -3133,7 +3266,7 @@ fn test_partial_refund_cumulative_exceeds_payment() {
 // ── DUNNING MANAGEMENT TESTS ─────────────────────────────────────────
 
 fn setup_dunning_contract(
-    env: &Env
+    env: &Env,
 ) -> (PaymentContractClient, Address, Address, Address, Address) {
     let contract_id = env.register(PaymentContract, ());
     let client = PaymentContractClient::new(env, &contract_id);
@@ -3151,7 +3284,7 @@ fn setup_dunning_contract(
         &(DunningConfig {
             initial_backoff_seconds: 3600, // 1 hour
             max_retries: 4,
-        })
+        }),
     );
 
     (client, admin, customer, merchant, token)
@@ -3328,8 +3461,7 @@ fn test_dunning_successful_retry_fires_dunning_resolved() {
     );
 
     // Start with no funds so first payment fails
-    let (sub_id, token_address) =
-        setup_failing_subscription(&env, &client, &customer, &merchant);
+    let (sub_id, token_address) = setup_failing_subscription(&env, &client, &customer, &merchant);
 
     env.ledger().set_timestamp(1000 + 86400 + 1);
     let _ = client.try_execute_recurring_payment(&sub_id);
@@ -3351,7 +3483,6 @@ fn test_dunning_successful_retry_fires_dunning_resolved() {
     let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.status, SubscriptionStatus::Active);
     assert_eq!(sub.retry_count, 0);
-
 }
 
 #[test]
@@ -3360,7 +3491,9 @@ fn test_create_escrowed_payment_locks_funds_in_escrow() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3388,7 +3521,7 @@ fn test_create_escrowed_payment_locks_funds_in_escrow() {
         &1000_u64,
         &0_u64,
         &String::from_str(&env, "bridge"),
-        &true
+        &true,
     );
 
     assert_eq!(ids.0, 1);
@@ -3409,7 +3542,9 @@ fn test_complete_escrowed_payment_releases_escrow_and_merchant_funds() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3439,7 +3574,7 @@ fn test_complete_escrowed_payment_releases_escrow_and_merchant_funds() {
         &1000_u64,
         &0_u64,
         &String::from_str(&env, "bridge"),
-        &true
+        &true,
     );
 
     payment_client.complete_escrowed_payment(&admin, &ids.0);
@@ -3458,7 +3593,9 @@ fn test_cancel_escrowed_payment_refunds_customer() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3486,7 +3623,7 @@ fn test_cancel_escrowed_payment_refunds_customer() {
         &1000_u64,
         &0_u64,
         &String::from_str(&env, "bridge"),
-        &true
+        &true,
     );
 
     payment_client.cancel_escrowed_payment(&customer, &ids.0);
@@ -3537,7 +3674,7 @@ fn test_payment_multisig_propose_complete_payment() {
         &token,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let mut data_bytes = [0u8; 8];
@@ -3718,7 +3855,7 @@ fn test_create_batch_payment_partial_failure() {
             window_duration: 100_000,
             max_payment_amount: 0,
             max_daily_volume: 0,
-        })
+        }),
     );
 
     let entries = soroban_sdk::vec![
@@ -3755,7 +3892,9 @@ fn test_complete_batch_payment_success() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_mint_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3779,7 +3918,7 @@ fn test_complete_batch_payment_success() {
         &token_contract_id,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let pid2 = client.create_payment(
         &customer,
@@ -3788,7 +3927,7 @@ fn test_complete_batch_payment_success() {
         &token_contract_id,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment_ids = soroban_sdk::vec![&env, pid1, pid2];
@@ -3805,7 +3944,9 @@ fn test_complete_batch_payment_partial_failure() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_mint_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -3826,7 +3967,7 @@ fn test_complete_batch_payment_partial_failure() {
         &token_contract_id,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     // Complete pid1 first so it's already processed
     client.complete_payment(&admin, &pid1);
@@ -3860,7 +4001,7 @@ fn test_cancel_batch_payment_success() {
         &token,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     let pid2 = client.create_payment(
         &customer,
@@ -3869,7 +4010,7 @@ fn test_cancel_batch_payment_success() {
         &token,
         &Currency::USDC,
         &0_u64,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     let payment_ids = soroban_sdk::vec![&env, pid1, pid2];
@@ -3898,15 +4039,18 @@ fn test_batch_payment_events_emitted() {
 
     client.initialize(&admin);
 
-    let entries = soroban_sdk::vec![&env, BatchPaymentEntry {
-        customer: customer.clone(),
-        merchant: merchant.clone(),
-        amount: 100_i128,
-        token: token.clone(),
-        currency: Currency::USDC,
-        expiration_duration: 0,
-        metadata: String::from_str(&env, "batch_event_test"),
-    }];
+    let entries = soroban_sdk::vec![
+        &env,
+        BatchPaymentEntry {
+            customer: customer.clone(),
+            merchant: merchant.clone(),
+            amount: 100_i128,
+            token: token.clone(),
+            currency: Currency::USDC,
+            expiration_duration: 0,
+            metadata: String::from_str(&env, "batch_event_test"),
+        }
+    ];
 
     let results = client.create_batch_payment(&entries);
     assert!(results.get(0).unwrap().success);
@@ -3920,10 +4064,18 @@ fn test_batch_payment_events_emitted() {
 // ── FEE MANAGEMENT TESTS ─────────────────────────────────────────────────────
 
 fn setup_fee_contract(
-    env: &Env
-) -> (PaymentContractClient<'_>, Address, Address, Address, Address) {
+    env: &Env,
+) -> (
+    PaymentContractClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let token_admin = Address::generate(env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
 
     let contract_id = env.register(PaymentContract, ());
     let client = PaymentContractClient::new(env, &contract_id);
@@ -3994,7 +4146,7 @@ fn test_fee_deducted_from_payment_amount() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4023,7 +4175,7 @@ fn test_fee_min_clamping() {
 
     let fee_config = FeeConfig {
         fee_bps: 10, // 0.10%: raw_fee = 100 * 10 / 10000 = 0
-        min_fee: 5, // clamped to 5
+        min_fee: 5,  // clamped to 5
         max_fee: 0,
         treasury: treasury.clone(),
         fee_token: token_contract_id.clone(),
@@ -4041,7 +4193,7 @@ fn test_fee_min_clamping() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4084,7 +4236,7 @@ fn test_fee_max_clamping() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4126,7 +4278,7 @@ fn test_merchant_tier_upgrade_to_premium() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4169,7 +4321,7 @@ fn test_merchant_tier_upgrade_to_enterprise() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4183,7 +4335,9 @@ fn test_auto_tier_upgrade_runs_on_complete_payment_even_without_fee_config() {
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_client = token::StellarAssetClient::new(&env, &token_contract_id);
     let token_user_client = token::Client::new(&env, &token_contract_id);
 
@@ -4207,7 +4361,7 @@ fn test_auto_tier_upgrade_runs_on_complete_payment_even_without_fee_config() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4227,14 +4381,17 @@ fn test_auto_tier_upgrade_never_downgrades() {
     let merchant = Address::generate(&env);
     let treasury = Address::generate(&env);
 
-    client.set_fee_config(&admin, &(FeeConfig {
-        fee_bps: 100,
-        min_fee: 0,
-        max_fee: 0,
-        treasury,
-        fee_token: token_contract_id.clone(),
-        active: true,
-    }));
+    client.set_fee_config(
+        &admin,
+        &(FeeConfig {
+            fee_bps: 100,
+            min_fee: 0,
+            max_fee: 0,
+            treasury,
+            fee_token: token_contract_id.clone(),
+            active: true,
+        }),
+    );
 
     // Lower initial thresholds so first completion reaches Enterprise quickly.
     client.set_tier_thresholds(
@@ -4256,7 +4413,7 @@ fn test_auto_tier_upgrade_never_downgrades() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &first);
     assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
@@ -4278,7 +4435,7 @@ fn test_auto_tier_upgrade_never_downgrades() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &second);
     assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
@@ -4304,7 +4461,7 @@ fn test_manual_override_allows_downgrade() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &first);
     assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
@@ -4320,7 +4477,7 @@ fn test_manual_override_allows_downgrade() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &second);
     assert_eq!(client.get_merchant_tier(&merchant), FeeTier::Enterprise);
@@ -4394,7 +4551,7 @@ fn test_tier_discount_reduces_fee() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &pid1);
 
@@ -4412,7 +4569,7 @@ fn test_tier_discount_reduces_fee() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &pid2);
 
@@ -4422,7 +4579,10 @@ fn test_tier_discount_reduces_fee() {
     assert_eq!(client.get_accumulated_fees(), total_fees);
 
     let merchant_balance = token_user_client.balance(&merchant);
-    assert_eq!(merchant_balance, vol_amount - fee1 + (amount2 - expected_fee2));
+    assert_eq!(
+        merchant_balance,
+        vol_amount - fee1 + (amount2 - expected_fee2)
+    );
 }
 
 #[test]
@@ -4458,7 +4618,7 @@ fn test_withdraw_fees_to_treasury() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4506,7 +4666,7 @@ fn test_withdraw_fees_only_to_treasury_address() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4549,7 +4709,7 @@ fn test_withdraw_fees_exceeds_accumulated_fails() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4591,7 +4751,7 @@ fn test_fee_not_collected_when_inactive() {
         &token_contract_id,
         &Currency::USDC,
         &0,
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
     client.complete_payment(&admin, &payment_id);
 
@@ -4668,7 +4828,7 @@ fn test_create_conditional_payment_timestamp_after() {
         &Currency::USDC,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     // Verify conditional payment was created
@@ -4708,7 +4868,7 @@ fn test_create_conditional_payment_timestamp_before() {
         &Currency::USDC,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     let conditional_payment = client.get_conditional_payment(&payment_id);
@@ -4732,7 +4892,7 @@ fn test_create_conditional_payment_oracle_price() {
         oracle,
         String::from_str(&env, "BTC"),
         50000,
-        PriceComparison::GreaterThan
+        PriceComparison::GreaterThan,
     );
 
     let payment_id = client.create_conditional_payment(
@@ -4743,7 +4903,7 @@ fn test_create_conditional_payment_oracle_price() {
         &Currency::BTC,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     let conditional_payment = client.get_conditional_payment(&payment_id);
@@ -4780,7 +4940,7 @@ fn test_create_conditional_payment_cross_contract_state() {
         &Currency::ETH,
         &0,
         &metadata,
-        &condition
+        &condition,
     );
 
     let conditional_payment = client.get_conditional_payment(&payment_id);
@@ -4816,7 +4976,7 @@ fn test_evaluate_condition_timestamp_after_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be true since 1000 > 500
@@ -4854,7 +5014,7 @@ fn test_evaluate_condition_timestamp_after_not_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be false since 1000 <= 2000
@@ -4888,7 +5048,7 @@ fn test_evaluate_condition_timestamp_before_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be true since 1000 < 2000
@@ -4922,7 +5082,7 @@ fn test_evaluate_condition_timestamp_before_not_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Evaluate condition - should be false since 2000 >= 1000
@@ -4949,7 +5109,7 @@ fn test_evaluate_condition_oracle_price_fails() {
         oracle,
         String::from_str(&env, "BTC"),
         50000,
-        PriceComparison::GreaterThan
+        PriceComparison::GreaterThan,
     );
 
     let payment_id = client.create_conditional_payment(
@@ -4960,7 +5120,7 @@ fn test_evaluate_condition_oracle_price_fails() {
         &Currency::BTC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Oracle conditions should fail with OracleCallFailed error
@@ -4990,7 +5150,7 @@ fn test_evaluate_condition_cross_contract_state_false() {
         &Currency::ETH,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Cross-contract invoke failures should return a typed error.
@@ -5019,7 +5179,7 @@ fn test_complete_conditional_payment_success() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Complete the conditional payment
@@ -5051,7 +5211,7 @@ fn test_complete_conditional_payment_condition_not_met() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Attempt to complete should fail with ConditionNotMet
@@ -5084,7 +5244,7 @@ fn test_complete_conditional_payment_expired() {
         &Currency::USDC,
         &100, // Expires at 1100
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Advance time past expiration
@@ -5117,7 +5277,7 @@ fn test_complete_conditional_payment_unauthorized() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // Attempt to complete with unauthorized user should fail
@@ -5157,7 +5317,7 @@ fn test_condition_evaluation_caching() {
         &Currency::USDC,
         &0,
         &String::from_str(&env, ""),
-        &condition
+        &condition,
     );
 
     // First evaluation
@@ -5188,7 +5348,7 @@ fn setup_fee_waiver_contract(env: &Env) -> (PaymentContractClient<'_>, Address, 
     let admin = Address::generate(env);
     env.mock_all_auths();
     client.initialize(&admin);
-    
+
     // Set up fee configuration
     let fee_config = FeeConfig {
         fee_bps: 200, // 2%
@@ -5199,7 +5359,7 @@ fn setup_fee_waiver_contract(env: &Env) -> (PaymentContractClient<'_>, Address, 
         active: true,
     };
     client.set_fee_config(&admin, &fee_config);
-    
+
     (client, admin, contract_id)
 }
 
@@ -5217,7 +5377,7 @@ fn test_grant_fee_waiver() {
     // Verify waiver was granted
     let waiver = client.get_fee_waiver(&merchant);
     assert!(waiver.is_some());
-    
+
     let waiver_data = waiver.unwrap();
     assert_eq!(waiver_data.merchant, merchant);
     assert_eq!(waiver_data.waiver_bps, 5000);
@@ -5227,7 +5387,8 @@ fn test_grant_fee_waiver() {
 
     // Verify event was published
     let events = env.events().all();
-    let waiver_events: Vec<_> = events.iter()
+    let waiver_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "FeeWaiverGranted")
         .collect();
     assert_eq!(waiver_events.len(), 1);
@@ -5235,7 +5396,9 @@ fn test_grant_fee_waiver() {
 
 // ── LARGE PAYMENT MULTI-SIG TESTS ───────────────────────────────────────────
 
-fn setup_large_payment_contract(env: &Env) -> (PaymentContractClient<'_>, Address, Address, Address) {
+fn setup_large_payment_contract(
+    env: &Env,
+) -> (PaymentContractClient<'_>, Address, Address, Address) {
     let contract_id = env.register(PaymentContract, ());
     let client = PaymentContractClient::new(env, &contract_id);
     let admin = Address::generate(env);
@@ -5254,7 +5417,7 @@ fn test_set_large_payment_threshold() {
 
     // Set threshold to 1000
     client.set_large_payment_threshold(&admin, &1000);
-    
+
     // Verify threshold is set
     assert_eq!(client.get_large_payment_threshold(), 1000);
 
@@ -5301,7 +5464,7 @@ fn test_revoke_fee_waiver() {
 
     // Grant waiver first
     client.grant_fee_waiver(&admin, &merchant, &5000, &1000000000, &reason);
-    
+
     // Verify waiver exists
     assert!(client.get_fee_waiver(&merchant).is_some());
 
@@ -5313,7 +5476,8 @@ fn test_revoke_fee_waiver() {
 
     // Verify event was published
     let events = env.events().all();
-    let revoke_events: Vec<_> = events.iter()
+    let revoke_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "FeeWaiverRevoked")
         .collect();
     assert_eq!(revoke_events.len(), 1);
@@ -5371,7 +5535,8 @@ fn test_expired_waiver_ignored() {
 
     // Verify expiration event was published
     let events = env.events().all();
-    let expire_events: Vec<_> = events.iter()
+    let expire_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "FeeWaiverExpired")
         .collect();
     assert_eq!(expire_events.len(), 1);
@@ -5496,7 +5661,7 @@ fn test_waiver_with_no_fee_config() {
 
     // Without fee config, effective fee should be 0
     assert_eq!(client.get_effective_fee_bps(&merchant), 0);
-    
+
     // Calculate fee should return 0
     assert_eq!(client.calculate_fee(&1000, &merchant), 0);
 }
@@ -5517,13 +5682,15 @@ fn test_fee_waiver_events() {
 
     // Check all events
     let events = env.events().all();
-    
-    let grant_events: Vec<_> = events.iter()
+
+    let grant_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "FeeWaiverGranted")
         .collect();
     assert_eq!(grant_events.len(), 1);
-    
-    let revoke_events: Vec<_> = events.iter()
+
+    let revoke_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "FeeWaiverRevoked")
         .collect();
     assert_eq!(revoke_events.len(), 1);
@@ -5554,7 +5721,15 @@ fn test_large_payment_auto_routes_through_multisig() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment (2000 > threshold)
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Attempting to complete payment should auto-create proposal and return error
     let result = client.try_complete_payment(&admin, &payment_id);
@@ -5584,7 +5759,15 @@ fn test_small_payment_completes_normally() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a small payment (500 < threshold)
-    let payment_id = client.create_payment(&customer, &merchant, &500, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &500,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Small payment should complete normally
     client.complete_payment(&admin, &payment_id);
@@ -5608,7 +5791,15 @@ fn test_threshold_zero_disables_multisig() {
     client.set_large_payment_threshold(&admin, &0);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &5000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &5000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Should complete normally even though amount is large
     client.complete_payment(&admin, &payment_id);
@@ -5632,7 +5823,15 @@ fn test_large_payment_approval_flow() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Manually propose large payment
     client.propose_large_payment(&merchant, &payment_id);
@@ -5677,7 +5876,15 @@ fn test_execute_large_payment_insufficient_approvals() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Propose large payment
     client.propose_large_payment(&merchant, &payment_id);
@@ -5701,7 +5908,15 @@ fn test_approve_large_payment_unauthorized() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Propose large payment
     client.propose_large_payment(&merchant, &payment_id);
@@ -5726,7 +5941,15 @@ fn test_approve_large_payment_already_approved() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Propose large payment
     client.propose_large_payment(&merchant, &payment_id);
@@ -5753,7 +5976,15 @@ fn test_execute_large_payment_expired() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Propose large payment
     client.propose_large_payment(&merchant, &payment_id);
@@ -5762,7 +5993,8 @@ fn test_execute_large_payment_expired() {
     client.approve_large_payment(&admin, &payment_id);
 
     // Advance time beyond proposal TTL (7 days)
-    env.ledger().set_timestamp(env.ledger().timestamp() + 604800 + 100);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 604800 + 100);
 
     // Try to execute expired proposal
     client.execute_large_payment(&payment_id);
@@ -5783,7 +6015,15 @@ fn test_propose_large_payment_not_merchant() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Someone other than merchant tries to propose
     let imposter = Address::generate(&env);
@@ -5805,7 +6045,15 @@ fn test_propose_large_payment_below_threshold() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a small payment (500 < threshold)
-    let payment_id = client.create_payment(&customer, &merchant, &500, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &500,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Should not be able to propose small payment
     client.propose_large_payment(&merchant, &payment_id);
@@ -5825,7 +6073,15 @@ fn test_large_payment_events() {
     client.set_large_payment_threshold(&admin, &1000);
 
     // Create a large payment
-    let payment_id = client.create_payment(&customer, &merchant, &2000, &token, &Currency::USDC, &0, &meta);
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &2000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
     // Propose large payment
     client.propose_large_payment(&merchant, &payment_id);
@@ -5838,29 +6094,33 @@ fn test_large_payment_events() {
 
     // Verify all events were published
     let events = env.events().all();
-    
-    // Should have events for: initialize, add_admin, update_required_signatures, 
-    // set_threshold, create_payment, propose_large_payment, approve_large_payment, 
+
+    // Should have events for: initialize, add_admin, update_required_signatures,
+    // set_threshold, create_payment, propose_large_payment, approve_large_payment,
     // payment_completed, large_payment_executed
     assert!(events.len() >= 9);
-    
+
     // Check specific events
-    let threshold_updated_events: Vec<_> = events.iter()
+    let threshold_updated_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "LargePaymentThresholdUpdated")
         .collect();
     assert_eq!(threshold_updated_events.len(), 1);
-    
-    let proposed_events: Vec<_> = events.iter()
+
+    let proposed_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "LargePaymentProposed")
         .collect();
     assert_eq!(proposed_events.len(), 1);
-    
-    let approved_events: Vec<_> = events.iter()
+
+    let approved_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "LargePaymentApproved")
         .collect();
     assert_eq!(approved_events.len(), 1);
-    
-    let executed_events: Vec<_> = events.iter()
+
+    let executed_events: Vec<_> = events
+        .iter()
         .filter(|e| e.topics[0] == "LargePaymentExecuted")
         .collect();
     assert_eq!(executed_events.len(), 1);

--- a/contracts/payment/src/test_cross_contract_escrow_verification.rs
+++ b/contracts/payment/src/test_cross_contract_escrow_verification.rs
@@ -1,0 +1,259 @@
+#![cfg(test)]
+
+use super::*;
+use escrow::{EscrowContract, EscrowContractClient, EscrowStatus};
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
+
+// Demonstrates that an external contract (Payment) can use the new escrow
+// state verification interface to inspect escrow state cross-contract.
+
+fn setup_env() -> (
+    Env,
+    PaymentContractClient<'static>,
+    EscrowContractClient<'static>,
+    Address, // customer
+    Address, // merchant
+    Address, // admin
+    Address, // token
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+
+    let payment_contract_id = env.register(PaymentContract, ());
+    let payment_client = PaymentContractClient::new(&env, &payment_contract_id);
+
+    let escrow_contract_id = env.register(EscrowContract, ());
+    let escrow_client = EscrowContractClient::new(&env, &escrow_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    payment_client.initialize(&admin);
+    token_admin_client.mint(&customer, &2000_i128);
+    token::Client::new(&env, &token_contract_id).approve(
+        &customer,
+        &payment_contract_id,
+        &2000_i128,
+        &100_000,
+    );
+
+    (
+        env,
+        payment_client,
+        escrow_client,
+        customer,
+        merchant,
+        admin,
+        token_contract_id,
+    )
+}
+
+fn create_escrowed_payment_ids(
+    env: &Env,
+    payment_client: &PaymentContractClient,
+    escrow_client: &EscrowContractClient,
+    customer: &Address,
+    merchant: &Address,
+    token: &Address,
+    amount: i128,
+) -> (u64, u64) {
+    let escrow_contract_id = escrow_client.address.clone();
+    payment_client.create_escrowed_payment(
+        customer,
+        merchant,
+        &amount,
+        token,
+        &Currency::USDC,
+        &escrow_contract_id,
+        &5000_u64,
+        &0_u64,
+        &String::from_str(env, "integration-test"),
+        &true,
+    )
+}
+
+// ── Cross-contract: is_escrow_released ────────────────────────────────────────
+
+#[test]
+fn test_cross_contract_is_escrow_released_false_while_locked() {
+    let (env, payment_client, escrow_client, customer, merchant, _admin, token) = setup_env();
+
+    let (_payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    // Escrow was just created — must not appear released yet.
+    assert!(!escrow_client.is_escrow_released(&escrow_id));
+}
+
+#[test]
+fn test_cross_contract_is_escrow_released_true_after_complete() {
+    let (env, payment_client, escrow_client, customer, merchant, admin, token) = setup_env();
+
+    let (payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    // Complete the payment, which releases the escrow.
+    payment_client.complete_escrowed_payment(&admin, &payment_id);
+
+    assert!(escrow_client.is_escrow_released(&escrow_id));
+}
+
+// ── Cross-contract: get_escrow_status ─────────────────────────────────────────
+
+#[test]
+fn test_cross_contract_get_escrow_status_locked_after_creation() {
+    let (env, payment_client, escrow_client, customer, merchant, _admin, token) = setup_env();
+
+    let (_payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    assert_eq!(
+        escrow_client.get_escrow_status(&escrow_id),
+        EscrowStatus::Locked
+    );
+}
+
+#[test]
+fn test_cross_contract_get_escrow_status_released_after_complete() {
+    let (env, payment_client, escrow_client, customer, merchant, admin, token) = setup_env();
+
+    let (payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    payment_client.complete_escrowed_payment(&admin, &payment_id);
+
+    assert_eq!(
+        escrow_client.get_escrow_status(&escrow_id),
+        EscrowStatus::Released
+    );
+}
+
+// ── Cross-contract: get_escrow_parties ───────────────────────────────────────
+
+#[test]
+fn test_cross_contract_get_escrow_parties_matches_payment_parties() {
+    let (env, payment_client, escrow_client, customer, merchant, _admin, token) = setup_env();
+
+    let (_payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    let (returned_customer, returned_merchant) = escrow_client.get_escrow_parties(&escrow_id);
+    assert_eq!(returned_customer, customer);
+    assert_eq!(returned_merchant, merchant);
+}
+
+// ── Cross-contract: get_escrow_amount ────────────────────────────────────────
+
+#[test]
+fn test_cross_contract_get_escrow_amount_matches_payment_amount() {
+    let (env, payment_client, escrow_client, customer, merchant, _admin, token) = setup_env();
+
+    let amount = 750_i128;
+    let (_payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        amount,
+    );
+
+    assert_eq!(escrow_client.get_escrow_amount(&escrow_id), amount);
+}
+
+// ── Cross-contract: verify_escrow_participant ─────────────────────────────────
+
+#[test]
+fn test_cross_contract_verify_customer_is_participant() {
+    let (env, payment_client, escrow_client, customer, merchant, _admin, token) = setup_env();
+
+    let (_payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    assert!(escrow_client.verify_escrow_participant(&escrow_id, &customer));
+}
+
+#[test]
+fn test_cross_contract_verify_merchant_is_participant() {
+    let (env, payment_client, escrow_client, customer, merchant, _admin, token) = setup_env();
+
+    let (_payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    assert!(escrow_client.verify_escrow_participant(&escrow_id, &merchant));
+}
+
+#[test]
+fn test_cross_contract_verify_unrelated_address_is_not_participant() {
+    let (env, payment_client, escrow_client, customer, merchant, _admin, token) = setup_env();
+
+    let (_payment_id, escrow_id) = create_escrowed_payment_ids(
+        &env,
+        &payment_client,
+        &escrow_client,
+        &customer,
+        &merchant,
+        &token,
+        500_i128,
+    );
+
+    let unrelated = Address::generate(&env);
+    assert!(!escrow_client.verify_escrow_participant(&escrow_id, &unrelated));
+}

--- a/contracts/payment/src/test_issue_113_115_119_120.rs
+++ b/contracts/payment/src/test_issue_113_115_119_120.rs
@@ -130,7 +130,9 @@ fn test_oracle_refresh_and_manual_fallback() {
     client
         .set_conversion_rate(&admin, &Currency::USDC, &1_0000000)
         .unwrap();
-    client.set_oracle_rate_config(&admin, &disabled_cfg).unwrap();
+    client
+        .set_oracle_rate_config(&admin, &disabled_cfg)
+        .unwrap();
     let fallback = client.refresh_conversion_rate(&Currency::USDC).unwrap();
     assert_eq!(fallback, 1_0000000);
 }
@@ -166,7 +168,8 @@ fn test_cross_contract_condition_success_and_failure() {
         .expect("idempotent re-execution should succeed");
 
     let bad_target = Address::generate(&env);
-    let bad_cond = ConditionType::CrossContractState(bad_target, BytesN::from_array(&env, &[9; 32]));
+    let bad_cond =
+        ConditionType::CrossContractState(bad_target, BytesN::from_array(&env, &[9; 32]));
     let payment_id2 = client
         .create_conditional_payment(
             &customer,
@@ -196,13 +199,29 @@ fn test_analytics_range_and_top_merchants() {
 
     env.ledger().set_timestamp(3_600);
     let p1 = client
-        .create_payment(&customer, &merchant_a, &1_000, &token, &Currency::USDC, &0, &meta)
+        .create_payment(
+            &customer,
+            &merchant_a,
+            &1_000,
+            &token,
+            &Currency::USDC,
+            &0,
+            &meta,
+        )
         .unwrap();
     let _ = client.cancel_payment(&customer, &p1);
 
     env.ledger().set_timestamp(7_200);
     let _ = client
-        .create_payment(&customer, &merchant_b, &5_000, &token, &Currency::USDC, &0, &meta)
+        .create_payment(
+            &customer,
+            &merchant_b,
+            &5_000,
+            &token,
+            &Currency::USDC,
+            &0,
+            &meta,
+        )
         .unwrap();
 
     let range = client

--- a/contracts/payment/src/test_metadata.rs
+++ b/contracts/payment/src/test_metadata.rs
@@ -1,12 +1,12 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{
-    testutils::Address as _,
-    token, Address, BytesN, Env, String,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env, String};
 
-fn create_token_contract<'a>(env: &Env, admin: &Address) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
+fn create_token_contract<'a>(
+    env: &Env,
+    admin: &Address,
+) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
     let contract = env.register_stellar_asset_contract_v2(admin.clone());
     let contract_address = contract.address();
     (
@@ -56,13 +56,7 @@ fn test_set_payment_metadata_by_merchant() {
     let content_ref = String::from_str(&env, "QmXYZ123...");
     let content_hash = BytesN::from_array(&env, &[1u8; 32]);
 
-    client.set_payment_metadata(
-        &merchant,
-        &payment_id,
-        &content_ref,
-        &content_hash,
-        &true,
-    );
+    client.set_payment_metadata(&merchant, &payment_id, &content_ref, &content_hash, &true);
 
     // Verify metadata was set
     let metadata = client.get_payment_metadata(&payment_id);
@@ -97,13 +91,7 @@ fn test_set_payment_metadata_by_customer() {
     let content_ref = String::from_str(&env, "QmABC456...");
     let content_hash = BytesN::from_array(&env, &[2u8; 32]);
 
-    client.set_payment_metadata(
-        &customer,
-        &payment_id,
-        &content_ref,
-        &content_hash,
-        &false,
-    );
+    client.set_payment_metadata(&customer, &payment_id, &content_ref, &content_hash, &false);
 
     // Verify metadata was set
     let metadata = client.get_payment_metadata(&payment_id);
@@ -134,13 +122,7 @@ fn test_set_payment_metadata_by_admin() {
     let content_ref = String::from_str(&env, "QmDEF789...");
     let content_hash = BytesN::from_array(&env, &[3u8; 32]);
 
-    client.set_payment_metadata(
-        &admin,
-        &payment_id,
-        &content_ref,
-        &content_hash,
-        &true,
-    );
+    client.set_payment_metadata(&admin, &payment_id, &content_ref, &content_hash, &true);
 
     // Verify metadata was set
     let metadata = client.get_payment_metadata(&payment_id);
@@ -197,13 +179,7 @@ fn test_set_payment_metadata_nonexistent_payment() {
     let content_ref = String::from_str(&env, "QmNONE...");
     let content_hash = BytesN::from_array(&env, &[5u8; 32]);
 
-    client.set_payment_metadata(
-        &merchant,
-        &999u64,
-        &content_ref,
-        &content_hash,
-        &true,
-    );
+    client.set_payment_metadata(&merchant, &999u64, &content_ref, &content_hash, &true);
 }
 
 #[test]
@@ -228,25 +204,13 @@ fn test_update_payment_metadata_keeps_original_hash() {
     let content_ref1 = String::from_str(&env, "QmVER1...");
     let original_hash = BytesN::from_array(&env, &[10u8; 32]);
 
-    client.set_payment_metadata(
-        &merchant,
-        &payment_id,
-        &content_ref1,
-        &original_hash,
-        &true,
-    );
+    client.set_payment_metadata(&merchant, &payment_id, &content_ref1, &original_hash, &true);
 
     // Update metadata with new content ref but different hash
     let content_ref2 = String::from_str(&env, "QmVER2...");
     let new_hash = BytesN::from_array(&env, &[20u8; 32]);
 
-    client.set_payment_metadata(
-        &merchant,
-        &payment_id,
-        &content_ref2,
-        &new_hash,
-        &true,
-    );
+    client.set_payment_metadata(&merchant, &payment_id, &content_ref2, &new_hash, &true);
 
     // Verify original hash is preserved
     let metadata = client.get_payment_metadata(&payment_id);
@@ -279,13 +243,7 @@ fn test_verify_metadata_integrity_success() {
     let content_ref = String::from_str(&env, "QmHASH...");
     let content_hash = BytesN::from_array(&env, &[42u8; 32]);
 
-    client.set_payment_metadata(
-        &merchant,
-        &payment_id,
-        &content_ref,
-        &content_hash,
-        &true,
-    );
+    client.set_payment_metadata(&merchant, &payment_id, &content_ref, &content_hash, &true);
 
     // Verify with correct hash
     let is_valid = client.verify_metadata_integrity(&payment_id, &content_hash);
@@ -314,13 +272,7 @@ fn test_verify_metadata_integrity_failure() {
     let content_ref = String::from_str(&env, "QmHASH...");
     let content_hash = BytesN::from_array(&env, &[42u8; 32]);
 
-    client.set_payment_metadata(
-        &merchant,
-        &payment_id,
-        &content_ref,
-        &content_hash,
-        &true,
-    );
+    client.set_payment_metadata(&merchant, &payment_id, &content_ref, &content_hash, &true);
 
     // Verify with incorrect hash
     let wrong_hash = BytesN::from_array(&env, &[99u8; 32]);

--- a/contracts/payment/src/test_trial.rs
+++ b/contracts/payment/src/test_trial.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
 
 fn setup(env: &Env) -> (PaymentContractClient, Address) {
     let id = env.register(PaymentContract, ());
@@ -12,11 +15,7 @@ fn setup(env: &Env) -> (PaymentContractClient, Address) {
     (client, admin)
 }
 
-fn make_sub(
-    client: &PaymentContractClient,
-    env: &Env,
-    trial_secs: u64,
-) -> u64 {
+fn make_sub(client: &PaymentContractClient, env: &Env, trial_secs: u64) -> u64 {
     let customer = Address::generate(env);
     let merchant = Address::generate(env);
     let token = Address::generate(env);
@@ -26,9 +25,9 @@ fn make_sub(
         &1000i128,
         &token,
         &Currency::USDC,
-        &3600u64,  // interval: 1 hour
-        &0u64,     // duration: indefinite
-        &3u64,     // max_retries
+        &3600u64, // interval: 1 hour
+        &0u64,    // duration: indefinite
+        &3u64,    // max_retries
         &String::from_str(env, ""),
         &trial_secs,
     )


### PR DESCRIPTION
closes #81 

Exposes six read-only functions on EscrowContract so external contracts can verify escrow state without relying on raw storage reads.

New functions:

is_escrow_released / is_escrow_disputed — lightweight bool predicates
get_escrow_status — returns current EscrowStatus or EscrowNotFound
get_escrow_parties — returns (customer, merchant) address pair
get_escrow_amount — returns the locked amount
verify_escrow_participant — checks if an address is the customer or merchant
Tests:

19 unit tests covering all 6 functions, all reachable status variants, both participant roles, and invalid escrow IDs
8 integration tests in the payment crate demonstrating cross-contract state inspection via EscrowContractClient
All functions are strictly read-only — no state mutations or token transfers.