### PR TITLE
feat(payment): add payment channel support for off-chain micro-paymen…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "payments"
 version = "0.0.0"
 dependencies = [
+ "ed25519-dalek",
  "escrow",
+ "rand",
  "soroban-sdk",
 ]
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -180,11 +180,10 @@ pub enum Error {
     SuccessionPlanExists = 52,
     SuccessionPlanNotFound = 53,
     SuccessionAlreadyActivated = 54,
-    // Merkle evidence (use free slots; contracterror has a max variant count)
     InvalidMerkleProof = 34,
     RootAlreadyCommitted = 38,
     NoEvidenceRoot = 39,
-    EmptyPauseReason = 52,
+    EmptyPauseReason = 55,
 }
 
 #[contractevent]

--- a/contracts/payment/Cargo.toml
+++ b/contracts/payment/Cargo.toml
@@ -15,3 +15,5 @@ escrow = { path = "../escrow" }
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 escrow = { path = "../escrow" }
+ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
+rand = "0.8.5"

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -41,6 +41,9 @@ pub enum DataKey {
     OutstandingBalance(u64),
     // Oracle data
     OracleRateConfig(Currency),
+    // Payment Channel support (#125)
+    PaymentChannel(u64),
+    PaymentChannelCounter,
 }
 
 // Customer-specific data keys
@@ -246,6 +249,14 @@ pub enum Error {
     PartialPaymentNotFound = 70,
     MerchantRateLimitExceeded = 50,
     AmountRateLimitExceeded = 51,
+    InvalidFeeConfig = 71,
+    InvalidAmount = 72,
+    ChannelNotFound = 73,
+    InvalidSignature = 74,
+    InvalidNonce = 75,
+    ChannelClosed = 76,
+    ChannelExpired = 77,
+    ChannelNotExpired = 78,
 }
 
 #[contractevent]
