### PR TITLE
feat(escrow): add weighted voting for multi-party escrow approvals (#99)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -184,6 +184,10 @@ pub enum Error {
     RootAlreadyCommitted = 38,
     NoEvidenceRoot = 39,
     EmptyPauseReason = 55,
+    InvalidWeightSum = 56,
+    InvalidThreshold = 57,
+    WeightUpdateLocked = 58,
+    ParticipantNotFound = 59,
 }
 
 #[contractevent]
@@ -247,6 +251,21 @@ pub struct ParticipantApproved {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MultiPartyEscrowReleased {
     pub escrow_id: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WeightUpdated {
+    pub escrow_id: u64,
+    pub participant: Address,
+    pub weight_bps: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThresholdUpdated {
+    pub escrow_id: u64,
+    pub threshold_bps: u32,
 }
 
 #[contractevent]
@@ -468,9 +487,11 @@ pub enum ParticipantRole {
 #[contracttype]
 pub struct Participant {
     pub address: Address,
-    pub share_bps: u32, // basis points out of 10000
     pub role: ParticipantRole,
-    pub required_approval: bool,
+    pub share_bps: u32,  // payout share in basis points (out of 10000)
+    pub weight_bps: u32, // voting weight in basis points (out of 10000)
+    pub approved: bool,
+    pub approved_at: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -482,7 +503,7 @@ pub struct MultiPartyEscrow {
     pub token: Address,
     pub status: EscrowStatus,
     pub approvals: Vec<Address>,
-    pub required_approvals: u32,
+    pub threshold_bps: u32, // cumulative approved weight needed for release
     pub created_at: u64,
     pub release_timestamp: u64,
 }
@@ -947,6 +968,16 @@ pub struct MultiPartyDisputeResolved {
     pub escrow_id: u64,
     pub favor_merchant: bool,
     pub resolved_at: u64,
+}
+
+fn sum_approved_weight(participants: &Vec<Participant>) -> u32 {
+    let mut total: u32 = 0;
+    for p in participants.iter() {
+        if p.approved {
+            total += p.weight_bps;
+        }
+    }
+    total
 }
 
 #[contract]
@@ -1581,19 +1612,29 @@ impl EscrowContract {
 
         // Ensure shares sum to 10000 bps
         let mut total_shares: u32 = 0;
+        let mut total_weights: u32 = 0;
         for p in participants.iter() {
             total_shares += p.share_bps;
+            total_weights += p.weight_bps;
         }
         if total_shares != 10000 {
             return Err(Error::InvalidSharesSum);
         }
+        if total_weights != 10000 {
+            return Err(Error::InvalidWeightSum);
+        }
 
-        // Count required approvals
-        let mut required_approvals: u32 = 0;
+        // Normalize participants (ensure approved=false, approved_at=None at creation)
+        let mut normalized = Vec::new(&env);
         for p in participants.iter() {
-            if p.required_approval {
-                required_approvals += 1;
-            }
+            normalized.push_back(Participant {
+                address: p.address.clone(),
+                role: p.role.clone(),
+                share_bps: p.share_bps,
+                weight_bps: p.weight_bps,
+                approved: false,
+                approved_at: None,
+            });
         }
 
         // Transfer funds from customer to contract
@@ -1611,14 +1652,15 @@ impl EscrowContract {
 
         let current_timestamp = env.ledger().timestamp();
 
+        // Default threshold: full weight (100%). Adjustable via update_approval_threshold_bps.
         let escrow = MultiPartyEscrow {
             id: escrow_id,
-            participants,
+            participants: normalized,
             total_amount,
             token,
             status: EscrowStatus::Locked,
             approvals: Vec::new(&env),
-            required_approvals,
+            threshold_bps: 10000,
             created_at: current_timestamp,
             release_timestamp,
         };
@@ -1660,30 +1702,37 @@ impl EscrowContract {
             return Err(Error::InvalidStatus);
         }
 
-        // Check if caller is a participant and needs to approve
-        let mut is_participant = false;
-        let mut needs_approval = false;
+        // Locate caller in participants. Only participants with weight_bps > 0 may vote.
+        let now = env.ledger().timestamp();
+        let mut updated_participants = Vec::new(&env);
+        let mut found_voter = false;
         for p in escrow.participants.iter() {
             if p.address == caller {
-                is_participant = true;
-                if p.required_approval {
-                    needs_approval = true;
+                if p.weight_bps == 0 {
+                    return Err(Error::Unauthorized);
                 }
-                break;
+                if p.approved {
+                    return Err(Error::DuplicateApproval);
+                }
+                found_voter = true;
+                updated_participants.push_back(Participant {
+                    address: p.address.clone(),
+                    role: p.role.clone(),
+                    share_bps: p.share_bps,
+                    weight_bps: p.weight_bps,
+                    approved: true,
+                    approved_at: Some(now),
+                });
+            } else {
+                updated_participants.push_back(p.clone());
             }
         }
 
-        if !is_participant || !needs_approval {
+        if !found_voter {
             return Err(Error::Unauthorized);
         }
 
-        // Check if already approved
-        for addr in escrow.approvals.iter() {
-            if addr == caller {
-                return Err(Error::DuplicateApproval);
-            }
-        }
-
+        escrow.participants = updated_participants;
         escrow.approvals.push_back(caller.clone());
         env.storage()
             .instance()
@@ -1717,8 +1766,9 @@ impl EscrowContract {
             return Err(Error::InvalidStatus);
         }
 
-        // Check if all required approvals are met
-        if escrow.approvals.len() < escrow.required_approvals {
+        // Check if cumulative approved weight meets the threshold
+        let approved_weight = sum_approved_weight(&escrow.participants);
+        if approved_weight < escrow.threshold_bps {
             return Err(Error::ApprovalsThresholdNotMet);
         }
 
@@ -1763,6 +1813,133 @@ impl EscrowContract {
             .instance()
             .get(&DataKey::MultiPartyEscrow(escrow_id))
             .unwrap())
+    }
+
+    /// Returns (current cumulative approved weight, required threshold) in basis points.
+    pub fn get_approval_weight(env: Env, escrow_id: u64) -> Result<(u32, u32), Error> {
+        let escrow: MultiPartyEscrow = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiPartyEscrow(escrow_id))
+            .ok_or(Error::EscrowNotFound)?;
+        let approved = sum_approved_weight(&escrow.participants);
+        Ok((approved, escrow.threshold_bps))
+    }
+
+    /// Admin updates a participant's voting weight. Blocked once any participant has approved.
+    /// The total participant weight must still sum to 10000 bps after the update.
+    pub fn set_participant_weight(
+        env: Env,
+        admin: Address,
+        escrow_id: u64,
+        participant: Address,
+        weight_bps: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let multisig = Self::get_multisig_config(env.clone());
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        let mut escrow: MultiPartyEscrow = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiPartyEscrow(escrow_id))
+            .ok_or(Error::EscrowNotFound)?;
+
+        if escrow.status != EscrowStatus::Locked {
+            return Err(Error::InvalidStatus);
+        }
+
+        // Block weight updates once any participant has already approved.
+        for p in escrow.participants.iter() {
+            if p.approved {
+                return Err(Error::WeightUpdateLocked);
+            }
+        }
+
+        let mut updated = Vec::new(&env);
+        let mut found = false;
+        let mut new_total: u32 = 0;
+        for p in escrow.participants.iter() {
+            if p.address == participant {
+                found = true;
+                new_total += weight_bps;
+                updated.push_back(Participant {
+                    address: p.address.clone(),
+                    role: p.role.clone(),
+                    share_bps: p.share_bps,
+                    weight_bps,
+                    approved: p.approved,
+                    approved_at: p.approved_at,
+                });
+            } else {
+                new_total += p.weight_bps;
+                updated.push_back(p.clone());
+            }
+        }
+
+        if !found {
+            return Err(Error::ParticipantNotFound);
+        }
+        if new_total != 10000 {
+            return Err(Error::InvalidWeightSum);
+        }
+
+        escrow.participants = updated;
+        env.storage()
+            .instance()
+            .set(&DataKey::MultiPartyEscrow(escrow_id), &escrow);
+
+        WeightUpdated {
+            escrow_id,
+            participant,
+            weight_bps,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Admin updates the approval threshold. Must be in the range (0, 10000].
+    pub fn update_approval_threshold_bps(
+        env: Env,
+        admin: Address,
+        escrow_id: u64,
+        threshold_bps: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let multisig = Self::get_multisig_config(env.clone());
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        if threshold_bps == 0 || threshold_bps > 10000 {
+            return Err(Error::InvalidThreshold);
+        }
+
+        let mut escrow: MultiPartyEscrow = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiPartyEscrow(escrow_id))
+            .ok_or(Error::EscrowNotFound)?;
+
+        if escrow.status != EscrowStatus::Locked {
+            return Err(Error::InvalidStatus);
+        }
+
+        escrow.threshold_bps = threshold_bps;
+        env.storage()
+            .instance()
+            .set(&DataKey::MultiPartyEscrow(escrow_id), &escrow);
+
+        ThresholdUpdated {
+            escrow_id,
+            threshold_bps,
+        }
+        .publish(&env);
+
+        Ok(())
     }
 
     pub fn create_multi_token_escrow(

--- a/contracts/escrow/src/multi_party_dispute_test.rs
+++ b/contracts/escrow/src/multi_party_dispute_test.rs
@@ -15,21 +15,27 @@ fn make_3_party_escrow(
     let mut participants = soroban_sdk::Vec::new(env);
     participants.push_back(Participant {
         address: p1.clone(),
-        share_bps: 4000,
         role: ParticipantRole::Customer,
-        required_approval: true,
+        share_bps: 4000,
+        weight_bps: 4000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p2.clone(),
-        share_bps: 3000,
         role: ParticipantRole::Merchant,
-        required_approval: true,
+        share_bps: 3000,
+        weight_bps: 3000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p3.clone(),
-        share_bps: 3000,
         role: ParticipantRole::ServiceProvider,
-        required_approval: false,
+        share_bps: 3000,
+        weight_bps: 3000,
+        approved: false,
+        approved_at: None,
     });
     client.create_multi_party_escrow(p1, &participants, &1000_i128, token, &9999_u64)
 }

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -1609,21 +1609,27 @@ fn test_create_multi_party_escrow_success() {
     let mut participants = Vec::new(&env);
     participants.push_back(Participant {
         address: p1.clone(),
-        share_bps: 5000,
         role: ParticipantRole::Merchant,
-        required_approval: true,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p2.clone(),
-        share_bps: 3000,
         role: ParticipantRole::ServiceProvider,
-        required_approval: true,
+        share_bps: 3000,
+        weight_bps: 3000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p3.clone(),
-        share_bps: 2000,
         role: ParticipantRole::Arbitrator,
-        required_approval: false,
+        share_bps: 2000,
+        weight_bps: 2000,
+        approved: false,
+        approved_at: None,
     });
 
     let release_timestamp = 1000_u64;
@@ -1638,7 +1644,7 @@ fn test_create_multi_party_escrow_success() {
     let escrow = client.get_multi_party_escrow(&escrow_id);
     assert_eq!(escrow.id, 1);
     assert_eq!(escrow.total_amount, amount);
-    assert_eq!(escrow.required_approvals, 2);
+    assert_eq!(escrow.threshold_bps, 10000);
     assert_eq!(escrow.status, EscrowStatus::Locked);
 
     // Verify tokens were transferred to contract
@@ -2022,15 +2028,19 @@ fn test_create_multi_party_escrow_invalid_shares() {
     let mut participants = Vec::new(&env);
     participants.push_back(Participant {
         address: Address::generate(&env),
-        share_bps: 5000,
         role: ParticipantRole::Merchant,
-        required_approval: true,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: Address::generate(&env),
-        share_bps: 4000, // Sum is 9000, should fail
         role: ParticipantRole::Merchant,
-        required_approval: true,
+        share_bps: 4000, // Sum is 9000, should fail
+        weight_bps: 4000,
+        approved: false,
+        approved_at: None,
     });
 
     client.create_multi_party_escrow(&customer, &participants, &1000, &token_id, &1000);
@@ -2057,15 +2067,19 @@ fn test_approve_release_success() {
     let mut participants = Vec::new(&env);
     participants.push_back(Participant {
         address: p1.clone(),
-        share_bps: 5000,
         role: ParticipantRole::Merchant,
-        required_approval: true,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p2.clone(),
-        share_bps: 5000,
         role: ParticipantRole::ServiceProvider,
-        required_approval: true,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
     });
 
     let escrow_id =
@@ -2105,21 +2119,27 @@ fn test_release_multi_party_escrow_success() {
     let mut participants = Vec::new(&env);
     participants.push_back(Participant {
         address: p1.clone(),
-        share_bps: 5000, // 5000
         role: ParticipantRole::Merchant,
-        required_approval: true,
+        share_bps: 5000, // 5000
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p2.clone(),
-        share_bps: 3000, // 3000
         role: ParticipantRole::ServiceProvider,
-        required_approval: true,
+        share_bps: 3000, // 3000
+        weight_bps: 3000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p3.clone(),
-        share_bps: 2000, // 2000
         role: ParticipantRole::Arbitrator,
-        required_approval: false,
+        share_bps: 2000, // 2000
+        weight_bps: 2000,
+        approved: false,
+        approved_at: None,
     });
 
     env.ledger().set_timestamp(500);
@@ -2355,15 +2375,19 @@ fn test_release_multi_party_escrow_threshold_not_met() {
     let mut participants = Vec::new(&env);
     participants.push_back(Participant {
         address: p1.clone(),
-        share_bps: 5000,
         role: ParticipantRole::Merchant,
-        required_approval: true,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
     });
     participants.push_back(Participant {
         address: p2.clone(),
-        share_bps: 5000,
         role: ParticipantRole::ServiceProvider,
-        required_approval: true,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
     });
 
     let escrow_id =
@@ -2374,6 +2398,232 @@ fn test_release_multi_party_escrow_threshold_not_met() {
 
     env.ledger().set_timestamp(1001);
     client.release_multi_party_escrow(&escrow_id);
+}
+
+// ── WEIGHTED VOTING TESTS ───────────────────────────────────────────────────
+
+fn make_weighted_escrow(
+    env: &Env,
+    client: &EscrowContractClient,
+    customer: &Address,
+    p_merchant: &Address,
+    p_investor: &Address,
+    token: &Address,
+) -> u64 {
+    // 60% merchant / 40% investor — both share and voting weight
+    let mut participants = Vec::new(env);
+    participants.push_back(Participant {
+        address: p_merchant.clone(),
+        role: ParticipantRole::Merchant,
+        share_bps: 6000,
+        weight_bps: 6000,
+        approved: false,
+        approved_at: None,
+    });
+    participants.push_back(Participant {
+        address: p_investor.clone(),
+        role: ParticipantRole::Custom(String::from_str(env, "investor")),
+        share_bps: 4000,
+        weight_bps: 4000,
+        approved: false,
+        approved_at: None,
+    });
+    client.create_multi_party_escrow(customer, &participants, &10000_i128, token, &1000_u64)
+}
+
+#[test]
+fn test_weighted_threshold_met_releases() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let token_user_client = token::Client::new(&env, &token_id);
+    token::StellarAssetClient::new(&env, &token_id).mint(&Address::generate(&env), &0); // touch
+
+    let customer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token_id).mint(&customer, &10000);
+
+    let merchant = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    let escrow_id = make_weighted_escrow(&env, &client, &customer, &merchant, &investor, &token_id);
+
+    // Lower threshold to 60% — merchant alone can authorize release.
+    client.update_approval_threshold_bps(&admin, &escrow_id, &6000);
+
+    client.approve_release(&merchant, &escrow_id);
+
+    let (current, required) = client.get_approval_weight(&escrow_id);
+    assert_eq!(current, 6000);
+    assert_eq!(required, 6000);
+
+    env.ledger().set_timestamp(1001);
+    client.release_multi_party_escrow(&escrow_id);
+
+    let escrow = client.get_multi_party_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(token_user_client.balance(&merchant), 6000);
+    assert_eq!(token_user_client.balance(&investor), 4000);
+}
+
+#[test]
+fn test_weighted_threshold_unmet_holds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let customer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token_id).mint(&customer, &10000);
+
+    let merchant = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    let escrow_id = make_weighted_escrow(&env, &client, &customer, &merchant, &investor, &token_id);
+
+    // Default threshold is 10000 (full weight). Only 60% approves — release must hold.
+    client.approve_release(&merchant, &escrow_id);
+
+    let (current, required) = client.get_approval_weight(&escrow_id);
+    assert_eq!(current, 6000);
+    assert_eq!(required, 10000);
+
+    env.ledger().set_timestamp(1001);
+    let result = client.try_release_multi_party_escrow(&escrow_id);
+    assert_eq!(result, Err(Ok(Error::ApprovalsThresholdNotMet)));
+
+    let escrow = client.get_multi_party_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Locked);
+}
+
+#[test]
+fn test_create_multi_party_escrow_invalid_weight_sum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let customer = Address::generate(&env);
+    let token_id = Address::generate(&env);
+
+    let mut participants = Vec::new(&env);
+    participants.push_back(Participant {
+        address: Address::generate(&env),
+        role: ParticipantRole::Merchant,
+        share_bps: 6000,
+        weight_bps: 5000, // weights sum to 9000 — should fail
+        approved: false,
+        approved_at: None,
+    });
+    participants.push_back(Participant {
+        address: Address::generate(&env),
+        role: ParticipantRole::ServiceProvider,
+        share_bps: 4000,
+        weight_bps: 4000,
+        approved: false,
+        approved_at: None,
+    });
+
+    let result =
+        client.try_create_multi_party_escrow(&customer, &participants, &10000, &token_id, &1000);
+    assert_eq!(result, Err(Ok(Error::InvalidWeightSum)));
+}
+
+#[test]
+fn test_set_participant_weight_blocked_after_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let customer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token_id).mint(&customer, &10000);
+
+    let merchant = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    let escrow_id = make_weighted_escrow(&env, &client, &customer, &merchant, &investor, &token_id);
+
+    // Admin can adjust weights pre-approval, as long as the new total is still 10000.
+    client.set_participant_weight(&admin, &escrow_id, &merchant, &7000);
+    client.set_participant_weight(&admin, &escrow_id, &investor, &3000);
+
+    // Once any participant approves, weight updates are locked.
+    client.approve_release(&merchant, &escrow_id);
+    let result = client.try_set_participant_weight(&admin, &escrow_id, &merchant, &8000);
+    assert_eq!(result, Err(Ok(Error::WeightUpdateLocked)));
+}
+
+#[test]
+fn test_set_participant_weight_must_keep_sum_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let customer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token_id).mint(&customer, &10000);
+
+    let merchant = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    let escrow_id = make_weighted_escrow(&env, &client, &customer, &merchant, &investor, &token_id);
+
+    // Bumping merchant alone breaks the 10000 invariant.
+    let result = client.try_set_participant_weight(&admin, &escrow_id, &merchant, &7000);
+    assert_eq!(result, Err(Ok(Error::InvalidWeightSum)));
+}
+
+#[test]
+fn test_update_approval_threshold_invalid_range() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let customer = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &token_id).mint(&customer, &10000);
+
+    let merchant = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    let escrow_id = make_weighted_escrow(&env, &client, &customer, &merchant, &investor, &token_id);
+
+    let too_low = client.try_update_approval_threshold_bps(&admin, &escrow_id, &0);
+    assert_eq!(too_low, Err(Ok(Error::InvalidThreshold)));
+
+    let too_high = client.try_update_approval_threshold_bps(&admin, &escrow_id, &10001);
+    assert_eq!(too_high, Err(Ok(Error::InvalidThreshold)));
 }
 
 // ── MULTI-SIG ADMIN TESTS ────────────────────────────────────────────────────


### PR DESCRIPTION
- Replace one-address-one-vote with stake-weighted approvals using per-participant weight_bps and a configurable threshold_bps.
- Track per-participant approval state (approved + approved_at) on the escrow itself so weights can be summed deterministically.
- Add set_participant_weight, get_approval_weight, and update_approval_threshold_bps admin/query helpers.
- Add WeightUpdated and ThresholdUpdated events.
- Tests cover threshold-met release, threshold-unmet hold, weight sum validation, weight-update lock after first approval, and threshold range validation.

Closes #99 