### PR TITLE
feat(escrow): implement escrow state migration for contract upgrades …

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -63,6 +63,9 @@ pub enum DataKey {
     ConditionalEscrow(u64),
     SuccessionPlan,
     GlobalExpiryConfig,
+    // Migration
+    MigrationStatusKey,
+    EscrowMigrated(u64),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -192,6 +195,9 @@ pub enum Error {
     EscrowNotExpired = 60,
     EscrowAlreadyExpired = 61,
     ExpiryBeforeRelease = 62,
+    MigrationNotStarted = 63,
+    MigrationAlreadyComplete = 64,
+    AlreadyMigrated = 65,
 }
 
 #[contractevent]
@@ -960,6 +966,16 @@ pub struct GlobalExpiryConfig {
     pub default_expiry_seconds: u64,
 }
 
+#[derive(Clone)]
+#[contracttype]
+pub struct MigrationStatus {
+    pub in_progress: bool,
+    pub migrated_count: u64,
+    pub total_count: u64,
+    pub started_at: u64,
+    pub completed_at: Option<u64>,
+}
+
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConditionalReleaseExecuted {
@@ -1512,6 +1528,17 @@ impl EscrowContract {
         auto_refund_on_expiry: bool,
     ) -> Result<u64, Error> {
         customer.require_auth();
+
+        // Block new escrow creation during migration
+        if let Some(status) = env
+            .storage()
+            .instance()
+            .get::<DataKey, MigrationStatus>(&DataKey::MigrationStatusKey)
+        {
+            if status.in_progress {
+                return Err(Error::ContractPaused);
+            }
+        }
 
         // Validate expiry: if set (non-zero), must be strictly after release_timestamp
         if expiry_timestamp != 0 && expiry_timestamp <= release_timestamp {
@@ -4637,6 +4664,197 @@ impl EscrowContract {
         false
     }
 
+    // ── MIGRATION ─────────────────────────────────────────────────────────────
+
+    pub fn begin_migration(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let multisig = Self::get_multisig_config(env.clone());
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        if let Some(status) = env
+            .storage()
+            .instance()
+            .get::<DataKey, MigrationStatus>(&DataKey::MigrationStatusKey)
+        {
+            if !status.in_progress && status.completed_at.is_some() {
+                return Err(Error::MigrationAlreadyComplete);
+            }
+        }
+
+        let total_count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EscrowCounter)
+            .unwrap_or(0);
+
+        let status = MigrationStatus {
+            in_progress: true,
+            migrated_count: 0,
+            total_count,
+            started_at: env.ledger().timestamp(),
+            completed_at: None,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::MigrationStatusKey, &status);
+        Ok(())
+    }
+
+    pub fn migrate_escrow(env: Env, admin: Address, escrow_id: u64) -> Result<(), Error> {
+        admin.require_auth();
+        let multisig = Self::get_multisig_config(env.clone());
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        let mut status: MigrationStatus = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigrationStatusKey)
+            .ok_or(Error::MigrationNotStarted)?;
+
+        if !status.in_progress {
+            return Err(Error::MigrationNotStarted);
+        }
+
+        if env
+            .storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::EscrowMigrated(escrow_id))
+            .unwrap_or(false)
+        {
+            return Err(Error::AlreadyMigrated);
+        }
+
+        // Read and re-write the escrow record (applies any new-format defaults)
+        let escrow: Escrow = env
+            .storage()
+            .instance()
+            .get(&DataKey::Escrow(escrow_id))
+            .ok_or(Error::EscrowNotFound)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowMigrated(escrow_id), &true);
+
+        status.migrated_count += 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::MigrationStatusKey, &status);
+
+        Ok(())
+    }
+
+    pub fn migrate_escrow_batch(
+        env: Env,
+        admin: Address,
+        escrow_ids: Vec<u64>,
+    ) -> Result<u32, Error> {
+        admin.require_auth();
+        let multisig = Self::get_multisig_config(env.clone());
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        let status: MigrationStatus = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigrationStatusKey)
+            .ok_or(Error::MigrationNotStarted)?;
+
+        if !status.in_progress {
+            return Err(Error::MigrationNotStarted);
+        }
+
+        let mut migrated: u32 = 0;
+        for escrow_id in escrow_ids.iter() {
+            // Skip already-migrated entries silently in batch mode
+            if env
+                .storage()
+                .instance()
+                .get::<DataKey, bool>(&DataKey::EscrowMigrated(escrow_id))
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            if let Some(escrow) = env
+                .storage()
+                .instance()
+                .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+            {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Escrow(escrow_id), &escrow);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::EscrowMigrated(escrow_id), &true);
+                migrated += 1;
+            }
+        }
+
+        // Update migrated_count
+        let mut updated_status: MigrationStatus = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigrationStatusKey)
+            .ok_or(Error::MigrationNotStarted)?;
+        updated_status.migrated_count += migrated as u64;
+        env.storage()
+            .instance()
+            .set(&DataKey::MigrationStatusKey, &updated_status);
+
+        Ok(migrated)
+    }
+
+    pub fn complete_migration(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let multisig = Self::get_multisig_config(env.clone());
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        let mut status: MigrationStatus = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigrationStatusKey)
+            .ok_or(Error::MigrationNotStarted)?;
+
+        if !status.in_progress {
+            return Err(Error::MigrationNotStarted);
+        }
+
+        if status.migrated_count < status.total_count {
+            return Err(Error::MigrationNotStarted);
+        }
+
+        status.in_progress = false;
+        status.completed_at = Some(env.ledger().timestamp());
+        env.storage()
+            .instance()
+            .set(&DataKey::MigrationStatusKey, &status);
+
+        Ok(())
+    }
+
+    pub fn get_migration_status(env: Env) -> MigrationStatus {
+        env.storage()
+            .instance()
+            .get(&DataKey::MigrationStatusKey)
+            .unwrap_or(MigrationStatus {
+                in_progress: false,
+                migrated_count: 0,
+                total_count: 0,
+                started_at: 0,
+                completed_at: None,
+            })
+    }
+
     fn require_not_paused(env: &Env, function_name: &str) -> Result<(), Error> {
         if let Some(state) = env
             .storage()
@@ -5941,3 +6159,6 @@ mod pause_history_test;
 
 #[cfg(test)]
 mod expiry_test;
+
+#[cfg(test)]
+mod migration_test;

--- a/contracts/escrow/src/migration_test.rs
+++ b/contracts/escrow/src/migration_test.rs
@@ -1,0 +1,210 @@
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    let customer = Address::generate(env);
+    let merchant = Address::generate(env);
+    let token = Address::generate(env);
+    (client, admin, customer, merchant, token)
+}
+
+// ── MIGRATION FLOW ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_begin_migration_sets_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    // Create a couple of escrows first
+    client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+
+    env.ledger().set_timestamp(100);
+    client.begin_migration(&admin);
+
+    let status = client.get_migration_status();
+    assert!(status.in_progress);
+    assert_eq!(status.total_count, 2);
+    assert_eq!(status.migrated_count, 0);
+    assert_eq!(status.started_at, 100);
+    assert!(status.completed_at.is_none());
+}
+
+#[test]
+fn test_migrate_escrow_single() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let id = client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    client.begin_migration(&admin);
+    client.migrate_escrow(&admin, &id);
+
+    let status = client.get_migration_status();
+    assert_eq!(status.migrated_count, 1);
+}
+
+#[test]
+fn test_complete_migration_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let id1 = client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    let id2 = client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+
+    env.ledger().set_timestamp(200);
+    client.begin_migration(&admin);
+    client.migrate_escrow(&admin, &id1);
+    client.migrate_escrow(&admin, &id2);
+
+    env.ledger().set_timestamp(300);
+    client.complete_migration(&admin);
+
+    let status = client.get_migration_status();
+    assert!(!status.in_progress);
+    assert_eq!(status.completed_at, Some(300));
+}
+
+#[test]
+fn test_migrate_escrow_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let id1 = client.create_escrow(&customer, &merchant, &100_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    let id2 = client.create_escrow(&customer, &merchant, &200_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    let id3 = client.create_escrow(&customer, &merchant, &300_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+
+    client.begin_migration(&admin);
+
+    let ids = vec![&env, id1, id2, id3];
+    let count = client.migrate_escrow_batch(&admin, &ids);
+    assert_eq!(count, 3);
+
+    let status = client.get_migration_status();
+    assert_eq!(status.migrated_count, 3);
+}
+
+// ── BLOCKED CREATION DURING MIGRATION ────────────────────────────────────────
+
+#[test]
+fn test_create_escrow_blocked_during_migration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    client.begin_migration(&admin);
+
+    let result = client.try_create_escrow(
+        &customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
+    );
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+#[test]
+fn test_create_escrow_allowed_after_migration_complete() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    // No escrows yet — begin and immediately complete
+    client.begin_migration(&admin);
+    client.complete_migration(&admin);
+
+    // Should succeed now
+    let id = client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    assert_eq!(id, 1);
+}
+
+// ── DOUBLE-MIGRATION GUARD ────────────────────────────────────────────────────
+
+#[test]
+fn test_double_migrate_returns_already_migrated() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let id = client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    client.begin_migration(&admin);
+    client.migrate_escrow(&admin, &id);
+
+    let result = client.try_migrate_escrow(&admin, &id);
+    assert_eq!(result, Err(Ok(Error::AlreadyMigrated)));
+}
+
+#[test]
+fn test_batch_skips_already_migrated() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let id1 = client.create_escrow(&customer, &merchant, &100_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    let id2 = client.create_escrow(&customer, &merchant, &200_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+
+    client.begin_migration(&admin);
+    client.migrate_escrow(&admin, &id1); // migrate id1 first
+
+    // Batch includes id1 again — should skip it, only count id2
+    let ids = vec![&env, id1, id2];
+    let count = client.migrate_escrow_batch(&admin, &ids);
+    assert_eq!(count, 1);
+
+    let status = client.get_migration_status();
+    assert_eq!(status.migrated_count, 2); // 1 from single + 1 from batch
+}
+
+// ── COMPLETE FAILS IF NOT ALL MIGRATED ───────────────────────────────────────
+
+#[test]
+fn test_complete_migration_fails_if_not_all_migrated() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+
+    client.begin_migration(&admin);
+    // Only migrate one of two
+    client.migrate_escrow(&admin, &1);
+
+    let result = client.try_complete_migration(&admin);
+    assert!(result.is_err());
+}
+
+// ── MIGRATE WITHOUT BEGIN ─────────────────────────────────────────────────────
+
+#[test]
+fn test_migrate_without_begin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let id = client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+
+    let result = client.try_migrate_escrow(&admin, &id);
+    assert_eq!(result, Err(Ok(Error::MigrationNotStarted)));
+}
+
+// ── UNAUTHORIZED ADMIN ────────────────────────────────────────────────────────
+
+#[test]
+fn test_begin_migration_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _customer, _merchant, _token) = setup(&env);
+
+    let not_admin = Address::generate(&env);
+    let result = client.try_begin_migration(&not_admin);
+    assert_eq!(result, Err(Ok(Error::NotAnAdmin)));
+}


### PR DESCRIPTION
closes #109

- Add MigrationStatus struct with in_progress, migrated_count, total_count, started_at, completed_at fields
- Add DataKey variants: MigrationStatusKey, EscrowMigrated(u64)
- Add error variants: MigrationNotStarted=63, MigrationAlreadyComplete=64, AlreadyMigrated=65
- Implement begin_migration, migrate_escrow, migrate_escrow_batch, complete_migration, get_migration_status
- Block create_escrow during active migration (returns ContractPaused)
- Add migration_test.rs with 11 tests covering full flow, blocked creation, double-migration guard, batch, and auth checks