### PR TITLE
feat(escrow): add cliff status query and enforce milestone cliff bounds

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -530,6 +530,16 @@ pub struct VestingSchedule {
     pub milestones: Vec<VestingMilestone>,
 }
 
+/// Snapshot of vesting cliff progress for a given escrow.
+#[derive(Clone)]
+#[contracttype]
+pub struct CliffStatus {
+    pub cliff_timestamp: u64,
+    pub cliff_passed: bool,
+    /// Seconds until the cliff is reached; `0` once `cliff_passed` is true.
+    pub seconds_remaining: u64,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum ActionType {
@@ -2640,7 +2650,8 @@ impl EscrowContract {
     /// * `token` - The token address for the payment
     /// * `cliff_timestamp` - Timestamp before which no vesting occurs
     /// * `end_timestamp` - Timestamp when vesting completes
-    /// * `milestones` - Optional vector of VestingMilestone for milestone-based vesting
+    /// * `milestones` - Optional vector of VestingMilestone for milestone-based vesting.
+    ///   Each milestone's `unlock_timestamp` must be `>= cliff_timestamp` and `<= end_timestamp`.
     ///
     /// # Returns
     /// The escrow ID for the created vesting schedule
@@ -2805,6 +2816,33 @@ impl EscrowContract {
             .instance()
             .get(&DataKey::VestingSchedule(escrow_id))
             .ok_or(Error::EscrowNotFound)
+    }
+
+    /// Returns cliff timing and whether the ledger time has reached the cliff.
+    ///
+    /// # Errors
+    /// * `EscrowNotFound` - No vesting schedule for this escrow
+    pub fn get_cliff_status(env: Env, escrow_id: u64) -> Result<CliffStatus, Error> {
+        let vesting_schedule = env
+            .storage()
+            .instance()
+            .get::<DataKey, VestingSchedule>(&DataKey::VestingSchedule(escrow_id))
+            .ok_or(Error::EscrowNotFound)?;
+
+        let now = env.ledger().timestamp();
+        let cliff_ts = vesting_schedule.cliff_timestamp;
+        let cliff_passed = now >= cliff_ts;
+        let seconds_remaining = if cliff_passed {
+            0_u64
+        } else {
+            cliff_ts.saturating_sub(now)
+        };
+
+        Ok(CliffStatus {
+            cliff_timestamp: cliff_ts,
+            cliff_passed,
+            seconds_remaining,
+        })
     }
 
     /// Calculates the total vested amount that has been unlocked based on the current timestamp.
@@ -3169,6 +3207,13 @@ impl EscrowContract {
 
         if existing_total.saturating_add(milestone.amount) > vesting_schedule.total_amount {
             return Err(Error::MilestoneOverflow);
+        }
+
+        if milestone.unlock_timestamp < vesting_schedule.cliff_timestamp {
+            return Err(Error::InvalidVestingSchedule);
+        }
+        if milestone.unlock_timestamp > vesting_schedule.end_timestamp {
+            return Err(Error::InvalidVestingSchedule);
         }
 
         // Auto-assign milestone_id if not provided

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1332,6 +1332,100 @@ fn test_create_vesting_escrow_invalid_milestone_sum() {
     );
 }
 
+#[test]
+fn test_create_vesting_escrow_rejects_milestone_unlock_before_cliff() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    // Cliff at 2000; first milestone unlocks at 1500 — invalid schedule
+    let milestones = vec![
+        &env,
+        VestingMilestone {
+            milestone_id: 1,
+            unlock_timestamp: 1500,
+            amount: 5000,
+            released: false,
+            description: String::from_str(&env, "Too early"),
+            approved_by: None,
+            approved_at: None,
+        },
+        VestingMilestone {
+            milestone_id: 2,
+            unlock_timestamp: 3000,
+            amount: 5000,
+            released: false,
+            description: String::from_str(&env, "Ok"),
+            approved_by: None,
+            approved_at: None,
+        },
+    ];
+
+    let result = client.try_create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &2000_u64,
+        &4000_u64,
+        &milestones,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidVestingSchedule)));
+}
+
+#[test]
+fn test_get_cliff_status_seconds_remaining_and_passed_flag() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    let milestones = Vec::new(&env);
+    let cliff_ts = 5000_u64;
+    let escrow_id = client.create_vesting_escrow(
+        &customer,
+        &merchant,
+        &10000_i128,
+        &token,
+        &cliff_ts,
+        &10_000_u64,
+        &milestones,
+    );
+
+    env.ledger().set_timestamp(2000);
+    let s = client.get_cliff_status(&escrow_id);
+    assert_eq!(s.cliff_timestamp, cliff_ts);
+    assert!(!s.cliff_passed);
+    assert_eq!(s.seconds_remaining, 3000);
+
+    env.ledger().set_timestamp(5000);
+    let s = client.get_cliff_status(&escrow_id);
+    assert!(s.cliff_passed);
+    assert_eq!(s.seconds_remaining, 0);
+
+    // Mid vesting window: linear schedule has releasable amount > 0
+    env.ledger().set_timestamp(7500);
+    let s = client.get_cliff_status(&escrow_id);
+    assert!(s.cliff_passed);
+    assert_eq!(s.seconds_remaining, 0);
+    let released = client.release_vested_amount(&admin, &escrow_id);
+    assert!(released > 0);
+}
+
 // ── MULTI-PARTY ESCROW TESTS ────────────────────────────────────────────────
 
 #[test]
