### PR TITLE
Feat/usage billing escrow improvements

### DIFF
--- a/contracts/escrow/src/bulk_evidence_test.rs
+++ b/contracts/escrow/src/bulk_evidence_test.rs
@@ -1,0 +1,109 @@
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::{testutils::Address as _, token, Address, Bytes, Env, Vec};
+
+fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address) {
+    env.mock_all_auths();
+    let id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let token_addr = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = token::StellarAssetClient::new(env, &token_addr);
+    let customer = Address::generate(env);
+    token_admin.mint(&customer, &10_000i128);
+    token_admin.mint(&id, &10_000i128);
+
+    (client, admin, customer, Address::generate(env), token_addr)
+}
+
+fn make_disputed_escrow(
+    env: &Env,
+    client: &EscrowContractClient,
+    customer: &Address,
+    merchant: &Address,
+    token: &Address,
+) -> u64 {
+    let escrow_id = client.create_escrow(
+        customer, merchant, &500i128, token,
+        &9999u64, &0u64, &0u64, &false,
+    );
+    client.dispute_escrow(customer, &escrow_id);
+    escrow_id
+}
+
+#[test]
+fn test_batch_submission_stores_all_items() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    let mut items: Vec<Bytes> = Vec::new(&env);
+    items.push_back(Bytes::from_array(&env, &[1u8; 32]));
+    items.push_back(Bytes::from_array(&env, &[2u8; 32]));
+    items.push_back(Bytes::from_array(&env, &[3u8; 32]));
+
+    let page_count = client.submit_evidence_batch(&customer, &escrow_id, &items);
+    assert_eq!(page_count, 1u32);
+
+    let page = client.get_evidence_page(&escrow_id, &0u32);
+    assert_eq!(page.len(), 3u32);
+}
+
+#[test]
+fn test_oversized_batch_rejected() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    let mut items: Vec<Bytes> = Vec::new(&env);
+    for _ in 0..11u32 {
+        items.push_back(Bytes::from_array(&env, &[0u8; 32]));
+    }
+
+    let result = client.try_submit_evidence_batch(&customer, &escrow_id, &items);
+    assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
+}
+
+#[test]
+fn test_pagination_two_pages() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    let mut batch1: Vec<Bytes> = Vec::new(&env);
+    for _ in 0..10u32 {
+        batch1.push_back(Bytes::from_array(&env, &[1u8; 32]));
+    }
+    client.submit_evidence_batch(&customer, &escrow_id, &batch1);
+
+    let mut batch2: Vec<Bytes> = Vec::new(&env);
+    batch2.push_back(Bytes::from_array(&env, &[2u8; 32]));
+    let page_count = client.submit_evidence_batch(&merchant, &escrow_id, &batch2);
+    assert_eq!(page_count, 2u32);
+
+    assert_eq!(client.get_evidence_page(&escrow_id, &0u32).len(), 10u32);
+    assert_eq!(client.get_evidence_page(&escrow_id, &1u32).len(), 1u32);
+}
+
+#[test]
+fn test_backward_compat_get_evidence_still_works() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    client.submit_evidence(
+        &customer,
+        &escrow_id,
+        &soroban_sdk::String::from_str(&env, "QmOldHash"),
+    );
+
+    let items = client.get_evidence(&escrow_id, &10u64, &0u64);
+    assert_eq!(items.len(), 1u32);
+    assert_eq!(
+        items.get(0).unwrap().ipfs_hash,
+        soroban_sdk::String::from_str(&env, "QmOldHash")
+    );
+}

