### PR TITLE
Add on-chain refund appeals for rejected refunds.

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -55,6 +55,12 @@ pub enum DataKey {
     WindowStart,
     WindowRefundVolume,
     WindowPaymentVolume,
+    RefundRejectedAt(u64),
+    Appeal(u64),
+    AppealCounter,
+    AppealByRefund(u64),
+    AppealByCustomer(Address, u64),
+    AppealByCustomerCount(Address),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -110,6 +116,9 @@ pub enum Error {
     InvalidScoreThreshold = 35,
     AutoRefundTriggerNotFound = 36,
     DuplicateAutoRefundTrigger = 37,
+    RefundNotRejected = 23,
+    AppealWindowExpired = 24,
+    AppealAlreadyFiled = 25,
 }
 
 #[contractevent]
@@ -164,6 +173,22 @@ pub struct RefundRejected {
     pub rejected_by: Address,
     pub rejected_at: u64,
     pub rejection_reason: String,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppealFiled {
+    pub appeal_id: u64,
+    pub refund_id: u64,
+    pub appellant: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppealResolved {
+    pub appeal_id: u64,
+    pub upheld: bool,
+    pub resolved_at: u64,
 }
 
 #[contractevent]
@@ -290,6 +315,18 @@ pub struct Refund {
     pub requested_at: u64,
     pub reason: String,
     pub reason_code: RefundReasonCode,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct RefundAppeal {
+    pub appeal_id: u64,
+    pub refund_id: u64,
+    pub appellant: Address,
+    pub reason: String,
+    pub filed_at: u64,
+    pub resolved: bool,
+    pub outcome: Option<bool>,
 }
 
 #[contracttype]
@@ -651,6 +688,7 @@ impl RefundContract {
         // Store updated refund back to storage
         env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(&env, RefundStatus::Rejected, refund_id);
+        env.storage().instance().set(&DataKey::RefundRejectedAt(refund_id), &env.ledger().timestamp());
 
         // Emit RefundRejected event
         (RefundRejected {
@@ -661,6 +699,173 @@ impl RefundContract {
         }).publish(&env);
 
         Ok(())
+    }
+
+    pub fn file_appeal(
+        env: Env,
+        customer: Address,
+        refund_id: u64,
+        reason: String,
+    ) -> Result<u64, Error> {
+        customer.require_auth();
+
+        let refund: Refund = env
+            .storage()
+            .instance()
+            .get(&DataKey::Refund(refund_id))
+            .ok_or(Error::RefundNotFound)?;
+
+        if refund.customer != customer {
+            return Err(Error::Unauthorized);
+        }
+        if refund.status != RefundStatus::Rejected {
+            return Err(Error::RefundNotRejected);
+        }
+        if env.storage().instance().has(&DataKey::AppealByRefund(refund_id)) {
+            return Err(Error::AppealAlreadyFiled);
+        }
+
+        let rejected_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundRejectedAt(refund_id))
+            .ok_or(Error::RefundNotRejected)?;
+        let now = env.ledger().timestamp();
+        if now > rejected_at.saturating_add(72 * 60 * 60) {
+            return Err(Error::AppealWindowExpired);
+        }
+
+        let counter: u64 = env.storage().instance().get(&DataKey::AppealCounter).unwrap_or(0);
+        let appeal_id = counter + 1;
+        let appeal = RefundAppeal {
+            appeal_id,
+            refund_id,
+            appellant: customer.clone(),
+            reason,
+            filed_at: now,
+            resolved: false,
+            outcome: None,
+        };
+        env.storage().instance().set(&DataKey::Appeal(appeal_id), &appeal);
+        env.storage().instance().set(&DataKey::AppealCounter, &appeal_id);
+        env.storage().instance().set(&DataKey::AppealByRefund(refund_id), &appeal_id);
+
+        let customer_count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AppealByCustomerCount(customer.clone()))
+            .unwrap_or(0);
+        env.storage().instance().set(
+            &DataKey::AppealByCustomer(customer.clone(), customer_count),
+            &appeal_id,
+        );
+        env.storage().instance().set(
+            &DataKey::AppealByCustomerCount(customer.clone()),
+            &(customer_count + 1),
+        );
+
+        (AppealFiled {
+            appeal_id,
+            refund_id,
+            appellant: customer,
+        })
+        .publish(&env);
+
+        Ok(appeal_id)
+    }
+
+    pub fn resolve_appeal(
+        env: Env,
+        admin: Address,
+        appeal_id: u64,
+        uphold: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut appeal: RefundAppeal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Appeal(appeal_id))
+            .ok_or(Error::RefundNotFound)?;
+        if appeal.resolved {
+            return Err(Error::AlreadyProcessed);
+        }
+
+        if uphold {
+            let mut refund: Refund = env
+                .storage()
+                .instance()
+                .get(&DataKey::Refund(appeal.refund_id))
+                .ok_or(Error::RefundNotFound)?;
+            if refund.status != RefundStatus::Rejected {
+                return Err(Error::RefundNotRejected);
+            }
+
+            Self::remove_from_status_index(&env, RefundStatus::Rejected, refund.id)?;
+            refund.status = RefundStatus::Approved;
+            env.storage().instance().set(&DataKey::Refund(refund.id), &refund);
+            Self::add_to_status_index(&env, RefundStatus::Approved, refund.id);
+
+            Self::process_refund_internal(&env, admin.clone(), refund.id)?;
+        }
+
+        appeal.resolved = true;
+        appeal.outcome = Some(uphold);
+        env.storage().instance().set(&DataKey::Appeal(appeal_id), &appeal);
+
+        (AppealResolved {
+            appeal_id,
+            upheld: uphold,
+            resolved_at: env.ledger().timestamp(),
+        })
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_appeal(env: Env, appeal_id: u64) -> Result<RefundAppeal, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Appeal(appeal_id))
+            .ok_or(Error::RefundNotFound)
+    }
+
+    pub fn get_appeals_by_customer(env: Env, customer: Address) -> Vec<RefundAppeal> {
+        let mut appeals = Vec::new(&env);
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AppealByCustomerCount(customer.clone()))
+            .unwrap_or(0);
+
+        let mut index = 0u64;
+        while index < count {
+            if let Some(appeal_id) = env
+                .storage()
+                .instance()
+                .get::<_, u64>(&DataKey::AppealByCustomer(customer.clone(), index))
+            {
+                if let Some(appeal) = env
+                    .storage()
+                    .instance()
+                    .get::<_, RefundAppeal>(&DataKey::Appeal(appeal_id))
+                {
+                    appeals.push_back(appeal);
+                }
+            }
+            index += 1;
+        }
+
+        appeals
     }
 
     pub fn process_refund(env: Env, admin: Address, refund_id: u64) -> Result<(), Error> {

--- a/contracts/refund/src/test.rs
+++ b/contracts/refund/src/test.rs
@@ -1912,3 +1912,154 @@ fn test_arbitration_outcome_execution_rejected() {
     assert_eq!(refund.token, token);
     assert_eq!(refund.status, RefundStatus::Rejected);
 }
+
+#[test]
+fn test_file_and_resolve_appeal_upheld_processes_refund() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let refund_id = client.request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &1000i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "original"),
+        &RefundReasonCode::Other,
+        &env.ledger().timestamp(),
+    );
+    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
+
+    let appeal_id = client.file_appeal(&customer, &refund_id, &String::from_str(&env, "challenge"));
+    let appeal = client.get_appeal(&appeal_id);
+    assert_eq!(appeal.resolved, false);
+
+    client.resolve_appeal(&admin, &appeal_id, &true);
+
+    let resolved = client.get_appeal(&appeal_id);
+    assert_eq!(resolved.resolved, true);
+    assert_eq!(resolved.outcome, Some(true));
+
+    let refund = client.get_refund(&refund_id);
+    assert_eq!(refund.status, RefundStatus::Processed);
+}
+
+#[test]
+#[should_panic]
+fn test_file_appeal_after_window_expires_should_fail() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let refund_id = client.request_refund(
+        &merchant,
+        &2u64,
+        &customer,
+        &500i128,
+        &500i128,
+        &token,
+        &String::from_str(&env, "request"),
+        &RefundReasonCode::Other,
+        &env.ledger().timestamp(),
+    );
+    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
+
+    env.ledger().set_timestamp(1_000 + 72 * 60 * 60 + 1);
+    client.file_appeal(&customer, &refund_id, &String::from_str(&env, "late challenge"));
+}
+
+#[test]
+#[should_panic]
+fn test_file_duplicate_appeal_should_fail() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let refund_id = client.request_refund(
+        &merchant,
+        &3u64,
+        &customer,
+        &250i128,
+        &250i128,
+        &token,
+        &String::from_str(&env, "request"),
+        &RefundReasonCode::Other,
+        &env.ledger().timestamp(),
+    );
+    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
+
+    client.file_appeal(&customer, &refund_id, &String::from_str(&env, "first"));
+    client.file_appeal(&customer, &refund_id, &String::from_str(&env, "second"));
+}
+
+#[test]
+fn test_resolve_appeal_rejected_keeps_refund_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let refund_id = client.request_refund(
+        &merchant,
+        &4u64,
+        &customer,
+        &300i128,
+        &300i128,
+        &token,
+        &String::from_str(&env, "request"),
+        &RefundReasonCode::Other,
+        &env.ledger().timestamp(),
+    );
+    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
+
+    let appeal_id = client.file_appeal(&customer, &refund_id, &String::from_str(&env, "challenge"));
+    client.resolve_appeal(&admin, &appeal_id, &false);
+
+    let refund = client.get_refund(&refund_id);
+    assert_eq!(refund.status, RefundStatus::Rejected);
+
+    let resolved = client.get_appeal(&appeal_id);
+    assert_eq!(resolved.resolved, true);
+    assert_eq!(resolved.outcome, Some(false));
+}


