### PR TITLE
feat(escrow): add admin succession recovery

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -60,6 +60,7 @@ pub enum DataKey {
     MultiPartyDisputeKey(u64),
     // Conditional escrow (on-chain state)
     ConditionalEscrow(u64),
+    SuccessionPlan,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -175,6 +176,9 @@ pub enum Error {
     SameBeneficiary = 43,
     ConditionalEscrowNotFound = 50,
     ConditionAlreadyEvaluated = 51,
+    SuccessionPlanExists = 52,
+    SuccessionPlanNotFound = 53,
+    SuccessionAlreadyActivated = 54,
     // Merkle evidence (use free slots; contracterror has a max variant count)
     InvalidMerkleProof = 34,
     RootAlreadyCommitted = 38,
@@ -576,6 +580,16 @@ pub struct MultiSigConfig {
 
 #[derive(Clone)]
 #[contracttype]
+pub struct SuccessionPlan {
+    pub successor: Address,
+    pub designated_by: Address,
+    pub designated_at: u64,
+    pub activatable_after: u64,
+    pub activated: bool,
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub struct AdminProposal {
     pub id: String,
     pub proposer: Address,
@@ -712,6 +726,26 @@ pub struct AdminAdded {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AdminRemoved {
     pub admin: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SuccessorDesignated {
+    pub successor: Address,
+    pub activatable_after: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SuccessionActivated {
+    pub new_admin: Address,
+    pub activated_at: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SuccessionRevoked {
+    pub revoked_by: Address,
 }
 
 #[contractevent]
@@ -1290,6 +1324,128 @@ impl EscrowContract {
             .set(&DataKey::MultiSigConfig, &config);
 
         Ok(())
+    }
+
+    pub fn designate_successor(
+        env: Env,
+        admin: Address,
+        successor: Address,
+        delay_seconds: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        if let Some(existing) = env
+            .storage()
+            .instance()
+            .get::<DataKey, SuccessionPlan>(&DataKey::SuccessionPlan)
+        {
+            if !existing.activated {
+                return Err(Error::SuccessionPlanExists);
+            }
+        }
+
+        let designated_at = env.ledger().timestamp();
+        let activatable_after = designated_at.saturating_add(delay_seconds);
+        let plan = SuccessionPlan {
+            successor: successor.clone(),
+            designated_by: admin,
+            designated_at,
+            activatable_after,
+            activated: false,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::SuccessionPlan, &plan);
+
+        SuccessorDesignated {
+            successor,
+            activatable_after,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn activate_succession(env: Env, successor: Address) -> Result<(), Error> {
+        successor.require_auth();
+
+        let mut plan: SuccessionPlan = env
+            .storage()
+            .instance()
+            .get(&DataKey::SuccessionPlan)
+            .ok_or(Error::SuccessionPlanNotFound)?;
+
+        if plan.activated {
+            return Err(Error::SuccessionAlreadyActivated);
+        }
+        if plan.successor != successor {
+            return Err(Error::Unauthorized);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < plan.activatable_after {
+            return Err(Error::ActionNotReady);
+        }
+
+        let mut config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&successor) {
+            config.admins.push_back(successor.clone());
+            config.total_admins += 1;
+            env.storage()
+                .instance()
+                .set(&DataKey::MultiSigConfig, &config);
+            AdminAdded {
+                admin: successor.clone(),
+            }
+            .publish(&env);
+        }
+
+        plan.activated = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::SuccessionPlan, &plan);
+
+        SuccessionActivated {
+            new_admin: successor,
+            activated_at: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn revoke_succession(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        let config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        let plan: SuccessionPlan = env
+            .storage()
+            .instance()
+            .get(&DataKey::SuccessionPlan)
+            .ok_or(Error::SuccessionPlanNotFound)?;
+
+        if plan.activated {
+            return Err(Error::SuccessionAlreadyActivated);
+        }
+
+        env.storage().instance().remove(&DataKey::SuccessionPlan);
+        SuccessionRevoked { revoked_by: admin }.publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_succession_plan(env: Env) -> Option<SuccessionPlan> {
+        env.storage().instance().get(&DataKey::SuccessionPlan)
     }
 
     pub fn create_escrow(
@@ -5421,3 +5577,6 @@ mod beneficiary_transfer_test;
 
 #[cfg(test)]
 mod multi_party_dispute_test;
+
+#[cfg(test)]
+mod succession_test;

--- a/contracts/escrow/src/succession_test.rs
+++ b/contracts/escrow/src/succession_test.rs
@@ -1,0 +1,95 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env};
+
+fn setup() -> (Env, EscrowContractClient<'static>, Address) {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    (env, client, admin)
+}
+
+#[test]
+fn test_designate_successor_stores_plan() {
+    let (env, client, admin) = setup();
+    let successor = Address::generate(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.designate_successor(&admin, &successor, &300_u64);
+
+    let plan = client.get_succession_plan().unwrap();
+    assert_eq!(plan.successor, successor);
+    assert_eq!(plan.designated_by, admin);
+    assert_eq!(plan.designated_at, 1_000);
+    assert_eq!(plan.activatable_after, 1_300);
+    assert!(!plan.activated);
+}
+
+#[test]
+fn test_activate_succession_adds_successor_as_admin() {
+    let (env, client, admin) = setup();
+    let successor = Address::generate(&env);
+
+    env.ledger().set_timestamp(2_000);
+    client.designate_successor(&admin, &successor, &60_u64);
+
+    env.ledger().set_timestamp(2_060);
+    client.activate_succession(&successor);
+
+    let config = client.get_multisig_config();
+    assert!(config.admins.contains(&successor));
+    assert_eq!(config.total_admins, 2);
+
+    let plan = client.get_succession_plan().unwrap();
+    assert!(plan.activated);
+
+    client.set_batch_limit(&successor, &75_u32);
+    assert_eq!(client.get_batch_limit(), 75);
+}
+
+#[test]
+fn test_activate_succession_rejects_premature_activation() {
+    let (env, client, admin) = setup();
+    let successor = Address::generate(&env);
+
+    env.ledger().set_timestamp(5_000);
+    client.designate_successor(&admin, &successor, &120_u64);
+
+    env.ledger().set_timestamp(5_119);
+    let result = client.try_activate_succession(&successor);
+    assert_eq!(result, Err(Ok(Error::ActionNotReady)));
+}
+
+#[test]
+fn test_any_admin_can_revoke_pending_succession() {
+    let (env, client, admin) = setup();
+    let second_admin = Address::generate(&env);
+    let successor = Address::generate(&env);
+
+    client.add_admin(&admin, &second_admin);
+    env.ledger().set_timestamp(8_000);
+    client.designate_successor(&admin, &successor, &600_u64);
+
+    client.revoke_succession(&second_admin);
+
+    assert!(client.get_succession_plan().is_none());
+}
+
+#[test]
+fn test_only_one_pending_succession_plan_allowed() {
+    let (env, client, admin) = setup();
+    let first_successor = Address::generate(&env);
+    let second_successor = Address::generate(&env);
+
+    env.ledger().set_timestamp(10_000);
+    client.designate_successor(&admin, &first_successor, &60_u64);
+
+    let result = client.try_designate_successor(&admin, &second_successor, &120_u64);
+    assert_eq!(result, Err(Ok(Error::SuccessionPlanExists)));
+}


### PR DESCRIPTION
## Closes  #108
## Summary

This PR adds an admin succession/recovery mechanism to the escrow contract so the protocol can recover if current admin keys are lost or compromised.

A current admin can now designate a backup address as a successor with a time delay before takeover is allowed. Once the delay has passed, the designated successor can activate the plan and be added as a full admin. Any active admin can revoke a pending succession plan before activation. Only one pending succession plan is allowed at a time.

## What Changed

### Escrow contract
- Added `SuccessionPlan` storage model
- Added `designate_successor`
- Added `activate_succession`
- Added `revoke_succession`
- Added `get_succession_plan`

### Events
- Added `SuccessorDesignated`
- Added `SuccessionActivated`
- Added `SuccessionRevoked`

### Validation / behavior
- Prevents activation before `activatable_after`
- Adds successor to the multisig admin set on successful activation
- Allows any current admin to revoke a pending plan
- Enforces a single active pending succession plan

## Why

Without a recovery path, loss or compromise of all admin keys can permanently lock critical contract administration. This change adds a controlled fallback path with a delay window, which reduces permanent lockout risk while preserving time for review or revocation.

## Tests

Added coverage for:
- successor designation
- successful succession activation
- premature activation rejection
- revocation by another active admin
- rejection when attempting to create a second pending plan

## Notes

Local formatting and full test verification were partially blocked by existing machine/workspace issues:
- workspace-level `cargo fmt` is blocked by a pre-existing parse issue in `contracts/payment/src/lib.rs`
- targeted escrow test compilation was interrupted by a Windows linker/PDB issue and low disk space (`os error 112`)

The escrow succession implementation itself is isolated to the escrow contract and dedicated succession tests.
