### PR TITLE
feat(refund): add rolling merchant refund quota and management APIs (…

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -23,6 +23,7 @@ pub enum DataKey {
     RefundStatusCount(RefundStatus),
     RefundStatusIndex(u64),
     MerchantRefunds(Address, u64),
+    MerchantRefundQuota(Address),
     MerchantRefundCount(Address),
     CustomerRefunds(Address, u64),
     CustomerRefundCount(Address),
@@ -163,6 +164,8 @@ pub enum Error {
     HookNotFound = 41,
     MaxHooksPerEventReached = 42,
     HookNotOwnedBySubscriber = 43,
+    MerchantQuotaExceeded = 44,
+    QuotaNotConfigured = 45,
 }
 
 #[contractevent]
@@ -427,6 +430,16 @@ pub struct MerchantRefundSummary {
     pub total_amount_refunded: i128,
     pub pending_count: u64,
     pub pending_amount: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct MerchantRefundQuota {
+    pub merchant: Address,
+    pub limit: i128,
+    pub period_seconds: u64,
+    pub used: i128,
+    pub period_start: u64,
 }
 
 // Issue #147: Customer refund summary
@@ -1197,6 +1210,66 @@ impl RefundContract {
             .instance()
             .get(&PolicyKey::AutoRefundTrigger(trigger_id))
             .ok_or(Error::AutoRefundTriggerNotFound)
+    }
+
+    pub fn set_merchant_refund_quota(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+        limit: i128,
+        period_seconds: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let quota = MerchantRefundQuota {
+            merchant: merchant.clone(),
+            limit,
+            period_seconds,
+            used: 0,
+            period_start: env.ledger().timestamp(),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantRefundQuota(merchant), &quota);
+        Ok(())
+    }
+
+    pub fn get_merchant_refund_quota(env: Env, merchant: Address) -> Option<MerchantRefundQuota> {
+        env.storage()
+            .instance()
+            .get(&DataKey::MerchantRefundQuota(merchant))
+    }
+
+    pub fn reset_merchant_quota(env: Env, admin: Address, merchant: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut quota: MerchantRefundQuota = env
+            .storage()
+            .instance()
+            .get(&DataKey::MerchantRefundQuota(merchant.clone()))
+            .ok_or(Error::QuotaNotConfigured)?;
+        quota.used = 0;
+        quota.period_start = env.ledger().timestamp();
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantRefundQuota(merchant), &quota);
+        Ok(())
     }
 
     pub fn set_customer_rate_limit(
@@ -3254,6 +3327,31 @@ impl RefundContract {
             refund.amount,
             refund.original_payment_amount,
         )?;
+
+        // Enforce merchant refund quota if configured
+        if let Some(mut quota) = env
+            .storage()
+            .instance()
+            .get::<_, MerchantRefundQuota>(&DataKey::MerchantRefundQuota(refund.merchant.clone()))
+        {
+            let now = env.ledger().timestamp();
+            // auto-reset if period elapsed
+            if now > quota.period_start.saturating_add(quota.period_seconds) {
+                quota.used = 0;
+                quota.period_start = now;
+            }
+            let new_used = quota
+                .used
+                .checked_add(refund.amount)
+                .ok_or(Error::InvalidAmount)?;
+            if new_used > quota.limit {
+                return Err(Error::MerchantQuotaExceeded);
+            }
+            quota.used = new_used;
+            env.storage()
+                .instance()
+                .set(&DataKey::MerchantRefundQuota(refund.merchant.clone()), &quota);
+        }
 
         Self::remove_from_status_index(env, RefundStatus::Approved, refund_id)?;
         refund.status = RefundStatus::Processed;


### PR DESCRIPTION
Closes #193

Implemented a rolling merchant refund quota with automatic period resets to protect merchants from refund drain attacks.

Summary

Adds a new contract storage struct and APIs to configure and manage per-merchant refund quotas.
Enforces quota during refund processing: refunds that would exceed the configured rolling limit are rejected.
Automatically resets a merchant's used quota when the configured period elapses.
Admins can manually set and reset merchant quotas.

What I changed

New storage key: [DataKey::MerchantRefundQuota(Address)](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to store per-merchant quota.
New contracttype:
[MerchantRefundQuota { merchant: Address, limit: i128, period_seconds: u64, used: i128, period_start: u64 }](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Error variants added: [MerchantQuotaExceeded](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [QuotaNotConfigured](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
New public functions:
[set_merchant_refund_quota(env: Env, admin: Address, merchant: Address, limit: i128, period_seconds: u64) -> Result<(), Error>](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[get_merchant_refund_quota(env: Env, merchant: Address) -> Option<MerchantRefundQuota>](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[reset_merchant_quota(env: Env, admin: Address, merchant: Address) -> Result<(), Error>](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Quota enforcement:
[process_refund_internal](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now checks for a configured quota for the merchant, auto-resets if the period has elapsed, verifies the refund won't exceed the limit, increments used, and persists the quota.
If no quota is configured, processing proceeds as before.
Admin authorization required for [set_merchant_refund_quota](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [reset_merchant_quota](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html).


Notes / Acceptance Criteria Mapping

Processing a refund increments the merchant's used amount; exceeding the limit returns [MerchantQuotaExceeded](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
When [process_refund()](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is called after [period_start + period_seconds](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html), the quota automatically resets before checking.
[reset_merchant_quota()](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is restricted to admin and resets used to zero.
Tests were not added in this change per instructions to skip unnecessary tests; can add unit tests on request.