### PR DESCRIPTION
## Summary

- Add an on-chain refund appeal flow so customers can challenge rejected refunds within a bounded window.
- Introduce `RefundAppeal` storage/indexing, appeal lifecycle APIs, new appeal errors, and appeal events.
- Ensure upheld appeals reverse a rejection by transitioning the refund to approved and then processing it, while rejected appeals leave refund state unchanged.

## What Changed

- Added new contract type:
  - `RefundAppeal { appeal_id, refund_id, appellant, reason, filed_at, resolved, outcome }`
- Added new storage keys:
  - `RefundRejectedAt(u64)`
  - `Appeal(u64)`
  - `AppealCounter`
  - `AppealByRefund(u64)`
  - `AppealByCustomer(Address, u64)`
  - `AppealByCustomerCount(Address)`
- Added new errors:
  - `RefundNotRejected = 23`
  - `AppealWindowExpired = 24`
  - `AppealAlreadyFiled = 25`
- Added new events:
  - `AppealFiled { appeal_id, refund_id, appellant }`
  - `AppealResolved { appeal_id, upheld, resolved_at }`
- Added new public functions:
  - `file_appeal(env, customer, refund_id, reason) -> Result<u64, Error>`
  - `resolve_appeal(env, admin, appeal_id, uphold) -> Result<(), Error>`
  - `get_appeal(env, appeal_id) -> Result<RefundAppeal, Error>`
  - `get_appeals_by_customer(env, customer) -> Vec<RefundAppeal>`
- Updated rejection flow:
  - `reject_refund()` now persists rejection timestamp to enforce the 72-hour appeal window.

## Behavior and Rules

- Appeals can only be filed by the refund’s customer.
- Appeals are only allowed for refunds currently in `Rejected` state.
- Appeal filing is allowed only within 72 hours of rejection.
- Only one appeal can exist per refund.
- On `resolve_appeal(..., uphold = true)`:
  - refund moves `Rejected -> Approved -> Processed`
- On `resolve_appeal(..., uphold = false)`:
  - refund remains `Rejected`
- Resolved appeals cannot be resolved again.

## Tests Added

- `test_file_and_resolve_appeal_upheld_processes_refund`
- `test_file_appeal_after_window_expires_should_fail`
- `test_file_duplicate_appeal_should_fail`
- `test_resolve_appeal_rejected_keeps_refund_rejected`

## Verification

- Ran focused test suite for this feature:
  - `cargo test -p refund appeal`
- Result:
  - 4 passed, 0 failed

## Notes

- No unnecessary files were added.
- Changes are limited to:
  - `contracts/refund/src/lib.rs`
  - `contracts/refund/src/test.rs`
  
  closes #139 