@@ -385,6 +396,44 @@ pub struct RiskFeeApplied {
     pub base_fee_bps: u32,
     pub risk_surcharge_bps: u32,
     pub total_fee_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaymentChannel {
+    pub channel_id: u64,
+    pub customer: Address,
+    pub merchant: Address,
+    pub token: Address,
+    pub deposited: i128,
+    pub settled: i128,
+    pub nonce: u64,
+    pub open: bool,
+    pub expires_at: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChannelOpened {
+    pub channel_id: u64,
+    pub customer: Address,
+    pub merchant: Address,
+    pub amount: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChannelSettled {
+    pub channel_id: u64,
+    pub merchant_amount: i128,
+    pub customer_refund: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChannelExpiredClosed {
+    pub channel_id: u64,
+    pub refunded_to: Address,
 }
 
 #[contractevent]
@@ -6497,6 +6546,9 @@ impl PaymentContract {
         env.storage()
             .instance()
             .set(&DataKey::RiskFeeConfig, &config);
+        Ok(())
+    }
+
     /// Toggle proration for a subscription. Only the customer can change this.
     pub fn set_subscription_proration(
         env: Env,
@@ -6531,6 +6583,183 @@ impl PaymentContract {
 
         Ok(())
     }
+
+    // ── PAYMENT CHANNEL METHODS (#125) ──────────────────────────────────────
+
+    pub fn open_channel(
+        env: Env,
+        customer: Address,
+        merchant: Address,
+        token: Address,
+        amount: i128,
+        expires_at: u64,
+    ) -> Result<u64, Error> {
+        customer.require_auth();
+        if amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&customer, &contract_address, &amount);
+
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentChannelCounter)
+            .unwrap_or(0);
+        let channel_id = counter + 1;
+
+        let channel = PaymentChannel {
+            channel_id,
+            customer: customer.clone(),
+            merchant: merchant.clone(),
+            token,
+            deposited: amount,
+            settled: 0,
+            nonce: 0,
+            open: true,
+            expires_at,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PaymentChannel(channel_id), &channel);
+        env.storage()
+            .instance()
+            .set(&DataKey::PaymentChannelCounter, &channel_id);
+
+        (ChannelOpened {
+            channel_id,
+            customer,
+            merchant,
+            amount,
+        })
+        .publish(&env);
+
+        Ok(channel_id)
+    }
+
+    pub fn settle_channel(
+        env: Env,
+        channel_id: u64,
+        merchant_amount: i128,
+        nonce: u64,
+        signature: BytesN<64>,
+    ) -> Result<(), Error> {
+        let mut channel: PaymentChannel = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentChannel(channel_id))
+            .ok_or(Error::ChannelNotFound)?;
+
+        if !channel.open {
+            return Err(Error::ChannelClosed);
+        }
+
+        if channel.expires_at > 0 && env.ledger().timestamp() > channel.expires_at {
+            return Err(Error::ChannelExpired);
+        }
+
+        if nonce <= channel.nonce {
+            return Err(Error::InvalidNonce);
+        }
+
+        if merchant_amount > channel.deposited {
+            return Err(Error::InvalidAmount);
+        }
+
+        // Verify signature over (channel_id, merchant_amount, nonce)
+        let mut msg = Bytes::new(&env);
+        msg.append(&channel_id.to_xdr(&env));
+        msg.append(&merchant_amount.to_xdr(&env));
+        msg.append(&nonce.to_xdr(&env));
+
+        let pk = Self::extract_public_key(&env, &channel.customer);
+        env.crypto().ed25519_verify(&pk, &msg, &signature);
+
+        let customer_refund = channel.deposited - merchant_amount;
+        let token_client = token::Client::new(&env, &channel.token);
+        let contract_address = env.current_contract_address();
+
+        if merchant_amount > 0 {
+            token_client.transfer(&contract_address, &channel.merchant, &merchant_amount);
+        }
+        if customer_refund > 0 {
+            token_client.transfer(&contract_address, &channel.customer, &customer_refund);
+        }
+
+        channel.settled = merchant_amount;
+        channel.nonce = nonce;
+        channel.open = false;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PaymentChannel(channel_id), &channel);
+
+        (ChannelSettled {
+            channel_id,
+            merchant_amount,
+            customer_refund,
+        })
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn close_channel_expired(env: Env, channel_id: u64) -> Result<(), Error> {
+        let mut channel: PaymentChannel = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentChannel(channel_id))
+            .ok_or(Error::ChannelNotFound)?;
+
+        if !channel.open {
+            return Err(Error::ChannelClosed);
+        }
+
+        if channel.expires_at == 0 || env.ledger().timestamp() <= channel.expires_at {
+            return Err(Error::ChannelNotExpired);
+        }
+
+        let refund_amount = channel.deposited;
+        let token_client = token::Client::new(&env, &channel.token);
+        let contract_address = env.current_contract_address();
+
+        if refund_amount > 0 {
+            token_client.transfer(&contract_address, &channel.customer, &refund_amount);
+        }
+
+        channel.open = false;
+        env.storage()
+            .instance()
+            .set(&DataKey::PaymentChannel(channel_id), &channel);
+
+        (ChannelExpiredClosed {
+            channel_id,
+            refunded_to: channel.customer.clone(),
+        })
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_channel(env: Env, channel_id: u64) -> Result<PaymentChannel, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PaymentChannel(channel_id))
+            .ok_or(Error::ChannelNotFound)
+    }
+
+    fn extract_public_key(env: &Env, address: &Address) -> BytesN<32> {
+        let xdr = address.to_xdr(env);
+        // Ed25519 Account Address XDR: 0 (ScAddress Account) + 0 (AccountId Ed25519) + 32 bytes PK
+        let mut pk = [0u8; 32];
+        for i in 0..32 {
+            pk[i] = xdr.get(8 + (i as u32)).unwrap();
+        }
+        BytesN::from_array(env, &pk)
+    }
 }
 
 mod test;
@@ -6544,6 +6773,9 @@ mod test_trial;
 mod test_issue_113_115_119_120;
 #[cfg(test)]
 mod test_metadata;
+
+#[cfg(test)]
+mod test_payment_channel;
 
 #[cfg(test)]
 mod test_cross_contract_escrow_verification;

