### PR TITLE
feat(payment): Implement rate limiting per merchant with configurable thresholds

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -25,6 +25,7 @@ pub enum DataKey {
     MerchantSubscriptionCount(Address),
     RateLimitConfig,
     AddressRateLimit(Address),
+    MerchantRateLimit(Address),
     AddressFlagReason(Address),
     AddressAllowlist(Address),
     DunningConfig,
@@ -199,6 +200,8 @@ pub enum Error {
     MetadataAlreadySet = 67,
     MetadataNotFound = 68,
     HashMismatch = 69,
+    MerchantRateLimitExceeded = 50,
+    AmountRateLimitExceeded = 51,
 }
 
 #[contractevent]
@@ -397,6 +400,17 @@ pub struct AddressRateLimit {
     pub daily_volume: i128,
     pub last_payment_at: u64,
     pub flagged: bool,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct MerchantRateLimit {
+    pub merchant: Address,
+    pub max_transactions_per_hour: u32,
+    pub max_amount_per_hour: i128,
+    pub current_transactions: u32,
+    pub current_amount: i128,
+    pub window_start: u64,
 }
 
 #[derive(Clone)]
@@ -1330,6 +1344,9 @@ impl PaymentContract {
 
         // Check rate limits and anti-fraud before processing
         PaymentContract::check_rate_limit(env, &customer, amount)?;
+
+        // Check merchant rate limits
+        PaymentContract::check_merchant_rate_limit(env, &merchant, amount)?;
 
         let counter: u64 = env
             .storage()
@@ -3556,6 +3573,136 @@ impl PaymentContract {
             .instance()
             .get(&DataKey::AddressAllowlist(address.clone()))
             .unwrap_or(false)
+    }
+
+    pub fn set_merchant_rate_limit(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+        config: MerchantRateLimit,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let ms_config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !ms_config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantRateLimit(merchant), &config);
+        Ok(())
+    }
+
+    pub fn get_merchant_rate_limit(env: Env, merchant: Address) -> Option<MerchantRateLimit> {
+        env.storage()
+            .instance()
+            .get(&DataKey::MerchantRateLimit(merchant))
+    }
+
+    pub fn reset_merchant_rate_limit(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let ms_config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !ms_config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .remove(&DataKey::MerchantRateLimit(merchant));
+        Ok(())
+    }
+
+    pub fn check_rate_limit(env: Env, merchant: Address, amount: i128) -> bool {
+        // Check merchant-specific limit first (read-only)
+        if let Some(limit) = env
+            .storage()
+            .instance()
+            .get(&DataKey::MerchantRateLimit(merchant.clone()))
+        {
+            let now = env.ledger().timestamp();
+            // Check if window needs reset (read-only)
+            let reset_needed = limit.window_start > 0 && now >= limit.window_start + 3600;
+            let current_transactions = if reset_needed { 0 } else { limit.current_transactions };
+            let current_amount = if reset_needed { 0 } else { limit.current_amount };
+            // Check limits
+            if current_transactions >= limit.max_transactions_per_hour {
+                return false;
+            }
+            if current_amount + amount > limit.max_amount_per_hour {
+                return false;
+            }
+            // Would pass
+            return true;
+        } else {
+            // Fallback to global config
+            let config: Option<RateLimitConfig> =
+                env.storage().instance().get(&DataKey::RateLimitConfig);
+            if let Some(config) = config {
+                // For merchants, use global as fallback, but since it's read-only, just check if amount exceeds
+                if config.max_payment_amount > 0 && amount > config.max_payment_amount {
+                    return false;
+                }
+                // For transactions, since no state, assume ok
+                return true;
+            } else {
+                // No limits
+                return true;
+            }
+        }
+    }
+
+    fn check_merchant_rate_limit(env: &Env, merchant: &Address, amount: i128) -> Result<(), Error> {
+        // If no merchant limit, use global as fallback, but enforce if set
+        if let Some(mut limit) = env
+            .storage()
+            .instance()
+            .get(&DataKey::MerchantRateLimit(merchant.clone()))
+        {
+            let now = env.ledger().timestamp();
+            // Reset window if 1 hour passed
+            if limit.window_start > 0 && now >= limit.window_start + 3600 {
+                limit.current_transactions = 0;
+                limit.current_amount = 0;
+                limit.window_start = now;
+            } else if limit.window_start == 0 {
+                limit.window_start = now;
+            }
+            // Check limits
+            if limit.current_transactions >= limit.max_transactions_per_hour {
+                return Err(Error::MerchantRateLimitExceeded);
+            }
+            if limit.current_amount + amount > limit.max_amount_per_hour {
+                return Err(Error::AmountRateLimitExceeded);
+            }
+            // Update counters
+            limit.current_transactions += 1;
+            limit.current_amount += amount;
+            env.storage()
+                .instance()
+                .set(&DataKey::MerchantRateLimit(merchant.clone()), &limit);
+        } else {
+            // Fallback to global config for merchants
+            let config: Option<RateLimitConfig> =
+                env.storage().instance().get(&DataKey::RateLimitConfig);
+            if let Some(config) = config {
+                // For merchants, enforce global amount limit if set
+                if config.max_payment_amount > 0 && amount > config.max_payment_amount {
+                    return Err(Error::AmountExceedsLimit);
+                }
+                // No transaction limit for merchants in global
+            }
+        }
+        Ok(())
     }
 
     fn invoke_escrow_create(

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -3263,6 +3263,183 @@ fn test_partial_refund_cumulative_exceeds_payment() {
     assert_eq!(result.unwrap_err().unwrap(), Error::RefundExceedsPayment);
 }
 
+#[test]
+fn test_set_merchant_rate_limit() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let merchant = Address::generate(&env);
+    let limit = MerchantRateLimit {
+        merchant: merchant.clone(),
+        max_transactions_per_hour: 10,
+        max_amount_per_hour: 1000,
+        current_transactions: 0,
+        current_amount: 0,
+        window_start: 0,
+    };
+
+    client.set_merchant_rate_limit(&admin, &merchant, &limit);
+
+    let retrieved = client.get_merchant_rate_limit(&merchant);
+    assert!(retrieved.is_some());
+    assert_eq!(retrieved.unwrap().max_transactions_per_hour, 10);
+}
+
+#[test]
+fn test_merchant_rate_limit_enforcement() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = String::from_str(&env, "");
+
+    // Set merchant limit: 1 transaction per hour
+    let limit = MerchantRateLimit {
+        merchant: merchant.clone(),
+        max_transactions_per_hour: 1,
+        max_amount_per_hour: 1000,
+        current_transactions: 0,
+        current_amount: 0,
+        window_start: 0,
+    };
+    client.set_merchant_rate_limit(&admin, &merchant, &limit);
+
+    env.ledger().set_timestamp(1000);
+    // First payment should succeed
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+
+    // Second payment should fail
+    let result = client.try_create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), Error::MerchantRateLimitExceeded);
+}
+
+#[test]
+fn test_merchant_rate_limit_window_reset() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = String::from_str(&env, "");
+
+    // Set merchant limit: 1 transaction per hour
+    let limit = MerchantRateLimit {
+        merchant: merchant.clone(),
+        max_transactions_per_hour: 1,
+        max_amount_per_hour: 1000,
+        current_transactions: 0,
+        current_amount: 0,
+        window_start: 0,
+    };
+    client.set_merchant_rate_limit(&admin, &merchant, &limit);
+
+    env.ledger().set_timestamp(1000);
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+
+    // Advance time by 1 hour + 1 second
+    env.ledger().set_timestamp(1000 + 3600 + 1);
+
+    // Should succeed now
+    client.create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+}
+
+#[test]
+fn test_merchant_rate_limit_global_fallback() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = String::from_str(&env, "");
+
+    // Set global limit: max amount 50
+    client.set_rate_limit_config(
+        &admin,
+        &(RateLimitConfig {
+            max_payments_per_window: 0,
+            window_duration: 0,
+            max_payment_amount: 50,
+            max_daily_volume: 0,
+        }),
+    );
+
+    // No merchant limit set, should use global
+    let result = client.try_create_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), Error::AmountExceedsLimit);
+}
+
+#[test]
+fn test_check_rate_limit_read_only() {
+    let env = Env::default();
+    let (client, admin, _) = setup_rate_limit_contract(&env);
+
+    let merchant = Address::generate(&env);
+
+    // Set merchant limit
+    let limit = MerchantRateLimit {
+        merchant: merchant.clone(),
+        max_transactions_per_hour: 1,
+        max_amount_per_hour: 100,
+        current_transactions: 0,
+        current_amount: 0,
+        window_start: 0,
+    };
+    client.set_merchant_rate_limit(&admin, &merchant, &limit);
+
+    // Check should pass (read-only)
+    assert!(client.check_rate_limit(&merchant, &50));
+
+    // State should not change
+    let retrieved = client.get_merchant_rate_limit(&merchant);
+    assert_eq!(retrieved.unwrap().current_transactions, 0);
+}
+
 // ── DUNNING MANAGEMENT TESTS ─────────────────────────────────────────
 
 fn setup_dunning_contract(

--- a/description.md
+++ b/description.md
@@ -1,0 +1,3 @@
+Implement rate limiting per merchant with configurable thresholds.
+
+Issue: 110

--- a/description.md
+++ b/description.md
@@ -1,3 +1,10 @@
 Implement rate limiting per merchant with configurable thresholds.
 
+This change introduces merchant-specific rate limiting support in the payment contract. It adds a new `MerchantRateLimit` struct and management functions for setting, querying, and resetting merchant limits. Merchants with custom limits will be evaluated against their own thresholds, while merchants without a custom configuration will continue to use the global `RateLimitConfig`.
+
+Key behaviors:
+- Merchant limits override global limits when configured.
+- The rate limit window resets automatically after one hour.
+- `check_rate_limit()` can preview whether a merchant and amount would exceed limits without consuming the allowance.
+
 Issue: 110


### PR DESCRIPTION
This PR implements merchant-specific rate limiting for issue #110.

## Changes
- Added  struct with configurable transaction and amount limits per hour
- Added admin functions: , , 
- Added  read-only preview function for checking limits without consumption
- Added new errors:  and 
- Integrated merchant limit enforcement in payment creation with automatic 1-hour window reset
- Falls back to global  when no merchant-specific limit is set
- Added comprehensive tests covering limit enforcement, window reset, and global fallback behavior

## Key Features
- Per-merchant limits override global limits when configured
- Automatic rate limit window reset after 1 hour
- Read-only preview via  without consuming limits
- Seamless fallback to global configuration for merchants without custom limits

closes #110