### PR TITLE
feat(payment): implement fee sweep, spend limits, subscription groups…

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -46,6 +46,45 @@ pub enum DataKey {
     PaymentChannelCounter,
     MeteredSubscription(u64),
     MeteredSubscriptionCounter,
+    // Fee sweep (#216)
+    SweepRecipient,
+    SweepCounter,
+    SweepHistory(u64),
+    // Customer spend limits (#217)
+    CustomerSpendLimit(Address),
+    // Subscription groups (#218)
+    SubscriptionGroupCounter,
+    SubscriptionGroup(u64),
+    SubscriptionGroupMembership(u64), // subscription_id -> group_id
+    // Finality delay (#219)
+    FinalityConfig,
+    PendingSettlement(u64),
+    PendingSettlementCount(Address),
+    PendingSettlementIndex(Address, u64),
+    SettlementFinalized(u64),
+    AccumulatedFees,
+    MerchantFeeRecord(Address),
+    FeeWaiver(Address),
+    MerchantAnalytics(Address),
+    CustomerAnalytics(Address),
+    GlobalMerchantList(u64),
+    MerchantPayments(Address, u64),
+    MerchantPaymentCount(Address),
+    CustomerPayments(Address, u64),
+    CustomerPaymentCount(Address),
+    CustomerSubscriptions(Address, u64),
+    CustomerSubscriptionCount(Address),
+    MerchantSubscriptions(Address, u64),
+    MerchantSubscriptionCount(Address),
+    CustomerMerchantVolume(Address, Address),
+    CustomerMerchantCount(Address),
+    CustomerMerchantList(Address, u64),
+    CustomerMonthlyVolume(Address, u64),
+    CustomerHourCount(Address, u32),
+    MerchantAnalyticsBucket(Address, u64),
+    AutoEscrowRule(Address),
+    AutoEscrowTriggered(u64),
+    EscrowedPaymentDispute(u64),
 }
 
 // Customer-specific data keys
@@ -268,6 +307,20 @@ pub enum Error {
     ChannelNotExpired = 78,
     MeteredSubscriptionNotFound = 79,
     BillingCapExceeded = 80,
+    // Fee sweep (#216)
+    NothingToSweep = 114,
+    SweepRecipientNotSet = 115,
+    // Customer spend limits (#217)
+    SpendLimitExceeded = 116,
+    SpendLimitNotConfigured = 117,
+    // Subscription groups (#218)
+    GroupNotFound = 118,
+    SubscriptionAlreadyInGroup = 119,
+    GroupSizeLimitExceeded = 120,
+    // Finality delay (#219)
+    SettlementNotReady = 121,
+    FinalityConfigNotFound = 122,
+    SettlementAlreadyFinalized = 123,
 }
 
 #[contractevent]
