### PR TITLE
Add merchant-scoped refund dashboard query functions (#2)

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
 };
 
 #[derive(Clone)]
-#[contracttype]
+#[contracttype(export = false)]
 pub enum DataKey {
     Admin,
     Refund(u64),
@@ -43,6 +43,8 @@ pub enum DataKey {
     AutoRefundTriggerCounter,
     // Batch refund limit (#135)
     BatchRefundLimit,
+    CustomerRefundRateLimit(Address),
+    GlobalRefundRateLimit,
     // Analytics
     RefundAnalyticsKey,
     // Pause system
@@ -323,6 +325,17 @@ pub struct Refund {
     pub requested_at: u64,
     pub reason: String,
     pub reason_code: RefundReasonCode,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct MerchantRefundSummary {
+    pub total_requests: u64,
+    pub total_approved: u64,
+    pub total_rejected: u64,
+    pub total_amount_refunded: i128,
+    pub pending_count: u64,
+    pub pending_amount: i128,
 }
 
 #[derive(Clone)]
@@ -1915,6 +1928,101 @@ impl RefundContract {
         results
     }
 
+    pub fn get_merchant_refunds(env: Env, merchant: Address, limit: u64, offset: u64) -> Vec<Refund> {
+        let mut results: Vec<Refund> = Vec::new(&env);
+        let total = Self::get_merchant_refund_count(&env, &merchant);
+
+        if limit == 0 || offset >= total {
+            return results;
+        }
+
+        let end = core::cmp::min(total, offset.saturating_add(limit));
+        let mut index = offset;
+        while index < end {
+            if
+                let Some(refund_id) = env
+                    .storage()
+                    .instance()
+                    .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
+            {
+                if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(refund_id)) {
+                    results.push_back(refund);
+                }
+            }
+            index += 1;
+        }
+
+        results
+    }
+
+    pub fn get_merchant_refunds_by_status(
+        env: Env,
+        merchant: Address,
+        status: RefundStatus,
+        limit: u64,
+        offset: u64
+    ) -> Vec<Refund> {
+        Self::get_merchant_refunds_by_status_internal(&env, &merchant, status, limit, offset)
+    }
+
+    pub fn get_merchant_pending_refunds(env: Env, merchant: Address) -> Vec<Refund> {
+        let total = Self::get_merchant_refund_count(&env, &merchant);
+        Self::get_merchant_refunds_by_status_internal(
+            &env,
+            &merchant,
+            RefundStatus::Requested,
+            total,
+            0,
+        )
+    }
+
+    pub fn get_merchant_refund_summary(env: Env, merchant: Address) -> MerchantRefundSummary {
+        let total_requests = Self::get_merchant_refund_count(&env, &merchant);
+        let mut total_approved = 0u64;
+        let mut total_rejected = 0u64;
+        let mut total_amount_refunded = 0i128;
+        let mut pending_count = 0u64;
+        let mut pending_amount = 0i128;
+
+        let mut index = 0u64;
+        while index < total_requests {
+            if
+                let Some(refund_id) = env
+                    .storage()
+                    .instance()
+                    .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
+            {
+                if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(refund_id)) {
+                    match refund.status {
+                        RefundStatus::Approved => {
+                            total_approved += 1;
+                        }
+                        RefundStatus::Rejected => {
+                            total_rejected += 1;
+                        }
+                        RefundStatus::Processed => {
+                            total_amount_refunded += refund.amount;
+                        }
+                        RefundStatus::Requested => {
+                            pending_count += 1;
+                            pending_amount += refund.amount;
+                        }
+                    }
+                }
+            }
+            index += 1;
+        }
+
+        MerchantRefundSummary {
+            total_requests,
+            total_approved,
+            total_rejected,
+            total_amount_refunded,
+            pending_count,
+            pending_amount,
+        }
+    }
+
     pub fn get_refunds_by_reason_code(
         env: &Env,
         code: RefundReasonCode,
@@ -3246,8 +3354,8 @@ impl RefundContract {
         }
 
         // Calculate refund rate
-        let refund_rate_bps = if total_payments > 0 {
-            (total_refunds * 10000) / total_payments
+        let refund_rate_bps: u32 = if total_payments > 0 {
+            ((total_refunds * 10000) / total_payments) as u32
         } else {
             0
         };
@@ -3267,7 +3375,7 @@ impl RefundContract {
                     signal.total_refunds = total_refunds;
                     env.storage()
                         .instance()
-                        .set(&DataKey::FraudSignal(address), &signal);
+                        .set(&DataKey::FraudSignal(address.clone()), &signal);
                     Some(signal)
                 }
                 None => {
@@ -3282,17 +3390,17 @@ impl RefundContract {
                     };
                     env.storage()
                         .instance()
-                        .set(&DataKey::FraudSignal(address), &signal);
+                        .set(&DataKey::FraudSignal(address.clone()), &signal);
 
                     // Add to flagged addresses index
-                    let mut flagged_count: u64 = env
+                    let flagged_count: u64 = env
                         .storage()
                         .instance()
                         .get(&DataKey::FlaggedAddressesIndex)
                         .unwrap_or(0);
                     env.storage()
                         .instance()
-                        .set(&DataKey::FlaggedAddressesIndex, &flagged_count + 1);
+                        .set(&DataKey::FlaggedAddressesIndex, &(flagged_count + 1));
 
                     // Emit fraud signal raised event
                     (FraudSignalRaised {
@@ -3341,7 +3449,7 @@ impl RefundContract {
         signal.reviewed = true;
         env.storage()
             .instance()
-            .set(&DataKey::FraudSignal(address), &signal);
+            .set(&DataKey::FraudSignal(address.clone()), &signal);
 
         // Emit fraud signal reviewed event
         (FraudSignalReviewed {
@@ -3389,6 +3497,50 @@ impl RefundContract {
             .unwrap_or(0);
         refund_count
     }
+
+    fn get_merchant_refund_count(env: &Env, merchant: &Address) -> u64 {
+        env.storage().instance().get(&DataKey::MerchantRefundCount(merchant.clone())).unwrap_or(0)
+    }
+
+    fn get_merchant_refunds_by_status_internal(
+        env: &Env,
+        merchant: &Address,
+        status: RefundStatus,
+        limit: u64,
+        offset: u64
+    ) -> Vec<Refund> {
+        let mut results: Vec<Refund> = Vec::new(env);
+        if limit == 0 {
+            return results;
+        }
+
+        let total = Self::get_merchant_refund_count(env, merchant);
+        let mut matched = 0u64;
+        let mut collected = 0u64;
+        let mut index = 0u64;
+
+        while index < total && collected < limit {
+            if
+                let Some(refund_id) = env
+                    .storage()
+                    .instance()
+                    .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
+            {
+                if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(refund_id)) {
+                    if refund.status == status {
+                        if matched >= offset {
+                            results.push_back(refund);
+                            collected += 1;
+                        }
+                        matched += 1;
+                    }
+                }
+            }
+            index += 1;
+        }
+
+        results
+    }
 }
 
 mod test;
@@ -3419,3 +3571,6 @@ mod test_arbitrator_reputation;
 
 #[cfg(test)]
 mod test_auto_refund;
+
+#[cfg(test)]
+mod test_merchant_refunds;

--- a/contracts/refund/src/test_merchant_refunds.rs
+++ b/contracts/refund/src/test_merchant_refunds.rs
@@ -1,0 +1,244 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{ testutils::Address as _, Address, Env, String };
+
+fn request_refund_for_merchant(
+    client: &RefundContractClient<'_>,
+    env: &Env,
+    merchant: &Address,
+    customer: &Address,
+    token: &Address,
+    payment_id: u64,
+    amount: i128,
+) -> u64 {
+    client.request_refund(
+        merchant,
+        &payment_id,
+        customer,
+        &amount,
+        &amount,
+        token,
+        &String::from_str(env, "merchant dashboard"),
+        &RefundReasonCode::Other,
+        &0_u64,
+    )
+}
+
+fn disable_fraud_checks(client: &RefundContractClient<'_>, admin: &Address) {
+    client.set_fraud_config(
+        admin,
+        &FraudConfig {
+            max_refund_rate_bps: 10000,
+            min_transactions_for_check: 1000,
+            enabled: false,
+        },
+    );
+}
+
+#[test]
+fn test_get_merchant_refunds_paginates_in_merchant_order() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant_a = Address::generate(&env);
+    let merchant_b = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    disable_fraud_checks(&client, &admin);
+
+    let a1 = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 1, 100);
+    let _b1 = request_refund_for_merchant(&client, &env, &merchant_b, &customer, &token, 2, 200);
+    let a2 = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 3, 300);
+    let a3 = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 4, 400);
+    let a4 = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 5, 500);
+
+    let page = client.get_merchant_refunds(&merchant_a, &2u64, &1u64);
+    assert_eq!(page.len(), 2);
+    assert_eq!(page.get(0).unwrap().id, a2);
+    assert_eq!(page.get(1).unwrap().id, a3);
+
+    let tail = client.get_merchant_refunds(&merchant_a, &3u64, &3u64);
+    assert_eq!(tail.len(), 1);
+    assert_eq!(tail.get(0).unwrap().id, a4);
+
+    let empty_limit = client.get_merchant_refunds(&merchant_a, &0u64, &0u64);
+    assert_eq!(empty_limit.len(), 0);
+
+    let empty_offset = client.get_merchant_refunds(&merchant_a, &2u64, &10u64);
+    assert_eq!(empty_offset.len(), 0);
+
+    let all_a = client.get_merchant_refunds(&merchant_a, &10u64, &0u64);
+    assert_eq!(all_a.len(), 4);
+    assert_eq!(all_a.get(0).unwrap().id, a1);
+    assert_eq!(all_a.get(1).unwrap().id, a2);
+    assert_eq!(all_a.get(2).unwrap().id, a3);
+    assert_eq!(all_a.get(3).unwrap().id, a4);
+}
+
+#[test]
+fn test_get_merchant_refunds_by_status_filters_matches_and_offset() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant_a = Address::generate(&env);
+    let merchant_b = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    disable_fraud_checks(&client, &admin);
+
+    let approved_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 11, 110);
+    let approved_two = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 12, 120);
+    let rejected_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 13, 130);
+    let processed_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 14, 140);
+    let _pending_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 15, 150);
+    let other_approved = request_refund_for_merchant(&client, &env, &merchant_b, &customer, &token, 16, 160);
+    let other_rejected = request_refund_for_merchant(&client, &env, &merchant_b, &customer, &token, 17, 170);
+
+    client.approve_refund(&admin, &approved_one);
+    client.approve_refund(&admin, &approved_two);
+    client.reject_refund(&admin, &rejected_one, &String::from_str(&env, "No"));
+    client.approve_refund(&admin, &processed_one);
+    client.process_refund(&admin, &processed_one);
+    client.approve_refund(&admin, &other_approved);
+    client.reject_refund(&admin, &other_rejected, &String::from_str(&env, "No"));
+
+    let approved = client.get_merchant_refunds_by_status(
+        &merchant_a,
+        &RefundStatus::Approved,
+        &10u64,
+        &0u64,
+    );
+    assert_eq!(approved.len(), 2);
+    assert_eq!(approved.get(0).unwrap().id, approved_one);
+    assert_eq!(approved.get(1).unwrap().id, approved_two);
+
+    let approved_offset = client.get_merchant_refunds_by_status(
+        &merchant_a,
+        &RefundStatus::Approved,
+        &1u64,
+        &1u64,
+    );
+    assert_eq!(approved_offset.len(), 1);
+    assert_eq!(approved_offset.get(0).unwrap().id, approved_two);
+
+    let rejected = client.get_merchant_refunds_by_status(
+        &merchant_a,
+        &RefundStatus::Rejected,
+        &10u64,
+        &0u64,
+    );
+    assert_eq!(rejected.len(), 1);
+    assert_eq!(rejected.get(0).unwrap().id, rejected_one);
+
+    let processed = client.get_merchant_refunds_by_status(
+        &merchant_a,
+        &RefundStatus::Processed,
+        &10u64,
+        &0u64,
+    );
+    assert_eq!(processed.len(), 1);
+    assert_eq!(processed.get(0).unwrap().id, processed_one);
+
+    let merchant_b_approved = client.get_merchant_refunds_by_status(
+        &merchant_b,
+        &RefundStatus::Approved,
+        &10u64,
+        &0u64,
+    );
+    assert_eq!(merchant_b_approved.len(), 1);
+    assert_eq!(merchant_b_approved.get(0).unwrap().id, other_approved);
+}
+
+#[test]
+fn test_get_merchant_pending_refunds_returns_only_requested() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant_a = Address::generate(&env);
+    let merchant_b = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    disable_fraud_checks(&client, &admin);
+
+    let pending_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 21, 210);
+    let approved_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 22, 220);
+    let rejected_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 23, 230);
+    let processed_one = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 24, 240);
+    let pending_two = request_refund_for_merchant(&client, &env, &merchant_a, &customer, &token, 25, 250);
+    let _other_pending = request_refund_for_merchant(&client, &env, &merchant_b, &customer, &token, 26, 260);
+
+    client.approve_refund(&admin, &approved_one);
+    client.reject_refund(&admin, &rejected_one, &String::from_str(&env, "No"));
+    client.approve_refund(&admin, &processed_one);
+    client.process_refund(&admin, &processed_one);
+
+    let pending = client.get_merchant_pending_refunds(&merchant_a);
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending.get(0).unwrap().id, pending_one);
+    assert_eq!(pending.get(0).unwrap().status, RefundStatus::Requested);
+    assert_eq!(pending.get(1).unwrap().id, pending_two);
+    assert_eq!(pending.get(1).unwrap().status, RefundStatus::Requested);
+}
+
+#[test]
+fn test_get_merchant_refund_summary_counts_current_statuses_and_amounts() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    let empty_merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    disable_fraud_checks(&client, &admin);
+
+    let pending_one = request_refund_for_merchant(&client, &env, &merchant, &customer, &token, 31, 50);
+    let approved_one = request_refund_for_merchant(&client, &env, &merchant, &customer, &token, 32, 60);
+    let rejected_one = request_refund_for_merchant(&client, &env, &merchant, &customer, &token, 33, 70);
+    let processed_one = request_refund_for_merchant(&client, &env, &merchant, &customer, &token, 34, 80);
+    let pending_two = request_refund_for_merchant(&client, &env, &merchant, &customer, &token, 35, 90);
+
+    let _ = pending_one;
+    let _ = pending_two;
+
+    client.approve_refund(&admin, &approved_one);
+    client.reject_refund(&admin, &rejected_one, &String::from_str(&env, "No"));
+    client.approve_refund(&admin, &processed_one);
+    client.process_refund(&admin, &processed_one);
+
+    let summary = client.get_merchant_refund_summary(&merchant);
+    assert_eq!(summary.total_requests, 5);
+    assert_eq!(summary.total_approved, 1);
+    assert_eq!(summary.total_rejected, 1);
+    assert_eq!(summary.total_amount_refunded, 80);
+    assert_eq!(summary.pending_count, 2);
+    assert_eq!(summary.pending_amount, 140);
+
+    let empty_summary = client.get_merchant_refund_summary(&empty_merchant);
+    assert_eq!(empty_summary.total_requests, 0);
+    assert_eq!(empty_summary.total_approved, 0);
+    assert_eq!(empty_summary.total_rejected, 0);
+    assert_eq!(empty_summary.total_amount_refunded, 0);
+    assert_eq!(empty_summary.pending_count, 0);
+    assert_eq!(empty_summary.pending_amount, 0);
+}