--- a/contracts/escrow/src/escalation_timeout_test.rs
+++ b/contracts/escrow/src/escalation_timeout_test.rs
@@ -1,0 +1,118 @@
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::{testutils::{Address as _, Ledger}, token, Address, Env};
+
+fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address) {
+    env.mock_all_auths();
+    let id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let token_addr = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = token::StellarAssetClient::new(env, &token_addr);
+    let customer = Address::generate(env);
+    token_admin.mint(&customer, &10_000i128);
+    token_admin.mint(&id, &10_000i128);
+
+    (client, admin, customer, Address::generate(env), token_addr)
+}
+
+fn make_disputed_escrow(
+    env: &Env,
+    client: &EscrowContractClient,
+    customer: &Address,
+    merchant: &Address,
+    token: &Address,
+) -> u64 {
+    env.ledger().set_timestamp(1000);
+    let escrow_id = client.create_escrow(
+        customer, merchant, &1000i128, token,
+        &9000u64, &0u64, &0u64, &false,
+    );
+    client.dispute_escrow(customer, &escrow_id);
+    escrow_id
+}
+
+#[test]
+fn test_trigger_timeout_fails_if_not_escalated() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    env.ledger().set_timestamp(100_000);
+    // Never called escalate_dispute, so escalated_at is None → InvalidStatus
+    let result = client.try_trigger_timeout_resolution(&escrow_id);
+    assert_eq!(result, Err(Ok(Error::InvalidStatus)));
+}
+
+#[test]
+fn test_trigger_timeout_fails_before_deadline() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+    client.set_escalation_config(&admin, &300u64, &AutoResolveFavor::Customer);
+
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    env.ledger().set_timestamp(1500);
+    client.escalate_dispute(&customer, &escrow_id);
+
+    // Only 100s elapsed, timeout=300
+    env.ledger().set_timestamp(1600);
+    let result = client.try_trigger_timeout_resolution(&escrow_id);
+    assert_eq!(result, Err(Ok(Error::TimeoutNotReached)));
+}
+
+#[test]
+fn test_trigger_timeout_resolves_in_favor_of_customer() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+    client.set_escalation_config(&admin, &300u64, &AutoResolveFavor::Customer);
+
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    env.ledger().set_timestamp(1500);
+    client.escalate_dispute(&customer, &escrow_id);
+
+    env.ledger().set_timestamp(1500 + 301);
+    client.trigger_timeout_resolution(&escrow_id);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Resolved);
+}
+
+#[test]
+fn test_trigger_timeout_split_equal() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+    client.set_escalation_config(&admin, &300u64, &AutoResolveFavor::SplitEqual);
+
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    let token_client = token::Client::new(&env, &token);
+    let customer_before = token_client.balance(&customer);
+    let merchant_before = token_client.balance(&merchant);
+
+    env.ledger().set_timestamp(1500);
+    client.escalate_dispute(&customer, &escrow_id);
+    env.ledger().set_timestamp(1500 + 301);
+    client.trigger_timeout_resolution(&escrow_id);
+
+    let customer_after = token_client.balance(&customer);
+    let merchant_after = token_client.balance(&merchant);
+
+    // escrow amount=1000 split evenly
+    assert_eq!(customer_after - customer_before, 500i128);
+    assert_eq!(merchant_after - merchant_before, 500i128);
+}
+
+#[test]
+fn test_check_escalation_timeout_false_before_escalation() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    env.ledger().set_timestamp(999_999);
+    assert!(!client.check_escalation_timeout(&escrow_id));
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -63,6 +63,9 @@ pub enum DataKey {
     ConditionalEscrow(u64),
     SuccessionPlan,
     GlobalExpiryConfig,
+    EscalationConfig,
+    EscrowEvidencePage(u64, u32),
+    EscrowEvidencePageCount(u64),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -73,6 +76,21 @@ pub enum EscrowStatus {
     Disputed,
     Resolved,
     Cancelled,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub enum AutoResolveFavor {
+    Customer,
+    Merchant,
+    SplitEqual,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct EscalationConfig {
+    pub timeout_seconds: u64,
+    pub favor: AutoResolveFavor,
 }
 
 #[derive(Clone)]
@@ -143,8 +161,6 @@ pub enum Error {
     InvalidVestingSchedule = 9,
     CliffPeriodNotPassed = 10,
     MilestoneAlreadyReleased = 11,
-    InsufficientVestedAmount = 12,
-    TransferFailed = 13,
     InvalidParticipantCount = 14,
     InvalidSharesSum = 15,
     DuplicateApproval = 16,
@@ -158,18 +174,11 @@ pub enum Error {
     NotAnAdmin = 24,
     AlreadyApproved = 25,
     ActionNotReady = 26,
-    ActionExpired = 27,
-    ActionAlreadyExecuted = 28,
-    ActionCancelled = 29,
     ContractPaused = 30,
     FunctionPaused = 31,
     EmptyTokenList = 35,
     DuplicateToken = 36,
     TokenTransferPartialFailure = 37,
-    Underfunded = 32,
-    NotClaimable = 33,
-    OracleStalePriceFeed = 44,
-    NoOracleCondition = 46,
     BatchTooLarge = 40,
     MilestoneNotFound = 47,
     MilestoneNotApproved = 48,
@@ -187,7 +196,6 @@ pub enum Error {
     EmptyPauseReason = 55,
     InvalidWeightSum = 56,
     InvalidThreshold = 57,
-    WeightUpdateLocked = 58,
     ParticipantNotFound = 59,
     EscrowNotExpired = 60,
     EscrowAlreadyExpired = 61,
@@ -475,8 +483,11 @@ pub struct Escrow {
     pub escalation_level: u64,
     pub min_hold_period: u64,
     pub fee_bps: i128,
-    pub expiry_timestamp: u64,       // 0 = no expiry
+    pub expiry_timestamp: u64,
     pub auto_refund_on_expiry: bool,
+    pub escalated_at: Option<u64>,
+    pub escalation_timeout: u64,
+    pub auto_resolve_in_favor_of: AutoResolveFavor,
 }
 
 #[derive(Clone)]
@@ -595,6 +606,7 @@ pub enum ActionType {
     AddAdmin,
     RemoveAdmin,
     UpdateRequiredSignatures,
+    UpdateThreshold { new_threshold: u32 },
 }
 
 #[derive(Clone)]
@@ -952,6 +964,14 @@ pub struct EscrowExpired {
     pub escrow_id: u64,
     pub refunded_to: Address,
     pub amount: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimeoutResolutionTriggered {
+    pub escrow_id: u64,
+    pub favor: AutoResolveFavor,
+    pub resolved_at: u64,
 }
 
 #[derive(Clone)]
@@ -1352,30 +1372,12 @@ impl EscrowContract {
     pub fn update_required_signatures(
         env: Env,
         caller: Address,
-        required: u32,
+        _required: u32,
     ) -> Result<(), Error> {
         caller.require_auth();
-
-        let mut config: MultiSigConfig = env
-            .storage()
-            .instance()
-            .get(&DataKey::MultiSigConfig)
-            .ok_or(Error::MultiSigNotInitialized)?;
-
-        if !config.admins.contains(&caller) {
-            return Err(Error::NotAnAdmin);
-        }
-
-        if required == 0 || required > config.total_admins {
-            return Err(Error::InsufficientAdmins);
-        }
-
-        config.required_signatures = required;
-        env.storage()
-            .instance()
-            .set(&DataKey::MultiSigConfig, &config);
-
-        Ok(())
+        // Direct calls are forbidden — must use propose_action / execute_action
+        // with ActionType::UpdateThreshold so the change requires multi-sig approval.
+        Err(Error::Unauthorized)
     }
 
     pub fn designate_successor(
@@ -1534,6 +1536,15 @@ impl EscrowContract {
             0
         };
 
+        let escalation_cfg: EscalationConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::EscalationConfig)
+            .unwrap_or(EscalationConfig {
+                timeout_seconds: 604800,
+                favor: AutoResolveFavor::Customer,
+            });
+
         let escrow = Escrow {
             id: escrow_id,
             customer: customer.clone(),
@@ -1550,6 +1561,9 @@ impl EscrowContract {
             fee_bps,
             expiry_timestamp,
             auto_refund_on_expiry,
+            escalated_at: None,
+            escalation_timeout: escalation_cfg.timeout_seconds,
+            auto_resolve_in_favor_of: escalation_cfg.favor,
         };
 
         env.storage()
@@ -1883,7 +1897,7 @@ impl EscrowContract {
         // Block weight updates once any participant has already approved.
         for p in escrow.participants.iter() {
             if p.approved {
-                return Err(Error::WeightUpdateLocked);
+                return Err(Error::InvalidStatus);
             }
         }
 
@@ -2631,6 +2645,65 @@ impl EscrowContract {
         items
     }
 
+    pub fn submit_evidence_batch(
+        env: Env,
+        caller: Address,
+        escrow_id: u64,
+        evidence_items: Vec<Bytes>,
+    ) -> Result<u32, Error> {
+        caller.require_auth();
+
+        if !env.storage().instance().has(&DataKey::Escrow(escrow_id)) {
+            return Err(Error::EscrowNotFound);
+        }
+
+        let escrow = EscrowContract::get_escrow(&env, escrow_id);
+        if escrow.status != EscrowStatus::Disputed {
+            return Err(Error::NotDisputed);
+        }
+        if escrow.customer != caller && escrow.merchant != caller {
+            return Err(Error::Unauthorized);
+        }
+
+        const MAX_BATCH: u32 = 10;
+        if evidence_items.len() > MAX_BATCH {
+            return Err(Error::BatchTooLarge);
+        }
+
+        let now = env.ledger().timestamp();
+        let page_num: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::EscrowEvidencePageCount(escrow_id))
+            .unwrap_or(0);
+
+        let mut page: Vec<Evidence> = Vec::new(&env);
+        for item in evidence_items.iter() {
+            let ipfs_hash = EscrowContract::evidence_bytes_to_label_string(&env, item);
+            page.push_back(Evidence {
+                submitter: caller.clone(),
+                ipfs_hash,
+                submitted_at: now,
+            });
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowEvidencePage(escrow_id, page_num), &page);
+        env.storage()
+            .instance()
+            .set(&DataKey::EscrowEvidencePageCount(escrow_id), &(page_num + 1));
+
+        Ok(page_num + 1)
+    }
+
+    pub fn get_evidence_page(env: Env, escrow_id: u64, page: u32) -> Vec<Evidence> {
+        env.storage()
+            .instance()
+            .get(&DataKey::EscrowEvidencePage(escrow_id, page))
+            .unwrap_or(Vec::new(&env))
+    }
+
     pub fn escalate_dispute(env: Env, caller: Address, escrow_id: u64) -> Result<(), Error> {
         caller.require_auth();
         if !env.storage().instance().has(&DataKey::Escrow(escrow_id)) {
@@ -2644,7 +2717,9 @@ impl EscrowContract {
             return Err(Error::Unauthorized);
         }
         escrow.escalation_level = escrow.escalation_level.saturating_add(1);
-        escrow.last_activity_at = env.ledger().timestamp();
+        let now = env.ledger().timestamp();
+        escrow.escalated_at = Some(now);
+        escrow.last_activity_at = now;
         env.storage()
             .instance()
             .set(&DataKey::Escrow(escrow_id), &escrow);
@@ -2695,6 +2770,116 @@ impl EscrowContract {
             amount: escrow.amount,
         }
         .publish(&env);
+        Ok(())
+    }
+
+    pub fn set_escalation_config(
+        env: Env,
+        admin: Address,
+        timeout_seconds: u64,
+        favor: AutoResolveFavor,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let multisig = Self::get_multisig_config(env.clone());
+        if !multisig.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+        let cfg = EscalationConfig { timeout_seconds, favor };
+        env.storage().instance().set(&DataKey::EscalationConfig, &cfg);
+        Ok(())
+    }
+
+    pub fn check_escalation_timeout(env: Env, escrow_id: u64) -> bool {
+        let escrow: Option<Escrow> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Escrow(escrow_id));
+        let escrow = match escrow {
+            Some(e) => e,
+            None => return false,
+        };
+        if let Some(escalated_at) = escrow.escalated_at {
+            let now = env.ledger().timestamp();
+            now.saturating_sub(escalated_at) >= escrow.escalation_timeout
+        } else {
+            false
+        }
+    }
+
+    pub fn trigger_timeout_resolution(env: Env, escrow_id: u64) -> Result<(), Error> {
+        if !env.storage().instance().has(&DataKey::Escrow(escrow_id)) {
+            return Err(Error::EscrowNotFound);
+        }
+
+        let mut escrow = EscrowContract::get_escrow(&env, escrow_id);
+
+        if escrow.status != EscrowStatus::Disputed {
+            return Err(Error::NotDisputed);
+        }
+
+        let escalated_at = escrow.escalated_at.ok_or(Error::InvalidStatus)?;
+
+        let now = env.ledger().timestamp();
+        if now.saturating_sub(escalated_at) < escrow.escalation_timeout {
+            return Err(Error::TimeoutNotReached);
+        }
+
+        let favor = escrow.auto_resolve_in_favor_of.clone();
+
+        match &favor {
+            AutoResolveFavor::Customer => {
+                escrow.status = EscrowStatus::Resolved;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Escrow(escrow_id), &escrow);
+                EscrowContract::transfer_if_token_contract(
+                    &env,
+                    &escrow.token,
+                    &escrow.customer,
+                    escrow.amount,
+                )?;
+            }
+            AutoResolveFavor::Merchant => {
+                escrow.status = EscrowStatus::Released;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Escrow(escrow_id), &escrow);
+                EscrowContract::transfer_if_token_contract(
+                    &env,
+                    &escrow.token,
+                    &escrow.merchant,
+                    escrow.amount,
+                )?;
+            }
+            AutoResolveFavor::SplitEqual => {
+                let half = escrow.amount / 2;
+                let remainder = escrow.amount - half;
+                escrow.status = EscrowStatus::Resolved;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Escrow(escrow_id), &escrow);
+                EscrowContract::transfer_if_token_contract(
+                    &env,
+                    &escrow.token,
+                    &escrow.customer,
+                    half,
+                )?;
+                EscrowContract::transfer_if_token_contract(
+                    &env,
+                    &escrow.token,
+                    &escrow.merchant,
+                    remainder,
+                )?;
+            }
+        }
+
+        (TimeoutResolutionTriggered {
+            escrow_id,
+            favor,
+            resolved_at: now,
+        })
+        .publish(&env);
+
         Ok(())
     }
 
@@ -3497,7 +3682,7 @@ impl EscrowContract {
         let releasable_amount = vested_amount.saturating_sub(vesting_schedule.released_amount);
 
         if releasable_amount == 0 {
-            return Err(Error::InsufficientVestedAmount);
+            return Err(Error::InvalidStatus);
         }
 
         // Update the released amount
@@ -3780,7 +3965,7 @@ impl EscrowContract {
             .try_transfer(&contract_address, recipient, &amount)
             .is_err()
         {
-            return Err(Error::TransferFailed);
+            return Err(Error::TokenTransferPartialFailure);
         }
         Ok(())
     }
@@ -4064,6 +4249,23 @@ impl EscrowContract {
                     .instance()
                     .set(&DataKey::MultiSigConfig, &config);
             }
+            ActionType::UpdateThreshold { new_threshold } => {
+                let mut config: MultiSigConfig = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::MultiSigConfig)
+                    .ok_or(Error::MultiSigNotInitialized)?;
+                if new_threshold == 0 {
+                    return Err(Error::InvalidThreshold);
+                }
+                if new_threshold > config.total_admins {
+                    return Err(Error::InsufficientAdmins);
+                }
+                config.required_signatures = new_threshold;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::MultiSigConfig, &config);
+            }
             _ => {}
         }
         Ok(())
@@ -4134,7 +4336,7 @@ impl EscrowContract {
             return Err(Error::ActionAlreadyExecuted);
         }
         if action.cancelled {
-            return Err(Error::ActionCancelled);
+            return Err(Error::AlreadyProcessed);
         }
 
         let current_time = env.ledger().timestamp();
@@ -4142,7 +4344,7 @@ impl EscrowContract {
             return Err(Error::ActionNotReady);
         }
         if current_time > action.expires_at {
-            return Err(Error::ActionExpired);
+            return Err(Error::ProposalExpired);
         }
 
         action.executed = true;
@@ -4195,10 +4397,10 @@ impl EscrowContract {
             .ok_or(Error::ProposalNotFound)?;
 
         if action.executed {
-            return Err(Error::ActionAlreadyExecuted);
+            return Err(Error::ProposalAlreadyExecuted);
         }
         if action.cancelled {
-            return Err(Error::ActionCancelled);
+            return Err(Error::AlreadyProcessed);
         }
 
         // Only the proposing admin or any other admin can cancel
@@ -4758,7 +4960,7 @@ impl EscrowContract {
 
         let escrow = Self::get_escrow(&env, escrow_id);
         if escrow.status != EscrowStatus::Resolved && escrow.status != EscrowStatus::Cancelled {
-            return Err(Error::NotClaimable);
+            return Err(Error::InvalidStatus);
         }
 
         let config: InsuranceConfig = env
@@ -4814,7 +5016,7 @@ impl EscrowContract {
 
         let mut pool = Self::get_insurance_pool(env.clone());
         if pool.balance < claim.amount {
-            return Err(Error::Underfunded);
+            return Err(Error::InvalidStatus);
         }
 
         Self::transfer_if_token_contract(&env, &pool.token, &claim.claimant, claim.amount)?;
@@ -5056,7 +5258,7 @@ impl EscrowContract {
         env.storage()
             .instance()
             .get(&DataKey::OracleCondition(escrow_id))
-            .ok_or(Error::NoOracleCondition)
+            .ok_or(Error::InvalidStatus)
     }
 
     pub fn auto_resolve_with_oracle(env: Env, escrow_id: u64) -> Result<(), Error> {
@@ -5071,7 +5273,7 @@ impl EscrowContract {
             .storage()
             .instance()
             .get(&DataKey::OracleCondition(escrow_id))
-            .ok_or(Error::NoOracleCondition)?;
+            .ok_or(Error::InvalidStatus)?;
 
         let mut args: Vec<soroban_sdk::Val> = Vec::new(&env);
         args.push_back(condition.oracle.price_feed_id.clone().into());
@@ -5083,7 +5285,7 @@ impl EscrowContract {
 
         let now = env.ledger().timestamp();
         if now.saturating_sub(price_data.timestamp) > condition.oracle.staleness_threshold {
-            return Err(Error::OracleStalePriceFeed);
+            return Err(Error::InvalidStatus);
         }
 
         let condition_met = match condition.comparison {
@@ -5941,3 +6143,12 @@ mod pause_history_test;
 
 #[cfg(test)]
 mod expiry_test;
+
+#[cfg(test)]
+mod multisig_threshold_test;
+
+#[cfg(test)]
+mod escalation_timeout_test;
+
+#[cfg(test)]
+mod bulk_evidence_test;

--- a/contracts/escrow/src/multisig_threshold_test.rs
+++ b/contracts/escrow/src/multisig_threshold_test.rs
@@ -1,0 +1,73 @@
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env};
+
+fn setup() -> (Env, EscrowContractClient<'static>, Address) {
+    let env = Env::default();
+    let id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+#[test]
+fn test_direct_update_required_signatures_rejected() {
+    let (env, client, admin) = setup();
+    let _ = env;
+    let result = client.try_update_required_signatures(&admin, &1u32);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_threshold_change_via_multisig() {
+    let (env, client, admin) = setup();
+
+    let admin2 = Address::generate(&env);
+    client.add_admin(&admin, &admin2);
+
+    // With threshold=1 (default), one approval from proposer is enough to execute.
+    let proposal_id = client.propose_action(
+        &admin,
+        &ActionType::UpdateThreshold { new_threshold: 2u32 },
+        &admin2,
+        &Bytes::new(&env),
+    );
+    client.execute_action(&proposal_id);
+
+    let config = client.get_multisig_config();
+    assert_eq!(config.required_signatures, 2);
+}
+
+#[test]
+fn test_threshold_zero_rejected() {
+    let (env, client, admin) = setup();
+
+    let proposal_id = client.propose_action(
+        &admin,
+        &ActionType::UpdateThreshold { new_threshold: 0u32 },
+        &admin,
+        &Bytes::new(&env),
+    );
+
+    let result = client.try_execute_action(&proposal_id);
+    assert_eq!(result, Err(Ok(Error::InvalidThreshold)));
+}
+
+#[test]
+fn test_threshold_exceeds_admin_count_rejected() {
+    let (env, client, admin) = setup();
+
+    // Only 1 admin exists; requesting threshold=2 should fail.
+    let proposal_id = client.propose_action(
+        &admin,
+        &ActionType::UpdateThreshold { new_threshold: 2u32 },
+        &admin,
+        &Bytes::new(&env),
+    );
+
+    let result = client.try_execute_action(&proposal_id);
+    assert_eq!(result, Err(Ok(Error::InsufficientAdmins)));
+}

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -44,6 +44,8 @@ pub enum DataKey {
     // Payment Channel support (#125)
     PaymentChannel(u64),
     PaymentChannelCounter,
+    MeteredSubscription(u64),
+    MeteredSubscriptionCounter,
 }
 
 // Customer-specific data keys
@@ -257,6 +259,8 @@ pub enum Error {
     ChannelClosed = 76,
     ChannelExpired = 77,
     ChannelNotExpired = 78,
+    MeteredSubscriptionNotFound = 79,
+    BillingCapExceeded = 80,
 }
 
 #[contractevent]
@@ -412,6 +416,20 @@ pub struct PaymentChannel {
     pub expires_at: u64,
 }
 
+#[derive(Clone)]
+#[contracttype]
+pub struct MeteredSubscription {
+    pub subscription_id: u64,
+    pub merchant: Address,
+    pub customer: Address,
+    pub token: Address,
+    pub price_per_unit: i128,
+    pub unit_name: String,
+    pub accumulated_units: u64,
+    pub billing_cap: Option<i128>,
+    pub last_reset_at: u64,
+}
+
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChannelOpened {
@@ -434,6 +452,29 @@ pub struct ChannelSettled {
 pub struct ChannelExpiredClosed {
     pub channel_id: u64,
     pub refunded_to: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UsageReported {
+    pub subscription_id: u64,
+    pub units: u64,
+    pub accumulated: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MeteredBillingExecuted {
+    pub subscription_id: u64,
+    pub amount: i128,
+    pub units_billed: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BillingCapReached {
+    pub subscription_id: u64,
+    pub cap: i128,
 }
 
 #[contractevent]
@@ -3365,6 +3406,175 @@ impl PaymentContract {
         }
 
         Ok(())
+    }
+
+    pub fn create_metered_subscription(
+        env: Env,
+        merchant: Address,
+        customer: Address,
+        price_per_unit: i128,
+        unit_name: String,
+        token: Address,
+        billing_cap: Option<i128>,
+    ) -> Result<u64, Error> {
+        merchant.require_auth();
+
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MeteredSubscriptionCounter)
+            .unwrap_or(0);
+        let sub_id = counter + 1;
+
+        let now = env.ledger().timestamp();
+
+        let sub = MeteredSubscription {
+            subscription_id: sub_id,
+            merchant,
+            customer,
+            token,
+            price_per_unit,
+            unit_name,
+            accumulated_units: 0,
+            billing_cap,
+            last_reset_at: now,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MeteredSubscription(sub_id), &sub);
+        env.storage()
+            .instance()
+            .set(&DataKey::MeteredSubscriptionCounter, &sub_id);
+
+        Ok(sub_id)
+    }
+
+    pub fn report_usage(
+        env: Env,
+        merchant: Address,
+        subscription_id: u64,
+        units: u64,
+    ) -> Result<(), Error> {
+        merchant.require_auth();
+
+        let mut sub: MeteredSubscription = env
+            .storage()
+            .instance()
+            .get(&DataKey::MeteredSubscription(subscription_id))
+            .ok_or(Error::MeteredSubscriptionNotFound)?;
+
+        if sub.merchant != merchant {
+            return Err(Error::Unauthorized);
+        }
+
+        sub.accumulated_units = sub.accumulated_units.saturating_add(units);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MeteredSubscription(subscription_id), &sub);
+
+        (UsageReported {
+            subscription_id,
+            units,
+            accumulated: sub.accumulated_units,
+        })
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_current_usage(env: Env, subscription_id: u64) -> MeteredSubscription {
+        env.storage()
+            .instance()
+            .get(&DataKey::MeteredSubscription(subscription_id))
+            .expect("MeteredSubscription not found")
+    }
+
+    pub fn set_billing_cap(
+        env: Env,
+        merchant: Address,
+        subscription_id: u64,
+        cap: i128,
+    ) -> Result<(), Error> {
+        merchant.require_auth();
+
+        let mut sub: MeteredSubscription = env
+            .storage()
+            .instance()
+            .get(&DataKey::MeteredSubscription(subscription_id))
+            .ok_or(Error::MeteredSubscriptionNotFound)?;
+
+        if sub.merchant != merchant {
+            return Err(Error::Unauthorized);
+        }
+
+        sub.billing_cap = Some(cap);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MeteredSubscription(subscription_id), &sub);
+
+        Ok(())
+    }
+
+    pub fn execute_metered_billing(
+        env: Env,
+        subscription_id: u64,
+    ) -> Result<i128, Error> {
+        let mut sub: MeteredSubscription = env
+            .storage()
+            .instance()
+            .get(&DataKey::MeteredSubscription(subscription_id))
+            .ok_or(Error::MeteredSubscriptionNotFound)?;
+
+        let units_billed = sub.accumulated_units;
+        if units_billed == 0 {
+            return Ok(0);
+        }
+
+        let mut amount = (units_billed as i128).saturating_mul(sub.price_per_unit);
+        let mut cap_hit = false;
+
+        if let Some(cap) = sub.billing_cap {
+            if amount > cap {
+                amount = cap;
+                cap_hit = true;
+            }
+        }
+
+        let token_client = token::Client::new(&env, &sub.token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer_from(
+            &contract_address,
+            &sub.customer,
+            &sub.merchant,
+            &amount,
+        );
+
+        sub.accumulated_units = 0;
+        sub.last_reset_at = env.ledger().timestamp();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MeteredSubscription(subscription_id), &sub);
+
+        if cap_hit {
+            (BillingCapReached {
+                subscription_id,
+                cap: sub.billing_cap.unwrap_or(0),
+            })
+            .publish(&env);
+        }
+
+        (MeteredBillingExecuted {
+            subscription_id,
+            amount,
+            units_billed,
+        })
+        .publish(&env);
+
+        Ok(amount)
     }
 
     /// Cancel a subscription. Only the customer, merchant, or admin may call this.
@@ -6779,3 +6989,6 @@ mod test_payment_channel;
 
 #[cfg(test)]
 mod test_cross_contract_escrow_verification;
+
+#[cfg(test)]
+mod test_metered_billing;

--- a/contracts/payment/src/test_metered_billing.rs
+++ b/contracts/payment/src/test_metered_billing.rs
@@ -1,0 +1,139 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    token, Address, Env, String,
+};
+
+fn setup(env: &Env) -> (PaymentContractClient, Address, Address, Address, Address) {
+    let id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let token_admin_addr = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin_addr.clone());
+    let token_address = token_contract.address();
+    let asset_client = token::StellarAssetClient::new(env, &token_address);
+
+    let customer = Address::generate(env);
+    let merchant = Address::generate(env);
+    asset_client.mint(&customer, &1_000_000i128);
+
+    (client, admin, merchant, customer, token_address)
+}
+
+#[test]
+fn test_report_usage_accumulates() {
+    let env = Env::default();
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &10i128,
+        &String::from_str(&env, "api_call"),
+        &token,
+        &None,
+    );
+
+    client.report_usage(&merchant, &sub_id, &5u64);
+    client.report_usage(&merchant, &sub_id, &3u64);
+
+    let usage = client.get_current_usage(&sub_id);
+    assert_eq!(usage.accumulated_units, 8);
+}
+
+#[test]
+fn test_report_usage_unauthorized() {
+    let env = Env::default();
+    let (client, _admin, merchant, customer, token) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &10i128,
+        &String::from_str(&env, "api_call"),
+        &token,
+        &None,
+    );
+
+    let result = client.try_report_usage(&stranger, &sub_id, &5u64);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_execute_metered_billing_charges_and_resets() {
+    let env = Env::default();
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &100i128,
+        &String::from_str(&env, "gb"),
+        &token,
+        &None,
+    );
+
+    client.report_usage(&merchant, &sub_id, &10u64);
+
+    let token_client = token::Client::new(&env, &token);
+    let merchant_balance_before = token_client.balance(&merchant);
+
+    let amount = client.execute_metered_billing(&sub_id);
+    assert_eq!(amount, 1000i128); // 10 units * 100 per unit
+
+    let usage_after = client.get_current_usage(&sub_id);
+    assert_eq!(usage_after.accumulated_units, 0);
+
+    let merchant_balance_after = token_client.balance(&merchant);
+    assert_eq!(merchant_balance_after - merchant_balance_before, 1000i128);
+}
+
+#[test]
+fn test_billing_cap_limits_charge() {
+    let env = Env::default();
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &100i128,
+        &String::from_str(&env, "gb"),
+        &token,
+        &Some(500i128),
+    );
+
+    // 10 units * 100 = 1000, but cap is 500
+    client.report_usage(&merchant, &sub_id, &10u64);
+
+    let amount = client.execute_metered_billing(&sub_id);
+    assert_eq!(amount, 500i128);
+
+    let usage_after = client.get_current_usage(&sub_id);
+    assert_eq!(usage_after.accumulated_units, 0);
+}
+
+#[test]
+fn test_set_billing_cap() {
+    let env = Env::default();
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &10i128,
+        &String::from_str(&env, "req"),
+        &token,
+        &None,
+    );
+
+    client.set_billing_cap(&merchant, &sub_id, &250i128);
+
+    let usage = client.get_current_usage(&sub_id);
+    assert_eq!(usage.billing_cap, Some(250i128));
+}


### PR DESCRIPTION

Payment contract:
- Add MeteredSubscription struct with price_per_unit, accumulated_units,
  and optional billing_cap
- Add create_metered_subscription, report_usage, get_current_usage,
  set_billing_cap, execute_metered_billing
- Billing cap limits charges; execute resets accumulated units to 0
- Emit UsageReported, MeteredBillingExecuted, BillingCapReached events

Escrow contract:
- Fix pre-existing LengthExceedsMax panic: reduce Error enum from 60 to
  50 variants (XDR hard limit) by consolidating redundant error codes
- Add ActionType::UpdateThreshold; direct update_required_signatures()
  now returns Unauthorized — threshold changes require multi-sig proposal
- Add AutoResolveFavor enum and escalation_timeout / escalated_at fields
  to Escrow; escalate_dispute stamps escalated_at; trigger_timeout_resolution
  callable by anyone after timeout elapses (Customer, Merchant, or SplitEqual)
- Add submit_evidence_batch (max 10 items per ledger entry) and
  get_evidence_page for paginated batch reads; get_evidence() unchanged
- Add set_escalation_config for global timeout/favor defaults

closes #91 
closes #103 
closes #107 
closes #101 