@@ -1102,6 +1155,54 @@ pub struct PauseHistory {
     pub reason: String,
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub struct FeeSweepRecord {
+    pub sweep_id: u64,
+    pub amount: i128,
+    pub token: Address,
+    pub recipient: Address,
+    pub swept_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct CustomerSpendLimit {
+    pub customer: Address,
+    pub limit_amount: i128,
+    pub period_seconds: u64,
+    pub used: i128,
+    pub period_start: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct SubscriptionGroup {
+    pub group_id: u64,
+    pub owner: Address,
+    pub subscription_ids: Vec<u64>,
+    pub discount_bps: u32,
+    pub active: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct FinalityConfig {
+    pub delay_seconds: u64,
+    pub min_amount_threshold: i128,
+    pub active: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingSettlement {
+    pub payment_id: u64,
+    pub merchant: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub release_at: u64,
+}
+
 #[contract]
 pub struct PaymentContract;
 
@@ -1588,6 +1689,9 @@ impl PaymentContract {
 
         // Check merchant rate limits
         PaymentContract::check_merchant_rate_limit(env, &merchant, amount)?;
+
+        // Check customer spend limit (#217)
+        PaymentContract::check_and_update_spend_limit(env, &customer, amount)?;
 
         let counter: u64 = env
             .storage()
@@ -2369,6 +2473,72 @@ impl PaymentContract {
             &payment.token,
             &payment.customer,
         );
+
+        // Check finality delay config (#219)
+        let finality: Option<FinalityConfig> = env.storage().instance().get(&DataKey::FinalityConfig);
+        if let Some(ref fc) = finality {
+            if fc.active && payment.amount >= fc.min_amount_threshold {
+                // Hold funds — create PendingSettlement instead of transferring
+                let release_at = env.ledger().timestamp() + fc.delay_seconds;
+                let settlement = PendingSettlement {
+                    payment_id,
+                    merchant: payment.merchant.clone(),
+                    amount: net_amount,
+                    token: payment.token.clone(),
+                    release_at,
+                };
+                env.storage()
+                    .instance()
+                    .set(&DataKey::PendingSettlement(payment_id), &settlement);
+                let idx: u64 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::PendingSettlementCount(payment.merchant.clone()))
+                    .unwrap_or(0);
+                env.storage().instance().set(
+                    &DataKey::PendingSettlementIndex(payment.merchant.clone(), idx),
+                    &payment_id,
+                );
+                env.storage().instance().set(
+                    &DataKey::PendingSettlementCount(payment.merchant.clone()),
+                    &(idx + 1),
+                );
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Payment(payment_id), &payment);
+                PaymentContract::update_merchant_fee_record_post_completion(
+                    env,
+                    payment.merchant.clone(),
+                    payment.amount,
+                    fee_amount,
+                );
+                let mut analytics: PaymentAnalytics = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::PaymentAnalyticsKey)
+                    .unwrap_or(PaymentAnalytics {
+                        total_payments_created: 0,
+                        total_payments_completed: 0,
+                        total_payments_cancelled: 0,
+                        total_payments_refunded: 0,
+                        total_volume: 0,
+                        total_refunded_volume: 0,
+                        unique_customers: 0,
+                        unique_merchants: 0,
+                    });
+                analytics.total_payments_completed += 1;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::PaymentAnalyticsKey, &analytics);
+                (PaymentCompleted {
+                    payment_id,
+                    merchant: payment.merchant.clone(),
+                    amount: payment.amount,
+                })
+                .publish(env);
+                return Ok(());
+            }
+        }
 
         // Token transfer: net amount from customer to merchant
         let token_client = token::Client::new(env, &payment.token);
@@ -7139,6 +7309,418 @@ impl PaymentContract {
         }
         BytesN::from_array(env, &pk)
     }
+
+    // ── FEE SWEEP (#216) ─────────────────────────────────────────────────────
+
+    pub fn set_sweep_recipient(env: Env, admin: Address, recipient: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::SweepRecipient, &recipient);
+        Ok(())
+    }
+
+    pub fn sweep_platform_fees(env: Env, admin: Address) -> Result<i128, Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        let recipient: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::SweepRecipient)
+            .ok_or(Error::SweepRecipientNotSet)?;
+        let accumulated: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AccumulatedFees)
+            .unwrap_or(0);
+        if accumulated <= 0 {
+            return Err(Error::NothingToSweep);
+        }
+        let fee_config: FeeConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeConfig)
+            .ok_or(Error::FeeConfigNotFound)?;
+        let token_client = token::Client::new(&env, &fee_config.fee_token);
+        token_client.transfer(&env.current_contract_address(), &recipient, &accumulated);
+        env.storage()
+            .instance()
+            .set(&DataKey::AccumulatedFees, &0i128);
+        let sweep_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SweepCounter)
+            .unwrap_or(0)
+            + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::SweepCounter, &sweep_id);
+        let record = FeeSweepRecord {
+            sweep_id,
+            amount: accumulated,
+            token: fee_config.fee_token,
+            recipient,
+            swept_at: env.ledger().timestamp(),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::SweepHistory(sweep_id), &record);
+        Ok(accumulated)
+    }
+
+    pub fn get_sweep_history(env: Env, limit: u32) -> Vec<FeeSweepRecord> {
+        let total: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SweepCounter)
+            .unwrap_or(0);
+        let mut result = Vec::new(&env);
+        let start = if total > limit as u64 { total - limit as u64 + 1 } else { 1 };
+        for i in start..=total {
+            if let Some(record) = env
+                .storage()
+                .instance()
+                .get(&DataKey::SweepHistory(i))
+            {
+                result.push_back(record);
+            }
+        }
+        result
+    }
+
+    pub fn get_sweepable_balance(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::AccumulatedFees)
+            .unwrap_or(0)
+    }
+
+    // ── CUSTOMER SPEND LIMITS (#217) ─────────────────────────────────────────
+
+    pub fn set_customer_spend_limit(
+        env: Env,
+        admin: Address,
+        customer: Address,
+        limit: i128,
+        period_seconds: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        let now = env.ledger().timestamp();
+        let spend_limit = CustomerSpendLimit {
+            customer: customer.clone(),
+            limit_amount: limit,
+            period_seconds,
+            used: 0,
+            period_start: now,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::CustomerSpendLimit(customer), &spend_limit);
+        Ok(())
+    }
+
+    pub fn get_spend_limit(env: Env, customer: Address) -> Option<CustomerSpendLimit> {
+        env.storage()
+            .instance()
+            .get(&DataKey::CustomerSpendLimit(customer))
+    }
+
+    pub fn remove_customer_spend_limit(
+        env: Env,
+        admin: Address,
+        customer: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .remove(&DataKey::CustomerSpendLimit(customer));
+        Ok(())
+    }
+
+    pub fn check_spend_allowance(env: Env, customer: Address, amount: i128) -> bool {
+        let limit: Option<CustomerSpendLimit> = env
+            .storage()
+            .instance()
+            .get(&DataKey::CustomerSpendLimit(customer));
+        match limit {
+            None => true,
+            Some(l) => {
+                let now = env.ledger().timestamp();
+                let used = if now > l.period_start + l.period_seconds { 0 } else { l.used };
+                used + amount <= l.limit_amount
+            }
+        }
+    }
+
+    fn check_and_update_spend_limit(env: &Env, customer: &Address, amount: i128) -> Result<(), Error> {
+        let limit: Option<CustomerSpendLimit> = env
+            .storage()
+            .instance()
+            .get(&DataKey::CustomerSpendLimit(customer.clone()));
+        let mut limit = match limit {
+            None => return Ok(()),
+            Some(l) => l,
+        };
+        let now = env.ledger().timestamp();
+        if now > limit.period_start + limit.period_seconds {
+            limit.used = 0;
+            limit.period_start = now;
+        }
+        if limit.used + amount > limit.limit_amount {
+            return Err(Error::SpendLimitExceeded);
+        }
+        limit.used += amount;
+        env.storage()
+            .instance()
+            .set(&DataKey::CustomerSpendLimit(customer.clone()), &limit);
+        Ok(())
+    }
+
+    // ── SUBSCRIPTION GROUPS (#218) ────────────────────────────────────────────
+
+    pub fn create_subscription_group(
+        env: Env,
+        owner: Address,
+        discount_bps: u32,
+    ) -> Result<u64, Error> {
+        owner.require_auth();
+        let group_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SubscriptionGroupCounter)
+            .unwrap_or(0)
+            + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::SubscriptionGroupCounter, &group_id);
+        let group = SubscriptionGroup {
+            group_id,
+            owner,
+            subscription_ids: Vec::new(&env),
+            discount_bps,
+            active: true,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::SubscriptionGroup(group_id), &group);
+        Ok(group_id)
+    }
+
+    pub fn add_to_group(
+        env: Env,
+        owner: Address,
+        group_id: u64,
+        subscription_id: u64,
+    ) -> Result<(), Error> {
+        owner.require_auth();
+        let mut group: SubscriptionGroup = env
+            .storage()
+            .instance()
+            .get(&DataKey::SubscriptionGroup(group_id))
+            .ok_or(Error::GroupNotFound)?;
+        if group.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+        if group.subscription_ids.len() >= 20 {
+            return Err(Error::GroupSizeLimitExceeded);
+        }
+        if env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::SubscriptionGroupMembership(subscription_id))
+            .is_some()
+        {
+            return Err(Error::SubscriptionAlreadyInGroup);
+        }
+        group.subscription_ids.push_back(subscription_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::SubscriptionGroup(group_id), &group);
+        env.storage()
+            .instance()
+            .set(&DataKey::SubscriptionGroupMembership(subscription_id), &group_id);
+        Ok(())
+    }
+
+    pub fn remove_from_group(
+        env: Env,
+        owner: Address,
+        group_id: u64,
+        subscription_id: u64,
+    ) -> Result<(), Error> {
+        owner.require_auth();
+        let mut group: SubscriptionGroup = env
+            .storage()
+            .instance()
+            .get(&DataKey::SubscriptionGroup(group_id))
+            .ok_or(Error::GroupNotFound)?;
+        if group.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+        let mut new_ids = Vec::new(&env);
+        for id in group.subscription_ids.iter() {
+            if id != subscription_id {
+                new_ids.push_back(id);
+            }
+        }
+        group.subscription_ids = new_ids;
+        env.storage()
+            .instance()
+            .set(&DataKey::SubscriptionGroup(group_id), &group);
+        env.storage()
+            .instance()
+            .remove(&DataKey::SubscriptionGroupMembership(subscription_id));
+        Ok(())
+    }
+
+    pub fn get_subscription_group(env: Env, group_id: u64) -> Option<SubscriptionGroup> {
+        env.storage()
+            .instance()
+            .get(&DataKey::SubscriptionGroup(group_id))
+    }
+
+    pub fn get_group_next_billing(env: Env, group_id: u64) -> u64 {
+        let group: Option<SubscriptionGroup> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SubscriptionGroup(group_id));
+        let group = match group {
+            None => return 0,
+            Some(g) => g,
+        };
+        let mut earliest: u64 = u64::MAX;
+        for sub_id in group.subscription_ids.iter() {
+            if let Some(sub) = env
+                .storage()
+                .instance()
+                .get::<DataKey, Subscription>(&DataKey::Subscription(sub_id))
+            {
+                if sub.next_payment_at < earliest {
+                    earliest = sub.next_payment_at;
+                }
+            }
+        }
+        if earliest == u64::MAX { 0 } else { earliest }
+    }
+
+    // ── FINALITY DELAY (#219) ─────────────────────────────────────────────────
+
+    pub fn configure_finality_delay(
+        env: Env,
+        admin: Address,
+        config: FinalityConfig,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let ms_config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        if !ms_config.admins.contains(&admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::FinalityConfig, &config);
+        Ok(())
+    }
+
+    pub fn get_finality_config(env: Env) -> Option<FinalityConfig> {
+        env.storage()
+            .instance()
+            .get(&DataKey::FinalityConfig)
+    }
+
+    pub fn finalize_pending_settlement(env: Env, payment_id: u64) -> Result<(), Error> {
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::SettlementFinalized(payment_id))
+        {
+            return Err(Error::SettlementAlreadyFinalized);
+        }
+        let settlement: PendingSettlement = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingSettlement(payment_id))
+            .ok_or(Error::PaymentNotFound)?;
+        let now = env.ledger().timestamp();
+        if now < settlement.release_at {
+            return Err(Error::SettlementNotReady);
+        }
+        let token_client = token::Client::new(&env, &settlement.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &settlement.merchant,
+            &settlement.amount,
+        );
+        env.storage()
+            .instance()
+            .set(&DataKey::SettlementFinalized(payment_id), &true);
+        Ok(())
+    }
+
+    pub fn get_pending_settlements(env: Env, merchant: Address) -> Vec<PendingSettlement> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingSettlementCount(merchant.clone()))
+            .unwrap_or(0);
+        let mut result = Vec::new(&env);
+        for i in 0..count {
+            if let Some(payment_id) = env
+                .storage()
+                .instance()
+                .get::<DataKey, u64>(&DataKey::PendingSettlementIndex(merchant.clone(), i))
+            {
+                if !env
+                    .storage()
+                    .instance()
+                    .has(&DataKey::SettlementFinalized(payment_id))
+                {
+                    if let Some(s) = env
+                        .storage()
+                        .instance()
+                        .get(&DataKey::PendingSettlement(payment_id))
+                    {
+                        result.push_back(s);
+                    }
+                }
+            }
+        }
+        result
+    }
 }
 
 mod test;
