### PR TITLE
Implement subscription pause proration and duration adjustment #123

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -113,6 +113,22 @@ pub enum PriceComparison {
     EqualTo,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct SubscriptionTrialData {
+    pub period_seconds: u64,
+    pub ends_at: u64,
+    pub converted: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct SubscriptionPauseData {
+    pub last_paused_at: u64,
+    pub total_pause_duration: u64,
+    pub proration_enabled: bool,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub struct Subscription {
@@ -132,9 +148,8 @@ pub struct Subscription {
     pub retry_count: u64,   // consecutive failed attempts on current cycle
     pub max_retries: u64,   // max retries before marking failed cycle skipped
     pub metadata: String,
-    pub trial_period_seconds: u64, // 0 = no trial
-    pub trial_ends_at: u64,        // 0 = no trial
-    pub converted: bool,           // true after first post-trial charge
+    pub trial_data: SubscriptionTrialData,
+    pub pause_data: SubscriptionPauseData,
 }
 
 #[contracterror]
@@ -307,6 +322,15 @@ pub struct SubscriptionPaused {
 pub struct SubscriptionResumed {
     pub subscription_id: u64,
     pub next_payment_at: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscriptionResumedWithProration {
+    pub subscription_id: u64,
+    pub pause_duration: u64,
+    pub new_next_billing_date: u64,
+    pub prorated_amount: i128,
 }
 
 #[contractevent]
@@ -2534,9 +2558,16 @@ impl PaymentContract {
             retry_count: 0,
             max_retries: retries,
             metadata,
-            trial_period_seconds,
-            trial_ends_at,
-            converted: false,
+            trial_data: SubscriptionTrialData {
+                period_seconds: trial_period_seconds,
+                ends_at: trial_ends_at,
+                converted: false,
+            },
+            pause_data: SubscriptionPauseData {
+                last_paused_at: 0,
+                total_pause_duration: 0,
+                proration_enabled: false,
+            },
         };
 
         env.storage()
@@ -2586,10 +2617,10 @@ impl PaymentContract {
         .publish(&env);
 
         // Emit TrialStarted if trial is active
-        if sub.trial_ends_at > 0 {
+        if sub.trial_data.ends_at > 0 {
             (TrialStarted {
                 subscription_id: sub_id,
-                trial_ends_at: sub.trial_ends_at,
+                trial_ends_at: sub.trial_data.ends_at,
             })
             .publish(&env);
         }
@@ -2725,7 +2756,7 @@ impl PaymentContract {
         }
 
         // Skip charge if still within trial period
-        if sub.trial_ends_at > 0 && now < sub.trial_ends_at {
+        if sub.trial_data.ends_at > 0 && now < sub.trial_data.ends_at {
             sub.next_payment_at = now + sub.interval;
             env.storage()
                 .instance()
@@ -2743,8 +2774,8 @@ impl PaymentContract {
 
         if transfer_ok {
             // Mark converted on first post-trial charge
-            if sub.trial_ends_at > 0 && !sub.converted {
-                sub.converted = true;
+            if sub.trial_data.ends_at > 0 && !sub.trial_data.converted {
+                sub.trial_data.converted = true;
                 (TrialConverted {
                     subscription_id,
                     converted_at: now,
@@ -2836,7 +2867,7 @@ impl PaymentContract {
 
         // Emit TrialCancelled if cancelled during trial
         let now = env.ledger().timestamp();
-        if sub.trial_ends_at > 0 && now < sub.trial_ends_at {
+        if sub.trial_data.ends_at > 0 && now < sub.trial_data.ends_at {
             (TrialCancelled {
                 subscription_id,
                 cancelled_at: now,
@@ -2884,6 +2915,7 @@ impl PaymentContract {
         }
 
         sub.status = SubscriptionStatus::Paused;
+        sub.pause_data.last_paused_at = env.ledger().timestamp();
         env.storage()
             .instance()
             .set(&DataKey::Subscription(subscription_id), &sub);
@@ -2924,8 +2956,38 @@ impl PaymentContract {
         }
 
         let now = env.ledger().timestamp();
-        sub.next_payment_at = now + sub.interval;
+        let pause_duration = now - sub.pause_data.last_paused_at;
+        sub.pause_data.total_pause_duration += pause_duration;
+
+        // Shift next billing date by pause duration
+        sub.next_payment_at += pause_duration;
+
+        // Shift ends_at if it's a fixed-duration subscription
+        if sub.ends_at > 0 {
+            sub.ends_at += pause_duration;
+        }
+
         sub.status = SubscriptionStatus::Active;
+
+        if sub.pause_data.proration_enabled {
+            // Proration formula: (Full Amount * Remaining Time in Cycle) / Cycle Duration
+            let remaining_time = sub.next_payment_at - now;
+            let prorated_amount = (sub.amount * remaining_time as i128) / sub.interval as i128;
+
+            (SubscriptionResumedWithProration {
+                subscription_id,
+                pause_duration,
+                new_next_billing_date: sub.next_payment_at,
+                prorated_amount,
+            })
+            .publish(&env);
+        } else {
+            (SubscriptionResumed {
+                subscription_id,
+                next_payment_at: sub.next_payment_at,
+            })
+            .publish(&env);
+        }
 
         env.storage()
             .instance()
@@ -5442,6 +5504,41 @@ impl PaymentContract {
             Some(meta) => meta.content_hash == plaintext_hash,
             None => false,
         }
+    }
+
+    /// Toggle proration for a subscription. Only the customer can change this.
+    pub fn set_subscription_proration(
+        env: Env,
+        customer: Address,
+        subscription_id: u64,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        customer.require_auth();
+
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Subscription(subscription_id))
+        {
+            return Err(Error::SubscriptionNotFound);
+        }
+
+        let mut sub: Subscription = env
+            .storage()
+            .instance()
+            .get(&DataKey::Subscription(subscription_id))
+            .unwrap();
+
+        if sub.customer != customer {
+            return Err(Error::Unauthorized);
+        }
+
+        sub.pause_data.proration_enabled = enabled;
+        env.storage()
+            .instance()
+            .set(&DataKey::Subscription(subscription_id), &sub);
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Implement Subscription Pause Proration and Duration Adjustment

## Description
This PR implements the pause-and-resume system for subscriptions as requested in issue #123. It introduces a mechanism to track pause durations, adjust billing cycles automatically upon resumption, and optionally apply prorated billing.

## Key Changes
- **Structural Refactoring**: Grouped trial and pause metadata into nested structs (`SubscriptionTrialData` and `SubscriptionPauseData`) to optimize the `Subscription` struct and comply with Soroban's contract size limits.
- **Pause & Resume Logic**: 
    - `pause_subscription`: Now records the exact timestamp when a subscription is paused.
    - `resume_subscription`: Calculates total pause duration and shifts `next_payment_at` and `ends_at` forward, ensuring no service time is lost.
- **Proration System**: Added support for calculating a `prorated_amount` during resumption if enabled for the subscription.
- **Proration Management**: Added a new function `set_subscription_proration` to allow customers to toggle this feature.
- **New Event**: Implemented `SubscriptionResumedWithProration` to provide detailed transparency on resumption calculations.

## Related Issues
Closes #123

## Screenshots
<!-- Coloca aquí el screenshot de las líneas 2958-2989 de contracts/payment/src/lib.rs como evidencia de la lógica central -->
<img width="838" height="536" alt="image" src="https://github.com/user-attachments/assets/1480c7fb-5ae7-4586-8a51-fdd8f24f6311" />