### PR DESCRIPTION
Closes #145

Overview

This PR introduces merchant-scoped refund query functions to improve on-chain data access for refund dashboards.

Previously, merchants could only retrieve refunds globally using get_refunds_by_status(), which required additional off-chain filtering to isolate their own data. This update removes that friction by enabling direct, merchant-specific queries.


---

✨ What’s Added

New Query Functions

get_merchant_refunds(env: Env, merchant: Address, limit: u64, offset: u64) -> Vec<Refund>
→ Fetch all refunds for a specific merchant with pagination

get_merchant_refunds_by_status(env: Env, merchant: Address, status: RefundStatus, limit: u64, offset: u64) -> Vec<Refund>
→ Fetch merchant refunds filtered by status

get_merchant_pending_refunds(env: Env, merchant: Address) -> Vec<Refund>
→ Fetch only pending (Requested) refunds for a merchant

get_merchant_refund_summary(env: Env, merchant: Address) -> MerchantRefundSummary
→ Returns aggregated refund metrics for dashboard use



---

New Struct

#[contracttype]
pub struct MerchantRefundSummary {
    pub total_requests: u64,
    pub total_approved: u64,
    pub total_rejected: u64,
    pub total_amount_refunded: i128,
    pub pending_count: u64,
    pub pending_amount: i128,
}


---

🧠 Why This Matters

Eliminates the need for off-chain filtering 🧹

Simplifies merchant dashboard integrations 📊

Improves performance and developer experience ⚡

Provides ready-to-use aggregated data for analytics



---

✅ Acceptance Criteria

All query functions support pagination via limit and offset

get_merchant_pending_refunds() returns only Requested status refunds

MerchantRefundSummary is computed dynamically from merchant refund records

Comprehensive tests added for:

Pagination correctness

Status filtering

Summary accuracy