@@ -1730,8 +1824,7 @@ fn test_release_vested_amount_milestone() {
 }
 
 #[test]
-#[should_panic]
-fn test_release_vested_amount_before_cliff() {
+fn test_release_vested_amount_before_cliff_returns_cliff_error() {
     let env = Env::default();
     env.ledger().set_timestamp(1000);
     let contract_id = env.register(EscrowContract, ());
@@ -1755,9 +1848,9 @@ fn test_release_vested_amount_before_cliff() {
         &milestones,
     );
 
-    // Try to release before cliff
     env.ledger().set_timestamp(1500);
-    client.release_vested_amount(&admin, &escrow_id);
+    let result = client.try_release_vested_amount(&admin, &escrow_id);
+    assert_eq!(result, Err(Ok(Error::CliffPeriodNotPassed)));
 }
 
 #[test]
@@ -3820,33 +3913,32 @@ fn test_add_milestone_success() {
     env.mock_all_auths();
     client.initialize(&admin);
 
-    // Create with milestones summing to 8000 (leaving 2000 headroom)
-    let milestones = vec![
-        &env,
-        VestingMilestone {
-            milestone_id: 1,
-            unlock_timestamp: 2000,
-            amount: 8000,
-            released: false,
-            description: String::from_str(&env, "Main deliverable"),
-            approved_by: None,
-            approved_at: None,
-        },
-    ];
+    // Time-linear shell (no milestones at create); amounts are added via add_milestone
+    let milestones = Vec::new(&env);
     let escrow_id = client.create_vesting_escrow(
         &customer,
         &merchant,
         &10000_i128,
         &token,
         &1500_u64,
-        &3000_u64,
+        &5000_u64,
         &milestones,
     );
 
-    // Add a new milestone for the remaining 2000
+    let first = VestingMilestone {
+        milestone_id: 1,
+        unlock_timestamp: 2000,
+        amount: 8000,
+        released: false,
+        description: String::from_str(&env, "Main deliverable"),
+        approved_by: None,
+        approved_at: None,
+    };
+    client.add_milestone(&admin, &escrow_id, &first);
+
     let new_milestone = VestingMilestone {
         milestone_id: 0, // auto-assigned
-        unlock_timestamp: 3000,
+        unlock_timestamp: 4500,
         amount: 2000,
         released: false,
         description: String::from_str(&env, "Bonus deliverable"),


### PR DESCRIPTION
## Summary
- Adds `CliffStatus` and `get_cliff_status` for vesting escrows.
- Enforces cliff/end bounds on `add_milestone` (aligned with `create_vesting_escrow` milestone rules).
- Extends tests for pre-cliff release, invalid pre-cliff milestones, cliff status, and post-cliff release; repairs `test_add_milestone_success` to match the contract’s requirement that milestone amounts sum to the total at create (or use a linear shell + `add_milestone`).

## Implementation Notes
- `contracts/escrow/src/lib.rs` — `CliffStatus`, `get_cliff_status`, `add_milestone` validation
- `contracts/escrow/src/test.rs` — new cases + `test_add_milestone_success` fix

## Validation
- `cargo test -p escrow <vesting-related filters>` — pass (new/updated tests)
- `cargo test -p escrow` — 13 failures remain (reproducible on `upstream/main` before this PR; not introduced here)
- Merge dry-run against `upstream/main` — **Automatic merge went well**

## Repro Steps for Maintainer
1. `cargo test -p escrow test_get_cliff_status`
2. `cargo test -p escrow rejects_milestone`
3. `cargo test -p escrow test_add_milestone_success`

## Risks / Follow-ups
- Full `cargo test -p escrow` has 13 pre-existing failing tests; consider a separate issue/CI triage.

Closes #105