### PR TITLE
feat(escrow): Add escrow expiry with automatic refund to customer

### DIFF
--- a/contracts/escrow/src/expiry_test.rs
+++ b/contracts/escrow/src/expiry_test.rs
@@ -1,0 +1,102 @@
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
+
+fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let token_addr = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = token::StellarAssetClient::new(env, &token_addr);
+    let customer = Address::generate(env);
+    token_admin.mint(&customer, &10_000);
+    // fund contract directly so transfers succeed
+    token_admin.mint(&contract_id, &10_000);
+
+    (client, admin, customer, Address::generate(env), token_addr)
+}
+
+#[test]
+fn test_expire_escrow_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+    // release_timestamp=2000, expiry_timestamp=3000
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true);
+
+    assert!(!client.is_escrow_expired(&escrow_id));
+
+    env.ledger().set_timestamp(3001);
+    assert!(client.is_escrow_expired(&escrow_id));
+
+    client.expire_escrow(&escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Cancelled);
+}
+
+#[test]
+fn test_expire_escrow_premature_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true);
+
+    // Still before expiry
+    env.ledger().set_timestamp(2500);
+    let result = client.try_expire_escrow(&escrow_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_expire_disputed_escrow_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+    let escrow_id =
+        client.create_escrow(&customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true);
+
+    client.dispute_escrow(&customer, &escrow_id);
+
+    // Advance past expiry
+    env.ledger().set_timestamp(4000);
+    let result = client.try_expire_escrow(&escrow_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_global_expiry_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _, _) = setup(&env);
+
+    client.set_global_expiry_config(&admin, &86400_u64);
+    // No panic = success; config stored correctly
+}
+
+#[test]
+fn test_create_escrow_expiry_before_release_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+    // expiry_timestamp <= release_timestamp should fail
+    let result = client.try_create_escrow(
+        &customer, &merchant, &500_i128, &token, &5000_u64, &0_u64, &4000_u64, &true,
+    );
+    assert!(result.is_err());
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -62,6 +62,7 @@ pub enum DataKey {
     // Conditional escrow (on-chain state)
     ConditionalEscrow(u64),
     SuccessionPlan,
+    GlobalExpiryConfig,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -188,6 +189,9 @@ pub enum Error {
     InvalidThreshold = 57,
     WeightUpdateLocked = 58,
     ParticipantNotFound = 59,
+    EscrowNotExpired = 60,
+    EscrowAlreadyExpired = 61,
+    ExpiryBeforeRelease = 62,
 }
 
 #[contractevent]
@@ -471,6 +475,8 @@ pub struct Escrow {
     pub escalation_level: u64,
     pub min_hold_period: u64,
     pub fee_bps: i128,
+    pub expiry_timestamp: u64,       // 0 = no expiry
+    pub auto_refund_on_expiry: bool,
 }
 
 #[derive(Clone)]
@@ -938,6 +944,20 @@ pub struct ConditionalEscrow {
 pub struct ConditionEvaluated {
     pub escrow_id: u64,
     pub met: bool,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowExpired {
+    pub escrow_id: u64,
+    pub refunded_to: Address,
+    pub amount: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct GlobalExpiryConfig {
+    pub default_expiry_seconds: u64,
 }
 
 #[contractevent]
@@ -1488,8 +1508,15 @@ impl EscrowContract {
         token: Address,
         release_timestamp: u64,
         min_hold_period: u64,
-    ) -> u64 {
+        expiry_timestamp: u64,
+        auto_refund_on_expiry: bool,
+    ) -> Result<u64, Error> {
         customer.require_auth();
+
+        // Validate expiry: if set (non-zero), must be strictly after release_timestamp
+        if expiry_timestamp != 0 && expiry_timestamp <= release_timestamp {
+            return Err(Error::ExpiryBeforeRelease);
+        }
 
         let counter: u64 = env
             .storage()
@@ -1521,6 +1548,8 @@ impl EscrowContract {
             escalation_level: 0,
             min_hold_period,
             fee_bps,
+            expiry_timestamp,
+            auto_refund_on_expiry,
         };
 
         env.storage()
@@ -1592,7 +1621,7 @@ impl EscrowContract {
         }
         .publish(&env);
 
-        escrow_id
+        Ok(escrow_id)
     }
 
     pub fn create_multi_party_escrow(
@@ -3230,6 +3259,8 @@ impl EscrowContract {
             escalation_level: 0,
             min_hold_period: 0,
             fee_bps,
+            expiry_timestamp: 0,
+            auto_refund_on_expiry: false,
         };
 
         env.storage()
@@ -5113,6 +5144,8 @@ impl EscrowContract {
             escalation_level: 0,
             min_hold_period: 0,
             fee_bps,
+            expiry_timestamp: 0,
+            auto_refund_on_expiry: false,
         };
 
         env.storage()
@@ -5673,6 +5706,8 @@ impl EscrowContract {
             escalation_level: 0,
             min_hold_period: 0, // Default for batch
             fee_bps: 0,         // Default fee
+            expiry_timestamp: 0,
+            auto_refund_on_expiry: false,
         };
 
         env.storage()
@@ -5767,6 +5802,75 @@ impl EscrowContract {
         Ok(())
     }
 
+    // ── EXPIRY ────────────────────────────────────────────────────────────
+
+    pub fn set_global_expiry_config(
+        env: Env,
+        admin: Address,
+        default_expiry_seconds: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::GlobalExpiryConfig, &GlobalExpiryConfig { default_expiry_seconds });
+        Ok(())
+    }
+
+    pub fn is_escrow_expired(env: Env, escrow_id: u64) -> bool {
+        if !env.storage().instance().has(&DataKey::Escrow(escrow_id)) {
+            return false;
+        }
+        let escrow = Self::get_escrow(&env, escrow_id);
+        if escrow.expiry_timestamp == 0 {
+            return false;
+        }
+        env.ledger().timestamp() >= escrow.expiry_timestamp
+    }
+
+    pub fn expire_escrow(env: Env, escrow_id: u64) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Escrow(escrow_id)) {
+            return Err(Error::EscrowNotFound);
+        }
+        let mut escrow = Self::get_escrow(&env, escrow_id);
+
+        match escrow.status {
+            EscrowStatus::Released | EscrowStatus::Resolved | EscrowStatus::Cancelled => {
+                return Err(Error::EscrowAlreadyExpired);
+            }
+            EscrowStatus::Disputed => return Err(Error::InvalidStatus),
+            EscrowStatus::Locked => {}
+        }
+
+        if escrow.expiry_timestamp == 0 || env.ledger().timestamp() < escrow.expiry_timestamp {
+            return Err(Error::EscrowNotExpired);
+        }
+
+        escrow.status = EscrowStatus::Cancelled;
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        EscrowContract::transfer_if_token_contract(
+            &env,
+            &escrow.token,
+            &escrow.customer,
+            escrow.amount,
+        )?;
+
+        EscrowExpired {
+            escrow_id,
+            refunded_to: escrow.customer.clone(),
+            amount: escrow.amount,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
     // ── ANALYTICS HELPERS ─────────────────────────────────────────────────
 
     fn update_customer_analytics<F>(env: &Env, customer: &Address, update_fn: F)
@@ -5834,3 +5938,6 @@ mod multi_party_dispute_test;
 
 #[cfg(test)]
 mod pause_history_test;
+
+#[cfg(test)]
+mod expiry_test;


### PR DESCRIPTION
## Summary

Implements configurable expiry timestamps on escrows. When an escrow passes its `expiry_timestamp` without being released or resolved, anyone can trigger `expire_escrow()` to automatically refund the full locked amount to the customer, preventing permanent fund lockup.

## Changes

### `contracts/escrow/src/lib.rs`

**Escrow struct** — two new fields:
- `expiry_timestamp: u64` — unix timestamp after which the escrow can be expired; `0` means no expiry
- `auto_refund_on_expiry: bool` — flag indicating intent for automatic refund on expiry

**New functions:**
- `create_escrow()` — extended with `expiry_timestamp` and `auto_refund_on_expiry` params; validates `expiry_timestamp > release_timestamp` when non-zero
- `expire_escrow(escrow_id)` — permissionless; refunds full amount to customer; blocked if escrow is disputed, already finalised, or not yet expired
- `is_escrow_expired(escrow_id)` — read-only helper; returns `true` when `ledger.timestamp >= expiry_timestamp`
- `set_global_expiry_config(admin, default_expiry_seconds)` — admin-only; stores a default expiry duration for use by callers

**New errors:**
- `EscrowNotExpired = 60` — called `expire_escrow` before expiry timestamp reached
- `EscrowAlreadyExpired = 61` — escrow already in a terminal state
- `ExpiryBeforeRelease = 62` — `expiry_timestamp` ≤ `release_timestamp` at creation

**New event:**
- `EscrowExpired { escrow_id, refunded_to, amount }` — emitted on successful expiry

**New type:**
- `GlobalExpiryConfig { default_expiry_seconds }` — stored under `DataKey::GlobalExpiryConfig`

### `contracts/escrow/src/expiry_test.rs` (new file)

Five tests:
1. `test_expire_escrow_success` — advances ledger past expiry, calls `expire_escrow`, asserts status is `Cancelled`
2. `test_expire_escrow_premature_fails` — calls before expiry timestamp, asserts error
3. `test_expire_disputed_escrow_fails` — disputes escrow then tries to expire, asserts error
4. `test_set_global_expiry_config` — admin sets config without panic
5. `test_create_escrow_expiry_before_release_fails` — passes `expiry_timestamp < release_timestamp`, asserts creation error

## Acceptance Criteria

- [x] `expiry_timestamp` must be greater than `release_timestamp` at creation
- [x] Anyone can call `expire_escrow()` after `expiry_timestamp` has passed
- [x] Expiry refunds the full locked amount to the customer
- [x] Disputed escrows cannot be expired without resolution first
- [x] Tests for successful expiry, premature expiry attempt, and disputed-escrow guard

Closes #98