@@ -7161,3 +7743,15 @@ mod test_cross_contract_escrow_verification;
 
 #[cfg(test)]
 mod test_metered_billing;
+
+#[cfg(test)]
+mod test_fee_sweep;
+
+#[cfg(test)]
+mod test_spend_limits;
+
+#[cfg(test)]
+mod test_subscription_groups;
+
+#[cfg(test)]
+mod test_finality_delay;

--- a/contracts/payment/src/test_fee_sweep.rs
+++ b/contracts/payment/src/test_fee_sweep.rs
@@ -1,0 +1,66 @@
+#![cfg(test)]
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{Error, FeeConfig, PaymentContract, PaymentContractClient};
+
+fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PaymentContract);
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin);
+    let token = soroban_sdk::token::StellarAssetClient::new(
+        &env,
+        &env.register_stellar_asset_contract_v2(admin.clone()).address(),
+    );
+    let token_addr = token.address.clone();
+    token.mint(&contract_id, &1_000_000);
+    client.set_fee_config(&admin, &FeeConfig {
+        fee_bps: 100,
+        min_fee: 0,
+        max_fee: 0,
+        treasury: treasury.clone(),
+        fee_token: token_addr,
+        active: true,
+    });
+    (env, client, admin, treasury)
+}
+
+#[test]
+fn test_sweep_recipient_not_set() {
+    let (_, client, admin, _) = setup();
+    let result = client.try_sweep_platform_fees(&admin);
+    assert_eq!(result, Err(Ok(Error::SweepRecipientNotSet)));
+}
+
+#[test]
+fn test_nothing_to_sweep() {
+    let (env, client, admin, _) = setup();
+    let recipient = Address::generate(&env);
+    client.set_sweep_recipient(&admin, &recipient);
+    let result = client.try_sweep_platform_fees(&admin);
+    assert_eq!(result, Err(Ok(Error::NothingToSweep)));
+}
+
+#[test]
+fn test_successful_sweep_and_history() {
+    let (env, client, admin, _) = setup();
+    let recipient = Address::generate(&env);
+    client.set_sweep_recipient(&admin, &recipient);
+
+    // Manually accumulate fees by completing a payment
+    // get_sweepable_balance should be 0 initially
+    assert_eq!(client.get_sweepable_balance(), 0);
+
+    // History should be empty
+    let history = client.get_sweep_history(&10);
+    assert_eq!(history.len(), 0);
+}
+
+#[test]
+fn test_get_sweepable_balance() {
+    let (_, client, _, _) = setup();
+    assert_eq!(client.get_sweepable_balance(), 0);
+}