--- a/contracts/payment/src/test_payment_channel.rs
+++ b/contracts/payment/src/test_payment_channel.rs
@@ -1,0 +1,161 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, BytesN as _, Ledger},
+    Address, Bytes, BytesN, Env,
+};
+use ed25519_dalek::{Signer, SigningKey};
+use rand::thread_rng;
+
+fn address_from_pk(env: &Env, pk: [u8; 32]) -> Address {
+    // ScAddress::Account(AccountId::PublicKeyTypeEd25519(Uint256(pk)))
+    let mut xdr = [0u8; 40];
+    xdr[3] = 0; // ScAddress::Account
+    xdr[7] = 0; // AccountId::PublicKeyTypeEd25519
+    xdr[8..].copy_from_slice(&pk);
+    Address::from_xdr(env, &Bytes::from_array(env, &xdr))
+}
+
+#[test]
+fn test_payment_channel_full_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Generate a real Ed25519 keypair for the customer
+    let mut rng = thread_rng();
+    let signing_key = SigningKey::generate(&mut rng);
+    let pk_bytes: [u8; 32] = signing_key.verifying_key().to_bytes();
+    
+    let customer = address_from_pk(&env, pk_bytes);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin.clone());
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    let token_client = token::Client::new(&env, &token_id);
+
+    let payment_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &payment_id);
+    client.initialize(&admin);
+
+    let deposit_amount = 1000i128;
+    token_admin_client.mint(&customer, &deposit_amount);
+
+    let expires_at = env.ledger().timestamp() + 3600;
+    let channel_id = client.open_channel(&customer, &merchant, &token_id, &deposit_amount, &expires_at);
+
+    // Verify channel state
+    let channel = client.get_channel(&channel_id);
+    assert_eq!(channel.channel_id, channel_id);
+    assert_eq!(channel.customer, customer);
+    assert_eq!(channel.merchant, merchant);
+    assert_eq!(channel.deposited, deposit_amount);
+    assert!(channel.open);
+
+    // Prepare settlement
+    let merchant_amount = 600i128;
+    let nonce = 1u64;
+
+    // Construct the same message as in the contract
+    let mut msg_bytes = Bytes::new(&env);
+    msg_bytes.append(&channel_id.to_xdr(&env));
+    msg_bytes.append(&merchant_amount.to_xdr(&env));
+    msg_bytes.append(&nonce.to_xdr(&env));
+    
+    let mut msg_raw = vec![0u8; msg_bytes.len() as usize];
+    msg_bytes.copy_into_slice(&mut msg_raw);
+
+    // Sign the message
+    let signature_bytes = signing_key.sign(&msg_raw).to_bytes();
+    let signature = BytesN::from_array(&env, &signature_bytes);
+
+    // Settle channel
+    client.settle_channel(&channel_id, &merchant_amount, &nonce, &signature);
+
+    // Verify balances after settlement
+    assert_eq!(token_client.balance(&customer), 400i128);
+    assert_eq!(token_client.balance(&merchant), 600i128);
+
+    // Verify channel closed
+    let channel_after = client.get_channel(&channel_id);
+    assert!(!channel_after.open);
+    assert_eq!(channel_after.settled, merchant_amount);
+    assert_eq!(channel_after.nonce, nonce);
+}
+
+#[test]
+fn test_settle_channel_invalid_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let mut rng = thread_rng();
+    let signing_key = SigningKey::generate(&mut rng);
+    let pk_bytes = signing_key.verifying_key().to_bytes();
+    let customer = address_from_pk(&env, pk_bytes);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin.clone());
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+
+    let payment_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &payment_id);
+    client.initialize(&admin);
+
+    token_admin_client.mint(&customer, &1000i128);
+    let channel_id = client.open_channel(&customer, &merchant, &token_id, &1000i128, &0);
+
+    // Message with nonce 0
+    let mut msg = Bytes::new(&env);
+    msg.append(&channel_id.to_xdr(&env));
+    msg.append(&500i128.to_xdr(&env));
+    msg.append(&0u64.to_xdr(&env));
+    let mut msg_raw = vec![0u8; msg.len() as usize];
+    msg.copy_into_slice(&mut msg_raw);
+    let sig = BytesN::from_array(&env, &signing_key.sign(&msg_raw).to_bytes());
+    
+    let result = client.try_settle_channel(&channel_id, &500i128, &0, &sig);
+    assert!(result.is_err());
+    // Since it's a Result<Result<(), Error>, ...>
+    match result {
+        Err(Ok(Error::InvalidNonce)) => {},
+        _ => panic!("Expected InvalidNonce error, got {:?}", result),
+    }
+}
+
+#[test]
+fn test_close_expired_channel() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let admin = Address::generate(&env);
+    
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin.clone());
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    let token_client = token::Client::new(&env, &token_id);
+
+    let payment_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &payment_id);
+    client.initialize(&admin);
+
+    token_admin_client.mint(&customer, &1000i128);
+    
+    let expires_at = 1000u64;
+    env.ledger().set_timestamp(expires_at - 10);
+    
+    let channel_id = client.open_channel(&customer, &merchant, &token_id, &1000i128, &expires_at);
+
+    // Fast forward
+    env.ledger().set_timestamp(expires_at + 1);
+    client.close_channel_expired(&channel_id);
+
+    assert_eq!(token_client.balance(&customer), 1000i128);
+    let channel = client.get_channel(&channel_id);
+    assert!(!channel.open);
+}


### PR DESCRIPTION
Key changes include:
   - New Data Structures: Added PaymentChannel struct and updated DataKey to support channel storage.
   - Contract Functions:
     - open_channel: Allows customers to fund and open a payment channel.
     - settle_channel: Settles the net balance on-chain using a valid customer Ed25519 signature.
     - close_channel_expired: Enables refunding the full balance to the customer if the channel expires without settlement.
     - get_channel: Retrieves current channel state.
   - Security: Implemented replay protection using nonces and signature verification over (channel_id, merchant_amount, nonce).
   - Testing: Added a comprehensive test suite in contracts/payment/src/test_payment_channel.rs covering the full lifecycle and error cases.

Closes #125 