### PR TITLE
feat(payment): add escrowed payment dispute handling with arbitration

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -30,6 +30,7 @@ pub enum DataKey {
     DunningConfig,
     DunningState(u64),
     EscrowedPayment(u64),
+    EscrowedPaymentDispute(u64),
     ConditionalPayment(u64),
     MultiSigConfig,
     AdminProposal(String),
@@ -265,6 +266,20 @@ pub struct EscrowedPaymentCancelled {
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowedPaymentDisputed {
+    pub payment_id: u64,
+    pub raised_by: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowedPaymentDisputeResolved {
+    pub payment_id: u64,
+    pub favor_customer: bool,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SubscriptionCreated {
     pub subscription_id: u64,
     pub customer: Address,
@@ -441,6 +456,18 @@ pub struct EscrowedPayment {
     pub escrow_id: u64,
     pub escrow_contract: Address,
     pub auto_release_on_complete: bool,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct EscrowedPaymentDispute {
+    pub payment_id: u64,
+    pub raised_by: Address,
+    pub reason: String,
+    pub raised_at: u64,
+    pub resolved: bool,
+    pub resolved_at: Option<u64>,
+    pub favor_customer: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -1576,7 +1603,7 @@ impl PaymentContract {
         (PaymentCreated {
             payment_id,
             customer: payment.customer,
-            merchant: payment.merchant,
+            merchant: payment.merchant.clone(),
             amount: payment.amount,
         })
         .publish(&env);
@@ -1684,6 +1711,7 @@ impl PaymentContract {
         if payment.status != PaymentStatus::Pending {
             return Err(Error::InvalidStatus);
         }
+        PaymentContract::require_no_unresolved_escrowed_payment_dispute(&env, payment_id)?;
 
         let escrow_client = EscrowContractClient::new(&env, &bridge.escrow_contract);
         if escrow_client
@@ -1724,6 +1752,7 @@ impl PaymentContract {
         if payment.customer != caller && payment.merchant != caller {
             return Err(Error::Unauthorized);
         }
+        PaymentContract::require_no_unresolved_escrowed_payment_dispute(&env, payment_id)?;
 
         let escrow_client = EscrowContractClient::new(&env, &bridge.escrow_contract);
         if escrow_client
@@ -1746,11 +1775,157 @@ impl PaymentContract {
         Ok(())
     }
 
+    pub fn dispute_escrowed_payment(
+        env: Env,
+        caller: Address,
+        payment_id: u64,
+        reason: String,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        if !env.storage().instance().has(&DataKey::Payment(payment_id)) {
+            return Err(Error::PaymentNotFound);
+        }
+
+        let bridge = PaymentContract::get_escrowed_payment(env.clone(), payment_id)?;
+        let payment = PaymentContract::get_payment(&env, payment_id);
+        if payment.status != PaymentStatus::Pending {
+            return Err(Error::InvalidStatus);
+        }
+        if payment.customer != caller && payment.merchant != caller {
+            return Err(Error::Unauthorized);
+        }
+        if let Some(dispute) =
+            PaymentContract::get_escrowed_payment_dispute(env.clone(), payment_id)
+        {
+            if !dispute.resolved {
+                return Err(Error::AlreadyProcessed);
+            }
+        }
+
+        let escrow_client = EscrowContractClient::new(&env, &bridge.escrow_contract);
+        if escrow_client
+            .try_dispute_escrow(&caller, &bridge.escrow_id)
+            .is_err()
+        {
+            return Err(Error::EscrowBridgeFailed);
+        }
+
+        let dispute = EscrowedPaymentDispute {
+            payment_id,
+            raised_by: caller.clone(),
+            reason,
+            raised_at: env.ledger().timestamp(),
+            resolved: false,
+            resolved_at: None,
+            favor_customer: None,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowedPaymentDispute(payment_id), &dispute);
+
+        (EscrowedPaymentDisputed {
+            payment_id,
+            raised_by: caller,
+        })
+        .publish(&env);
+        Ok(())
+    }
+
+    pub fn resolve_escrowed_payment_dispute(
+        env: Env,
+        admin: Address,
+        payment_id: u64,
+        favor_customer: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        if !env.storage().instance().has(&DataKey::Payment(payment_id)) {
+            return Err(Error::PaymentNotFound);
+        }
+
+        let bridge = PaymentContract::get_escrowed_payment(env.clone(), payment_id)?;
+        let mut dispute = PaymentContract::get_escrowed_payment_dispute(env.clone(), payment_id)
+            .ok_or(Error::InvalidStatus)?;
+        if dispute.resolved {
+            return Err(Error::AlreadyProcessed);
+        }
+
+        let mut payment = PaymentContract::get_payment(&env, payment_id);
+        if payment.status != PaymentStatus::Pending {
+            return Err(Error::InvalidStatus);
+        }
+
+        let release_to_merchant = !favor_customer;
+        let escrow_client = EscrowContractClient::new(&env, &bridge.escrow_contract);
+        if escrow_client
+            .try_resolve_dispute(&admin, &bridge.escrow_id, &release_to_merchant)
+            .is_err()
+        {
+            return Err(Error::EscrowBridgeFailed);
+        }
+
+        if favor_customer {
+            payment.status = PaymentStatus::Refunded;
+            payment.refunded_amount = payment.amount;
+        } else {
+            payment.status = PaymentStatus::Completed;
+        }
+        dispute.resolved = true;
+        dispute.resolved_at = Some(env.ledger().timestamp());
+        dispute.favor_customer = Some(favor_customer);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Payment(payment_id), &payment);
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowedPaymentDispute(payment_id), &dispute);
+
+        (EscrowedPaymentDisputeResolved {
+            payment_id,
+            favor_customer,
+        })
+        .publish(&env);
+        Ok(())
+    }
+
     pub fn get_escrowed_payment(env: Env, payment_id: u64) -> Result<EscrowedPayment, Error> {
         env.storage()
             .instance()
             .get(&DataKey::EscrowedPayment(payment_id))
             .ok_or(Error::EscrowMappingNotFound)
+    }
+
+    pub fn get_escrowed_payment_dispute(
+        env: Env,
+        payment_id: u64,
+    ) -> Option<EscrowedPaymentDispute> {
+        env.storage()
+            .instance()
+            .get(&DataKey::EscrowedPaymentDispute(payment_id))
+    }
+
+    fn require_no_unresolved_escrowed_payment_dispute(
+        env: &Env,
+        payment_id: u64,
+    ) -> Result<(), Error> {
+        if let Some(dispute) = env
+            .storage()
+            .instance()
+            .get::<DataKey, EscrowedPaymentDispute>(&DataKey::EscrowedPaymentDispute(payment_id))
+        {
+            if !dispute.resolved {
+                return Err(Error::InvalidStatus);
+            }
+        }
+        Ok(())
     }
 
     pub fn update_payment_notes(
@@ -1997,7 +2172,7 @@ impl PaymentContract {
         );
         (PaymentCompleted {
             payment_id,
-            merchant: payment.merchant,
+            merchant: payment.merchant.clone(),
             amount: payment.amount,
         })
         .publish(env);
@@ -5287,7 +5462,7 @@ impl PaymentContract {
             return Err(Error::PaymentProposalExpired);
         }
 
-        if proposal.approvals.len() < proposal.required as usize {
+        if proposal.approvals.len() < proposal.required {
             return Err(Error::InsufficientPaymentApprovals);
         }
 

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -3636,6 +3636,295 @@ fn test_cancel_escrowed_payment_refunds_customer() {
     assert_eq!(token_user_client.balance(&customer), amount);
 }
 
+#[test]
+fn test_dispute_escrowed_payment_by_customer_marks_escrow_disputed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let payment_contract_id = env.register(PaymentContract, ());
+    let payment_client = PaymentContractClient::new(&env, &payment_contract_id);
+    let escrow_contract_id = env.register(EscrowContract, ());
+    let escrow_client = EscrowContractClient::new(&env, &escrow_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let amount = 1_000_i128;
+
+    payment_client.initialize(&admin);
+    token_admin_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &payment_contract_id, &amount, &10_000);
+
+    let ids = payment_client.create_escrowed_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &escrow_contract_id,
+        &1000_u64,
+        &0_u64,
+        &String::from_str(&env, "bridge"),
+        &true,
+    );
+
+    env.ledger().set_timestamp(1234);
+    let reason = String::from_str(&env, "item not delivered");
+    payment_client.dispute_escrowed_payment(&customer, &ids.0, &reason);
+
+    let dispute = payment_client
+        .get_escrowed_payment_dispute(&ids.0)
+        .expect("dispute should exist");
+    assert_eq!(dispute.payment_id, ids.0);
+    assert_eq!(dispute.raised_by, customer);
+    assert_eq!(dispute.reason, reason);
+    assert_eq!(dispute.raised_at, 1234);
+    assert!(!dispute.resolved);
+    assert_eq!(dispute.resolved_at, None);
+    assert_eq!(dispute.favor_customer, None);
+
+    let escrow = escrow_client.get_escrow(&ids.1);
+    assert_eq!(escrow.status, EscrowStatus::Disputed);
+}
+
+#[test]
+fn test_dispute_escrowed_payment_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let payment_contract_id = env.register(PaymentContract, ());
+    let payment_client = PaymentContractClient::new(&env, &payment_contract_id);
+    let escrow_contract_id = env.register(EscrowContract, ());
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let amount = 1_000_i128;
+
+    payment_client.initialize(&admin);
+    token_admin_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &payment_contract_id, &amount, &10_000);
+
+    let ids = payment_client.create_escrowed_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &escrow_contract_id,
+        &1000_u64,
+        &0_u64,
+        &String::from_str(&env, "bridge"),
+        &true,
+    );
+
+    let result = payment_client.try_dispute_escrowed_payment(
+        &attacker,
+        &ids.0,
+        &String::from_str(&env, "unauthorized"),
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_disputed_escrowed_payment_cannot_be_completed_or_cancelled() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let payment_contract_id = env.register(PaymentContract, ());
+    let payment_client = PaymentContractClient::new(&env, &payment_contract_id);
+    let escrow_contract_id = env.register(EscrowContract, ());
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let amount = 1_000_i128;
+
+    payment_client.initialize(&admin);
+    token_admin_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &payment_contract_id, &amount, &10_000);
+
+    let ids = payment_client.create_escrowed_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &escrow_contract_id,
+        &1000_u64,
+        &0_u64,
+        &String::from_str(&env, "bridge"),
+        &true,
+    );
+
+    payment_client.dispute_escrowed_payment(
+        &customer,
+        &ids.0,
+        &String::from_str(&env, "hold funds"),
+    );
+
+    let complete_result = payment_client.try_complete_escrowed_payment(&admin, &ids.0);
+    assert_eq!(complete_result, Err(Ok(Error::InvalidStatus)));
+
+    let cancel_result = payment_client.try_cancel_escrowed_payment(&customer, &ids.0);
+    assert_eq!(cancel_result, Err(Ok(Error::InvalidStatus)));
+}
+
+#[test]
+fn test_resolve_escrowed_payment_dispute_in_favor_of_customer_refunds_customer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let payment_contract_id = env.register(PaymentContract, ());
+    let payment_client = PaymentContractClient::new(&env, &payment_contract_id);
+    let escrow_contract_id = env.register(EscrowContract, ());
+    let escrow_client = EscrowContractClient::new(&env, &escrow_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let amount = 1_000_i128;
+
+    payment_client.initialize(&admin);
+    token_admin_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &payment_contract_id, &amount, &10_000);
+
+    let ids = payment_client.create_escrowed_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &escrow_contract_id,
+        &1000_u64,
+        &0_u64,
+        &String::from_str(&env, "bridge"),
+        &true,
+    );
+
+    env.ledger().set_timestamp(1234);
+    payment_client.dispute_escrowed_payment(
+        &customer,
+        &ids.0,
+        &String::from_str(&env, "refund requested"),
+    );
+
+    env.ledger().set_timestamp(2345);
+    payment_client.resolve_escrowed_payment_dispute(&admin, &ids.0, &true);
+
+    let payment = payment_client.get_payment(&ids.0);
+    assert_eq!(payment.status, PaymentStatus::Refunded);
+    assert_eq!(payment.refunded_amount, amount);
+
+    let dispute = payment_client
+        .get_escrowed_payment_dispute(&ids.0)
+        .expect("dispute should exist");
+    assert!(dispute.resolved);
+    assert_eq!(dispute.resolved_at, Some(2345));
+    assert_eq!(dispute.favor_customer, Some(true));
+
+    let escrow = escrow_client.get_escrow(&ids.1);
+    assert_eq!(escrow.status, EscrowStatus::Resolved);
+    assert_eq!(token_user_client.balance(&customer), amount);
+    assert_eq!(token_user_client.balance(&merchant), 0);
+    assert_eq!(token_user_client.balance(&escrow_contract_id), 0);
+}
+
+#[test]
+fn test_resolve_escrowed_payment_dispute_in_favor_of_merchant_releases_merchant() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+    let token_user_client = token::Client::new(&env, &token_contract_id);
+
+    let payment_contract_id = env.register(PaymentContract, ());
+    let payment_client = PaymentContractClient::new(&env, &payment_contract_id);
+    let escrow_contract_id = env.register(EscrowContract, ());
+    let escrow_client = EscrowContractClient::new(&env, &escrow_contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let amount = 1_000_i128;
+
+    payment_client.initialize(&admin);
+    token_admin_client.mint(&customer, &amount);
+    token_user_client.approve(&customer, &payment_contract_id, &amount, &10_000);
+
+    let ids = payment_client.create_escrowed_payment(
+        &customer,
+        &merchant,
+        &amount,
+        &token_contract_id,
+        &Currency::USDC,
+        &escrow_contract_id,
+        &1000_u64,
+        &0_u64,
+        &String::from_str(&env, "bridge"),
+        &true,
+    );
+
+    env.ledger().set_timestamp(1234);
+    payment_client.dispute_escrowed_payment(
+        &merchant,
+        &ids.0,
+        &String::from_str(&env, "merchant evidence"),
+    );
+
+    env.ledger().set_timestamp(2345);
+    payment_client.resolve_escrowed_payment_dispute(&admin, &ids.0, &false);
+
+    let payment = payment_client.get_payment(&ids.0);
+    assert_eq!(payment.status, PaymentStatus::Completed);
+
+    let dispute = payment_client
+        .get_escrowed_payment_dispute(&ids.0)
+        .expect("dispute should exist");
+    assert!(dispute.resolved);
+    assert_eq!(dispute.resolved_at, Some(2345));
+    assert_eq!(dispute.favor_customer, Some(false));
+
+    let escrow = escrow_client.get_escrow(&ids.1);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(token_user_client.balance(&customer), 0);
+    assert_eq!(token_user_client.balance(&merchant), amount);
+    assert_eq!(token_user_client.balance(&escrow_contract_id), 0);
+}
+
 // ── MULTI-SIG ADMIN TESTS (PAYMENT CONTRACT) ─────────────────────────────────
 
 #[test]


### PR DESCRIPTION



---

## Summary
This PR closes the missing dispute path in `EscrowedPayment`. Previously, once a payment was completed it could not be contested on-chain. This change introduces a full dispute lifecycle — raising, freezing, and resolving disputed escrowed payments via admin arbitration — integrated with the existing `Escrow` contract dispute system.

Closes #121

---

## What changed

### New Functions

- **`dispute_escrowed_payment(env, caller, payment_id, reason)`**
  - Callable only by the customer or merchant on their own escrowed payment
  - Freezes the payment, blocking any further completion or cancellation until resolved
  - Emits `EscrowedPaymentDisputed { payment_id, raised_by }`

- **`resolve_escrowed_payment_dispute(env, admin, payment_id, favor_customer)`**
  - Admin-only resolution function
  - If `favor_customer = true` → refunds funds to the customer
  - If `favor_customer = false` → releases funds to the merchant
  - Emits `EscrowedPaymentDisputeResolved { payment_id, favor_customer }`

- **`get_escrowed_payment_dispute(env, payment_id)`**
  - Read-only query returning the current `EscrowedPaymentDispute` state for a given payment, or `None` if no dispute exists

### New Structure

```rust
#[contracttype]
pub struct EscrowedPaymentDispute {
    pub payment_id: u64,
    pub raised_by: Address,
    pub reason: String,
    pub raised_at: u64,
    pub resolved: bool,
    pub resolved_at: Option<u64>,
    pub favor_customer: Option<bool>,
}
```

### New Events

```rust
EscrowedPaymentDisputed { payment_id: u64, raised_by: Address }
EscrowedPaymentDisputeResolved { payment_id: u64, favor_customer: bool }
```

---

## How to verify

- Raise a dispute as the customer and assert:
  - `get_escrowed_payment_dispute` returns the dispute with `resolved: false`
  - `EscrowedPaymentDisputed` event is emitted with correct fields
- Attempt to complete or cancel the payment while disputed and assert it is blocked
- Attempt to raise a dispute as a third-party address and assert it is rejected
- Resolve in favor of the customer and assert the refund is issued and `resolved: true`
- Resolve in favor of the merchant and assert funds are released and `resolved: true`
- Assert `EscrowedPaymentDisputeResolved` is emitted correctly for both resolution outcomes

---

## Checklist
- [ ] Only customer or merchant can raise a dispute on their own payment
- [ ] Disputed payments are frozen — completion and cancellation blocked until resolved
- [ ] Admin-only resolution enforced
- [ ] Customer-favor resolution issues correct refund
- [ ] Merchant-favor resolution releases funds correctly
- [ ] `EscrowedPaymentDisputed` event emitted on raise
- [ ] `EscrowedPaymentDisputeResolved` event emitted on resolution
- [ ] `get_escrowed_payment_dispute` returns correct state
- [ ] Tests cover: dispute raise, completion block during dispute, customer-favor resolution, merchant-favor resolution
- [ ] Closes #121