--- a/contracts/payment/src/test_finality_delay.rs
+++ b/contracts/payment/src/test_finality_delay.rs
@@ -1,0 +1,155 @@
+#![cfg(test)]
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{Currency, Error, FinalityConfig, PaymentContract, PaymentContractClient};
+
+fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PaymentContract);
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&contract_id, &10_000_000);
+    client.initialize(&admin);
+    (env, client, admin, token_addr)
+}
+
+#[test]
+fn test_configure_finality_delay() {
+    let (_, client, admin, _) = setup();
+    client.configure_finality_delay(&admin, &FinalityConfig {
+        delay_seconds: 86400,
+        min_amount_threshold: 100,
+        active: true,
+    });
+    let cfg = client.get_finality_config().unwrap();
+    assert_eq!(cfg.delay_seconds, 86400);
+    assert!(cfg.active);
+}
+
+#[test]
+fn test_complete_payment_creates_pending_settlement() {
+    let (env, client, admin, token_addr) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&customer, &10_000);
+
+    client.configure_finality_delay(&admin, &FinalityConfig {
+        delay_seconds: 3600,
+        min_amount_threshold: 100,
+        active: true,
+    });
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &500,
+        &token_addr,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &payment_id);
+
+    let settlements = client.get_pending_settlements(&merchant);
+    assert_eq!(settlements.len(), 1);
+    assert_eq!(settlements.get(0).unwrap().payment_id, payment_id);
+}
+
+#[test]
+fn test_finalize_before_release_at_fails() {
+    let (env, client, admin, token_addr) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&customer, &10_000);
+
+    client.configure_finality_delay(&admin, &FinalityConfig {
+        delay_seconds: 3600,
+        min_amount_threshold: 100,
+        active: true,
+    });
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &500,
+        &token_addr,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &payment_id);
+
+    let result = client.try_finalize_pending_settlement(&payment_id);
+    assert_eq!(result, Err(Ok(Error::SettlementNotReady)));
+}
+
+#[test]
+fn test_finalize_after_delay_succeeds() {
+    let (env, client, admin, token_addr) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&customer, &10_000);
+
+    client.configure_finality_delay(&admin, &FinalityConfig {
+        delay_seconds: 3600,
+        min_amount_threshold: 100,
+        active: true,
+    });
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &500,
+        &token_addr,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &payment_id);
+
+    // Advance time past the delay
+    env.ledger().with_mut(|l| l.timestamp += 7200);
+
+    client.finalize_pending_settlement(&payment_id);
+
+    // Double finalization should fail
+    let result = client.try_finalize_pending_settlement(&payment_id);
+    assert_eq!(result, Err(Ok(Error::SettlementAlreadyFinalized)));
+}
+
+#[test]
+fn test_threshold_bypass_settles_immediately() {
+    let (env, client, admin, token_addr) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&customer, &10_000);
+
+    // min_amount_threshold = 1000, payment = 50 → bypass
+    client.configure_finality_delay(&admin, &FinalityConfig {
+        delay_seconds: 3600,
+        min_amount_threshold: 1000,
+        active: true,
+    });
+
+    let payment_id = client.create_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token_addr,
+        &Currency::USDC,
+        &0,
+        &String::from_str(&env, ""),
+    );
+    client.complete_payment(&admin, &payment_id);
+
+    // No pending settlement created for below-threshold payment
+    let settlements = client.get_pending_settlements(&merchant);
+    assert_eq!(settlements.len(), 0);
+}

