### PR TITLE
feat(refund): Add refund rate limiting per customer (#141)

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -55,6 +55,8 @@ pub enum DataKey {
     WindowStart,
     WindowRefundVolume,
     WindowPaymentVolume,
+    CustomerRefundRateLimit(Address),
+    GlobalRefundRateLimit,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -99,6 +101,7 @@ pub enum Error {
     ContractPaused = 17,
     FunctionPaused = 18,
     BatchRefundTooLarge = 20,
+    RefundRateLimitExceeded = 26,
     PaymentContractNotSet = 27,
     PaymentOwnershipMismatch = 28,
     CircuitBreakerTripped = 29,
@@ -419,6 +422,23 @@ pub struct BatchRefundResult {
     pub success: bool,
     pub error_code: u32,
     pub amount_refunded: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct CustomerRefundRateLimit {
+    pub customer: Address,
+    pub window_start: u64,
+    pub request_count: u32,
+    pub max_requests_per_window: u32,
+    pub window_seconds: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct GlobalRefundRateLimit {
+    pub max_requests_per_window: u32,
+    pub window_seconds: u64,
 }
 
 #[contractevent]
@@ -794,6 +814,59 @@ impl RefundContract {
             .instance()
             .get(&DataKey::AutoRefundTrigger(trigger_id))
             .ok_or(Error::AutoRefundTriggerNotFound)
+    }
+
+    pub fn set_customer_rate_limit(
+        env: Env,
+        admin: Address,
+        customer: Address,
+        max_per_window: u32,
+        window_seconds: u64
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        
+        let mut limit = env.storage().instance().get(&DataKey::CustomerRefundRateLimit(customer.clone()))
+            .unwrap_or(CustomerRefundRateLimit {
+                customer: customer.clone(),
+                window_start: env.ledger().timestamp(),
+                request_count: 0,
+                max_requests_per_window: max_per_window,
+                window_seconds,
+            });
+            
+        limit.max_requests_per_window = max_per_window;
+        limit.window_seconds = window_seconds;
+        
+        env.storage().instance().set(&DataKey::CustomerRefundRateLimit(customer), &limit);
+        Ok(())
+    }
+
+    pub fn get_customer_rate_limit_status(env: Env, customer: Address) -> CustomerRefundRateLimit {
+        env.storage().instance().get(&DataKey::CustomerRefundRateLimit(customer.clone()))
+            .unwrap_or(CustomerRefundRateLimit {
+                customer,
+                window_start: 0,
+                request_count: 0,
+                max_requests_per_window: 0,
+                window_seconds: 0,
+            })
+    }
+
+    pub fn set_global_refund_rate_limit(
+        env: Env,
+        admin: Address,
+        max_per_window: u32,
+        window_seconds: u64
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        
+        let limit = GlobalRefundRateLimit {
+            max_requests_per_window: max_per_window,
+            window_seconds,
+        };
+        
+        env.storage().instance().set(&DataKey::GlobalRefundRateLimit, &limit);
+        Ok(())
     }
 
     pub fn register_arbitrator(env: Env, admin: Address, arbitrator: Address) -> Result<(), Error> {
@@ -2274,6 +2347,7 @@ impl RefundContract {
 
         Self::can_refund_payment(&env, payment_id, amount, original_payment_amount)?;
         Self::check_and_update_circuit_breaker(&env, amount, original_payment_amount)?;
+        Self::check_and_update_customer_refund_rate_limit(&env, customer.clone())?;
         if env.storage().instance().has(&DataKey::Admin) {
             Self::validate_against_policy(
                 &env,
@@ -2892,11 +2966,53 @@ impl RefundContract {
 
         Ok(())
     }
+
+    fn check_and_update_customer_refund_rate_limit(
+        env: &Env,
+        customer: Address,
+    ) -> Result<(), Error> {
+        let global_limit_opt = env.storage().instance().get::<DataKey, GlobalRefundRateLimit>(&DataKey::GlobalRefundRateLimit);
+        let customer_limit_opt = env.storage().instance().get::<DataKey, CustomerRefundRateLimit>(&DataKey::CustomerRefundRateLimit(customer.clone()));
+
+        if global_limit_opt.is_none() && customer_limit_opt.is_none() {
+            return Ok(());
+        }
+
+        let mut limit = match customer_limit_opt {
+            Some(l) => l,
+            None => {
+                let g = global_limit_opt.unwrap();
+                CustomerRefundRateLimit {
+                    customer: customer.clone(),
+                    window_start: env.ledger().timestamp(),
+                    request_count: 0,
+                    max_requests_per_window: g.max_requests_per_window,
+                    window_seconds: g.window_seconds,
+                }
+            }
+        };
+
+        let now = env.ledger().timestamp();
+        if now >= limit.window_start + limit.window_seconds {
+            limit.window_start = now;
+            limit.request_count = 0;
+        }
+
+        if limit.request_count >= limit.max_requests_per_window {
+            return Err(Error::RefundRateLimitExceeded);
+        }
+
+        limit.request_count += 1;
+        env.storage().instance().set(&DataKey::CustomerRefundRateLimit(customer), &limit);
+
+        Ok(())
+    }
 }
 
 mod test;
 mod test_process;
 mod test_policy;
+mod test_rate_limit;
 
 #[cfg(test)]
 mod test_circuit_breaker;

--- a/contracts/refund/src/test_rate_limit.rs
+++ b/contracts/refund/src/test_rate_limit.rs
@@ -1,0 +1,155 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+#[test]
+fn test_global_refund_rate_limit() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let reason = String::from_str(&env, "Abuse");
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Set global limit: 3 requests per 24 hours (86400 seconds)
+    client.set_global_refund_rate_limit(&admin, &3, &86400);
+
+    // Request 3 refunds - should succeed
+    for i in 1..=3 {
+        client.request_refund(
+            &merchant,
+            &(i as u64),
+            &customer,
+            &100,
+            &100,
+            &token,
+            &reason,
+            &RefundReasonCode::Other,
+            &0
+        );
+    }
+
+    // 4th request should fail
+    let res = client.try_request_refund(
+        &merchant,
+        &4,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0
+    );
+
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_customer_override_refund_rate_limit() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let reason = String::from_str(&env, "Override");
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Set global limit: 1 request per 24 hours
+    client.set_global_refund_rate_limit(&admin, &1, &86400);
+    
+    // Set customer override: 5 requests per 24 hours
+    client.set_customer_rate_limit(&admin, &customer, &5, &86400);
+
+    // Request 3 refunds - should succeed because of override
+    for i in 1..=3 {
+        client.request_refund(
+            &merchant,
+            &(i as u64),
+            &customer,
+            &100,
+            &100,
+            &token,
+            &reason,
+            &RefundReasonCode::Other,
+            &0
+        );
+    }
+    
+    let status = client.get_customer_rate_limit_status(&customer);
+    assert_eq!(status.request_count, 3);
+}
+
+#[test]
+fn test_rate_limit_window_reset() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let reason = String::from_str(&env, "Reset");
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    // Set global limit: 1 request per 1 hour (3600 seconds)
+    client.set_global_refund_rate_limit(&admin, &1, &3600);
+
+    // 1st request succeeds
+    client.request_refund(
+        &merchant,
+        &1,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0
+    );
+
+    // 2nd request fails
+    let res = client.try_request_refund(
+        &merchant,
+        &2,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0
+    );
+    assert!(res.is_err());
+
+    // Jump time forward by 1 hour + 1 second
+    env.ledger().set_timestamp(3601);
+
+    // 3rd request succeeds because window reset
+    client.request_refund(
+        &merchant,
+        &3,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0
+    );
+}

--- a/solution_141.md
+++ b/solution_141.md
@@ -1,0 +1,24 @@
+# Solution Description - Issue 141: Refund Rate Limiting
+
+## Overview
+Implemented per-customer refund rate limiting to prevent coordinated abuse and reduce operational load on the arbitration system. The system supports both global rate limits and per-customer overrides.
+
+## Key Changes
+1.  **Data Structures**:
+    *   `CustomerRefundRateLimit`: Tracks the number of refund requests for a specific customer within a rolling time window.
+    *   `GlobalRefundRateLimit`: Defines the default rate limit applied to all customers if no per-customer override is set.
+2.  **Public API**:
+    *   `set_customer_rate_limit`: Admin function to set or update a specific customer's rate limit.
+    *   `get_customer_rate_limit_status`: Public function to query a customer's current rate limit usage.
+    *   `set_global_refund_rate_limit`: Admin function to set the default global rate limit.
+3.  **Core Logic**:
+    *   Integrated `check_and_update_customer_refund_rate_limit` into the `create_refund` flow.
+    *   Counter increments are atomic and windows reset automatically after the specified `window_seconds`.
+    *   Per-customer limits take precedence over global limits.
+4.  **Error Handling**:
+    *   Added `RefundRateLimitExceeded = 26` error code.
+5.  **Testing**:
+    *   Comprehensive unit tests in `test_rate_limit.rs` covering global limits, customer overrides, and window resets.
+
+## Issue Number
+#141


### PR DESCRIPTION
# Solution Description - Issue 141: Refund Rate Limiting

## Overview
Implemented per-customer refund rate limiting to prevent coordinated abuse and reduce operational load on the arbitration system. The system supports both global rate limits and per-customer overrides.

## Key Changes
1.  **Data Structures**:
    *   `CustomerRefundRateLimit`: Tracks the number of refund requests for a specific customer within a rolling time window.
    *   `GlobalRefundRateLimit`: Defines the default rate limit applied to all customers if no per-customer override is set.
2.  **Public API**:
    *   `set_customer_rate_limit`: Admin function to set or update a specific customer's rate limit.
    *   `get_customer_rate_limit_status`: Public function to query a customer's current rate limit usage.
    *   `set_global_refund_rate_limit`: Admin function to set the default global rate limit.
3.  **Core Logic**:
    *   Integrated `check_and_update_customer_refund_rate_limit` into the `create_refund` flow.
    *   Counter increments are atomic and windows reset automatically after the specified `window_seconds`.
    *   Per-customer limits take precedence over global limits.
4.  **Error Handling**:
    *   Added `RefundRateLimitExceeded = 26` error code.
5.  **Testing**:
    *   Comprehensive unit tests in `test_rate_limit.rs` covering global limits, customer overrides, and window resets.

closes #141