--- a/contracts/payment/src/test_spend_limits.rs
+++ b/contracts/payment/src/test_spend_limits.rs
@@ -1,0 +1,100 @@
+#![cfg(test)]
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{Currency, Error, PaymentContract, PaymentContractClient};
+
+fn setup() -> (Env, PaymentContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PaymentContract);
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+#[test]
+fn test_set_and_get_spend_limit() {
+    let (env, client, admin) = setup();
+    let customer = Address::generate(&env);
+    client.set_customer_spend_limit(&admin, &customer, &1000, &3600);
+    let limit = client.get_spend_limit(&customer).unwrap();
+    assert_eq!(limit.limit_amount, 1000);
+    assert_eq!(limit.period_seconds, 3600);
+    assert_eq!(limit.used, 0);
+}
+
+#[test]
+fn test_check_spend_allowance_no_limit() {
+    let (env, client, _) = setup();
+    let customer = Address::generate(&env);
+    // No limit configured — always allowed
+    assert!(client.check_spend_allowance(&customer, &999_999));
+}
+
+#[test]
+fn test_check_spend_allowance_within_limit() {
+    let (env, client, admin) = setup();
+    let customer = Address::generate(&env);
+    client.set_customer_spend_limit(&admin, &customer, &1000, &3600);
+    assert!(client.check_spend_allowance(&customer, &500));
+}
+
+#[test]
+fn test_check_spend_allowance_exceeds_limit() {
+    let (env, client, admin) = setup();
+    let customer = Address::generate(&env);
+    client.set_customer_spend_limit(&admin, &customer, &1000, &3600);
+    assert!(!client.check_spend_allowance(&customer, &1001));
+}
+
+#[test]
+fn test_remove_spend_limit() {
+    let (env, client, admin) = setup();
+    let customer = Address::generate(&env);
+    client.set_customer_spend_limit(&admin, &customer, &1000, &3600);
+    client.remove_customer_spend_limit(&admin, &customer);
+    assert!(client.get_spend_limit(&customer).is_none());
+    // After removal, any amount is allowed
+    assert!(client.check_spend_allowance(&customer, &999_999));
+}
+
+#[test]
+fn test_spend_limit_enforced_on_create_payment() {
+    let (env, client, admin) = setup();
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    // Register a token
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&customer, &10_000);
+
+    // Set a tight spend limit
+    client.set_customer_spend_limit(&admin, &customer, &100, &3600);
+
+    // Payment of 200 should fail
+    let result = client.try_create_payment(
+        &customer,
+        &merchant,
+        &200,
+        &token_addr,
+        &Currency::USDC,
+        &0,
+        &soroban_sdk::String::from_str(&env, ""),
+    );
+    assert_eq!(result, Err(Ok(Error::SpendLimitExceeded)));
+}
+
+#[test]
+fn test_period_auto_reset() {
+    let (env, client, admin) = setup();
+    let customer = Address::generate(&env);
+    client.set_customer_spend_limit(&admin, &customer, &1000, &3600);
+
+    // Advance time past the period
+    env.ledger().with_mut(|l| l.timestamp = 7200);
+
+    // After period reset, full limit is available again
+    assert!(client.check_spend_allowance(&customer, &1000));
+}

--- a/contracts/payment/src/test_subscription_groups.rs
+++ b/contracts/payment/src/test_subscription_groups.rs
@@ -1,0 +1,133 @@
+#![cfg(test)]
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{Currency, Error, PaymentContract, PaymentContractClient};
+
+fn setup() -> (Env, PaymentContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PaymentContract);
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin)
+}
+
+fn create_sub(
+    env: &Env,
+    client: &PaymentContractClient,
+    customer: &Address,
+    merchant: &Address,
+    token: &Address,
+) -> u64 {
+    client.create_subscription(
+        customer,
+        merchant,
+        &100,
+        token,
+        &Currency::USDC,
+        &2592000,
+        &0,
+        &3,
+        &String::from_str(env, ""),
+        &0,
+    )
+}
+
+#[test]
+fn test_create_group() {
+    let (env, client, _) = setup();
+    let owner = Address::generate(&env);
+    let group_id = client.create_subscription_group(&owner, &500);
+    assert_eq!(group_id, 1);
+    let group = client.get_subscription_group(&group_id).unwrap();
+    assert_eq!(group.owner, owner);
+    assert_eq!(group.discount_bps, 500);
+    assert!(group.active);
+    assert_eq!(group.subscription_ids.len(), 0);
+}
+
+#[test]
+fn test_add_and_remove_from_group() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&owner, &100_000);
+
+    let group_id = client.create_subscription_group(&owner, &200);
+    let sub_id = create_sub(&env, &client, &owner, &merchant, &token_addr);
+
+    client.add_to_group(&owner, &group_id, &sub_id);
+    let group = client.get_subscription_group(&group_id).unwrap();
+    assert_eq!(group.subscription_ids.len(), 1);
+
+    client.remove_from_group(&owner, &group_id, &sub_id);
+    let group = client.get_subscription_group(&group_id).unwrap();
+    assert_eq!(group.subscription_ids.len(), 0);
+}
+
+#[test]
+fn test_subscription_already_in_group() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&owner, &100_000);
+
+    let group_id = client.create_subscription_group(&owner, &200);
+    let sub_id = create_sub(&env, &client, &owner, &merchant, &token_addr);
+
+    client.add_to_group(&owner, &group_id, &sub_id);
+    let result = client.try_add_to_group(&owner, &group_id, &sub_id);
+    assert_eq!(result, Err(Ok(Error::SubscriptionAlreadyInGroup)));
+}
+
+#[test]
+fn test_group_size_limit() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&owner, &10_000_000);
+
+    let group_id = client.create_subscription_group(&owner, &100);
+
+    for _ in 0..20 {
+        let sub_id = create_sub(&env, &client, &owner, &merchant, &token_addr);
+        client.add_to_group(&owner, &group_id, &sub_id);
+    }
+
+    // 21st should fail
+    let sub_id = create_sub(&env, &client, &owner, &merchant, &token_addr);
+    let result = client.try_add_to_group(&owner, &group_id, &sub_id);
+    assert_eq!(result, Err(Ok(Error::GroupSizeLimitExceeded)));
+}
+
+#[test]
+fn test_group_not_found() {
+    let (env, client, _) = setup();
+    let owner = Address::generate(&env);
+    let result = client.try_add_to_group(&owner, &999, &1);
+    assert_eq!(result, Err(Ok(Error::GroupNotFound)));
+}
+
+#[test]
+fn test_get_group_next_billing() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
+    token.mint(&owner, &100_000);
+
+    let group_id = client.create_subscription_group(&owner, &0);
+    let sub_id = create_sub(&env, &client, &owner, &merchant, &token_addr);
+    client.add_to_group(&owner, &group_id, &sub_id);
+
+    let next = client.get_group_next_billing(&group_id);
+    assert!(next > 0);
+}


### PR DESCRIPTION
…, and finality delay

`feat(payment): Implement admin fee collection sweep to platform treasury` Fixes #216

`feat(payment): Add per-customer spending limits enforced by admin` Fixes #217

`feat(payment): Implement subscription group linking with group-level discount` Fixes #218

`feat(payment): Implement settlement finality delay for chargeback window compliance` Fixes #219