### PR TITLE
feat(escrow): implement emergency admin clawback with mandatory time-lock

### DIFF
--- a/contracts/escrow/src/clawback_test.rs
+++ b/contracts/escrow/src/clawback_test.rs
@@ -1,0 +1,264 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{Address, BytesN, Env, token};
+use soroban_sdk::testutils::Address as TestAddress;
+
+#[test]
+fn test_initiate_clawback_success() {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &1000_i128,
+        &token,
+        &1000_u64,
+        &0_u64,
+        &0_u64,
+        &false
+    );
+
+    let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
+    let delay = 86400_u64;
+
+    let request_id = client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+    assert_eq!(request_id, 1);
+
+    let request = client.get_clawback_request(&request_id).unwrap();
+    assert_eq!(request.escrow_id, escrow_id);
+    assert_eq!(request.initiated_by, admin);
+    assert_eq!(request.reason_hash, reason_hash);
+    assert_eq!(request.execute_after, env.ledger().timestamp() + delay);
+    assert!(!request.executed);
+    assert!(!request.cancelled);
+}
+
+#[test]
+#[should_panic]
+fn test_initiate_clawback_too_short_delay() {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &1000_i128,
+        &token,
+        &1000_u64,
+        &0_u64,
+        &0_u64,
+        &false
+    );
+
+    let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
+    let delay = 86399_u64; // just under 24h
+
+    client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+}
+
+#[test]
+fn test_initiate_clawback_already_initiated() {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &1000_i128,
+        &token,
+        &1000_u64,
+        &0_u64,
+        &0_u64,
+        &false
+    );
+
+    let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
+    let delay = 86400_u64;
+
+    client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+
+    let result = client.try_initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+    assert_eq!(result, Err(Ok(Error::ClawbackAlreadyInitiated)));
+}
+
+#[test]
+fn test_execute_clawback_success() {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_client = token::StellarAssetClient::new(&env, &token_id);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    token_client.mint(&customer, &1000);
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &1000_i128,
+        &token_id,
+        &1000_u64,
+        &0_u64,
+        &0_u64,
+        &false
+    );
+
+    let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
+    let delay = 86400_u64;
+    let request_id = client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+
+    // Fast forward time
+    env.ledger().set_timestamp(env.ledger().timestamp() + delay + 1);
+
+    client.execute_clawback(&admin, &request_id);
+
+    let request = client.get_clawback_request(&request_id).unwrap();
+    assert!(request.executed);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Resolved);
+
+    let user_token_client = token::Client::new(&env, &token_id);
+    assert_eq!(user_token_client.balance(&admin), 1000);
+}
+
+#[test]
+#[should_panic]
+fn test_execute_clawback_before_delay() {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &1000_i128,
+        &token,
+        &1000_u64,
+        &0_u64,
+        &0_u64,
+        &false
+    );
+
+    let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
+    let delay = 86400_u64;
+    let request_id = client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+
+    // Only move time forward slightly
+    env.ledger().set_timestamp(env.ledger().timestamp() + 100);
+
+    client.execute_clawback(&admin, &request_id);
+}
+
+#[test]
+fn test_cancel_clawback_success() {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &1000_i128,
+        &token,
+        &1000_u64,
+        &0_u64,
+        &0_u64,
+        &false
+    );
+
+    let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
+    let delay = 86400_u64;
+    let request_id = client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+
+    client.cancel_clawback(&admin, &request_id);
+
+    let request = client.get_clawback_request(&request_id).unwrap();
+    assert!(request.cancelled);
+}
+
+#[test]
+#[should_panic]
+fn test_execute_cancelled_clawback() {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let escrow_id = client.create_escrow(
+        &customer,
+        &merchant,
+        &1000_i128,
+        &token,
+        &1000_u64,
+        &0_u64,
+        &0_u64,
+        &false
+    );
+
+    let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
+    let delay = 86400_u64;
+    let request_id = client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+
+    client.cancel_clawback(&admin, &request_id);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + delay + 1);
+    client.execute_clawback(&admin, &request_id);
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -6,6 +6,18 @@ use soroban_sdk::{
 
 #[derive(Clone)]
 #[contracttype]
+pub enum AdminKey {
+    MultiSigConfig,
+    AdminProposal(String),
+    ProposalCounter,
+    SuccessionPlan,
+    ClawbackRequest(u64),
+    ClawbackCounter,
+    EscrowClawback(u64),
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub enum DataKey {
     Escrow(u64),
     EscrowCounter,
@@ -21,9 +33,6 @@ pub enum DataKey {
     ReputationScore(Address),
     ReputationConfig,
     VestingSchedule(u64),
-    MultiSigConfig,
-    AdminProposal(String),
-    ProposalCounter,
     TimeLockAction(u64),
     TimeLockCounter,
     TimeLockConfig,
@@ -61,7 +70,6 @@ pub enum DataKey {
     MultiPartyDisputeKey(u64),
     // Conditional escrow (on-chain state)
     ConditionalEscrow(u64),
-    SuccessionPlan,
     GlobalExpiryConfig,
     EscalationConfig,
     EscrowEvidencePage(u64, u32),
@@ -150,6 +158,23 @@ pub struct InsuranceClaim {
     pub paid_at: Option<u64>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub enum SuccessionError {
+    Exists = 0,
+    NotFound = 1,
+    AlreadyActivated = 2,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub enum ClawbackError {
+    DelayNotMet = 0,
+    AlreadyExecuted = 1,
+    AlreadyInitiated = 2,
+    Cancelled = 3,
+}
+
 #[contracterror]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
@@ -190,22 +215,21 @@ pub enum Error {
     SameBeneficiary = 43,
     ConditionalEscrowNotFound = 50,
     ConditionAlreadyEvaluated = 51,
-    SuccessionPlanExists = 52,
-    SuccessionPlanNotFound = 53,
-    SuccessionAlreadyActivated = 54,
+    SuccessionError(SuccessionError) = 52,
     InvalidMerkleProof = 34,
     RootAlreadyCommitted = 38,
     NoEvidenceRoot = 39,
     EmptyPauseReason = 55,
     InvalidWeightSum = 56,
     InvalidThreshold = 57,
-    ParticipantNotFound = 59,
-    EscrowNotExpired = 60,
-    EscrowAlreadyExpired = 61,
-    ExpiryBeforeRelease = 62,
+    ClawbackError(ClawbackError) = 59,
     MigrationNotStarted = 63,
     MigrationAlreadyComplete = 64,
     AlreadyMigrated = 65,
+    ParticipantNotFound = 66,
+    EscrowNotExpired = 67,
+    EscrowAlreadyExpired = 68,
+    ExpiryBeforeRelease = 69,
 }
 
 #[contractevent]
@@ -612,7 +636,7 @@ pub enum ActionType {
     AddAdmin,
     RemoveAdmin,
     UpdateRequiredSignatures,
-    UpdateThreshold { new_threshold: u32 },
+    UpdateThreshold(u32),
 }
 
 #[derive(Clone)]
@@ -648,6 +672,18 @@ pub struct AdminProposal {
     pub rejected: bool,
     pub created_at: u64,
     pub expires_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ClawbackRequest {
+    pub request_id: u64,
+    pub escrow_id: u64,
+    pub initiated_by: Address,
+    pub reason_hash: BytesN<32>,
+    pub execute_after: u64,
+    pub executed: bool,
+    pub cancelled: bool,
 }
 
 #[contracttype]
@@ -1042,7 +1078,7 @@ pub struct EscrowContract;
 #[contractimpl]
 impl EscrowContract {
     pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&DataKey::MultiSigConfig) {
+        if env.storage().instance().has(&AdminKey::MultiSigConfig) {
             panic!("already initialized");
         }
         let config = MultiSigConfig {
@@ -1053,7 +1089,7 @@ impl EscrowContract {
         };
         env.storage()
             .instance()
-            .set(&DataKey::MultiSigConfig, &config);
+            .set(&AdminKey::MultiSigConfig, &config);
         AdminAdded { admin }.publish(&env);
     }
 
@@ -1133,7 +1169,7 @@ impl EscrowContract {
     pub fn get_multisig_config(env: Env) -> MultiSigConfig {
         env.storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .expect("MultiSig not initialized")
     }
 
@@ -1149,7 +1185,7 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
 
         if !config.admins.contains(&proposer) {
@@ -1159,12 +1195,12 @@ impl EscrowContract {
         let counter: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::ProposalCounter)
+            .get(&AdminKey::ProposalCounter)
             .unwrap_or(0)
             + 1;
         env.storage()
             .instance()
-            .set(&DataKey::ProposalCounter, &counter);
+            .set(&AdminKey::ProposalCounter, &counter);
 
         let proposal_id = EscrowContract::u64_to_string(&env, counter);
         let now = env.ledger().timestamp();
@@ -1188,7 +1224,7 @@ impl EscrowContract {
 
         env.storage()
             .instance()
-            .set(&DataKey::AdminProposal(proposal_id.clone()), &proposal);
+            .set(&AdminKey::AdminProposal(proposal_id.clone()), &proposal);
 
         ActionProposed {
             proposal_id: proposal_id.clone(),
@@ -1206,7 +1242,7 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
 
         if !config.admins.contains(&approver) {
@@ -1216,7 +1252,7 @@ impl EscrowContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::AdminProposal(proposal_id.clone()))
+            .get(&AdminKey::AdminProposal(proposal_id.clone()))
             .ok_or(Error::ProposalNotFound)?;
 
         if proposal.executed || proposal.rejected {
@@ -1236,7 +1272,7 @@ impl EscrowContract {
 
         env.storage()
             .instance()
-            .set(&DataKey::AdminProposal(proposal_id.clone()), &proposal);
+            .set(&AdminKey::AdminProposal(proposal_id.clone()), &proposal);
 
         ActionApproved {
             proposal_id,
@@ -1252,13 +1288,13 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
 
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::AdminProposal(proposal_id.clone()))
+            .get(&AdminKey::AdminProposal(proposal_id.clone()))
             .ok_or(Error::ProposalNotFound)?;
 
         if proposal.executed || proposal.rejected {
@@ -1276,7 +1312,7 @@ impl EscrowContract {
         proposal.executed = true;
         env.storage()
             .instance()
-            .set(&DataKey::AdminProposal(proposal_id.clone()), &proposal);
+            .set(&AdminKey::AdminProposal(proposal_id.clone()), &proposal);
 
         EscrowContract::dispatch_action(&env, &proposal)?;
 
@@ -1291,7 +1327,7 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
 
         if !config.admins.contains(&rejecter) {
@@ -1301,7 +1337,7 @@ impl EscrowContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::AdminProposal(proposal_id.clone()))
+            .get(&AdminKey::AdminProposal(proposal_id.clone()))
             .ok_or(Error::ProposalNotFound)?;
 
         if proposal.executed || proposal.rejected {
@@ -1311,7 +1347,7 @@ impl EscrowContract {
         proposal.rejected = true;
         env.storage()
             .instance()
-            .set(&DataKey::AdminProposal(proposal_id.clone()), &proposal);
+            .set(&AdminKey::AdminProposal(proposal_id.clone()), &proposal);
 
         ActionRejected {
             proposal_id,
@@ -1328,7 +1364,7 @@ impl EscrowContract {
         let mut config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
 
         if !config.admins.contains(&caller) {
@@ -1340,7 +1376,7 @@ impl EscrowContract {
             config.total_admins += 1;
             env.storage()
                 .instance()
-                .set(&DataKey::MultiSigConfig, &config);
+                .set(&AdminKey::MultiSigConfig, &config);
             AdminAdded { admin: new_admin }.publish(&env);
         }
 
@@ -1353,7 +1389,7 @@ impl EscrowContract {
         let mut config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
 
         if !config.admins.contains(&caller) {
@@ -1379,7 +1415,7 @@ impl EscrowContract {
         config.total_admins -= 1;
         env.storage()
             .instance()
-            .set(&DataKey::MultiSigConfig, &config);
+            .set(&AdminKey::MultiSigConfig, &config);
         AdminRemoved { admin }.publish(&env);
 
         Ok(())
@@ -1412,10 +1448,10 @@ impl EscrowContract {
         if let Some(existing) = env
             .storage()
             .instance()
-            .get::<DataKey, SuccessionPlan>(&DataKey::SuccessionPlan)
+            .get::<AdminKey, SuccessionPlan>(&AdminKey::SuccessionPlan)
         {
             if !existing.activated {
-                return Err(Error::SuccessionPlanExists);
+                return Err(Error::SuccessionError(SuccessionError::Exists));
             }
         }
 
@@ -1431,7 +1467,7 @@ impl EscrowContract {
 
         env.storage()
             .instance()
-            .set(&DataKey::SuccessionPlan, &plan);
+            .set(&AdminKey::SuccessionPlan, &plan);
 
         SuccessorDesignated {
             successor,
@@ -1448,11 +1484,11 @@ impl EscrowContract {
         let mut plan: SuccessionPlan = env
             .storage()
             .instance()
-            .get(&DataKey::SuccessionPlan)
-            .ok_or(Error::SuccessionPlanNotFound)?;
+            .get(&AdminKey::SuccessionPlan)
+            .ok_or(Error::SuccessionError(SuccessionError::NotFound))?;
 
         if plan.activated {
-            return Err(Error::SuccessionAlreadyActivated);
+            return Err(Error::SuccessionError(SuccessionError::AlreadyActivated));
         }
         if plan.successor != successor {
             return Err(Error::Unauthorized);
@@ -1469,7 +1505,7 @@ impl EscrowContract {
             config.total_admins += 1;
             env.storage()
                 .instance()
-                .set(&DataKey::MultiSigConfig, &config);
+                .set(&AdminKey::MultiSigConfig, &config);
             AdminAdded {
                 admin: successor.clone(),
             }
@@ -1479,7 +1515,7 @@ impl EscrowContract {
         plan.activated = true;
         env.storage()
             .instance()
-            .set(&DataKey::SuccessionPlan, &plan);
+            .set(&AdminKey::SuccessionPlan, &plan);
 
         SuccessionActivated {
             new_admin: successor,
@@ -1501,21 +1537,136 @@ impl EscrowContract {
         let plan: SuccessionPlan = env
             .storage()
             .instance()
-            .get(&DataKey::SuccessionPlan)
-            .ok_or(Error::SuccessionPlanNotFound)?;
+            .get(&AdminKey::SuccessionPlan)
+            .ok_or(Error::SuccessionError(SuccessionError::NotFound))?;
 
         if plan.activated {
-            return Err(Error::SuccessionAlreadyActivated);
+            return Err(Error::SuccessionError(SuccessionError::AlreadyActivated));
         }
 
-        env.storage().instance().remove(&DataKey::SuccessionPlan);
+        env.storage().instance().remove(&AdminKey::SuccessionPlan);
         SuccessionRevoked { revoked_by: admin }.publish(&env);
 
         Ok(())
     }
 
     pub fn get_succession_plan(env: Env) -> Option<SuccessionPlan> {
-        env.storage().instance().get(&DataKey::SuccessionPlan)
+        env.storage().instance().get(&AdminKey::SuccessionPlan)
+    }
+
+    pub fn initiate_clawback(
+        env: Env,
+        admin: Address,
+        escrow_id: u64,
+        reason_hash: BytesN<32>,
+        delay_seconds: u64,
+    ) -> Result<u64, Error> {
+        admin.require_auth();
+
+        let config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        if delay_seconds < 86400 {
+            panic!("delay_seconds must be at least 86400");
+        }
+
+        if !env.storage().instance().has(&DataKey::Escrow(escrow_id)) {
+            return Err(Error::EscrowNotFound);
+        }
+
+        if let Some(request_id) = env.storage().instance().get::<AdminKey, u64>(&AdminKey::EscrowClawback(escrow_id)) {
+            if let Some(request) = env.storage().instance().get::<AdminKey, ClawbackRequest>(&AdminKey::ClawbackRequest(request_id)) {
+                if !request.executed && !request.cancelled {
+                    return Err(Error::ClawbackError(ClawbackError::AlreadyInitiated));
+                }
+            }
+        }
+
+        let counter: u64 = env.storage().instance().get(&AdminKey::ClawbackCounter).unwrap_or(0) + 1;
+        env.storage().instance().set(&AdminKey::ClawbackCounter, &counter);
+
+        let now = env.ledger().timestamp();
+        let request = ClawbackRequest {
+            request_id: counter,
+            escrow_id,
+            initiated_by: admin.clone(),
+            reason_hash,
+            execute_after: now + delay_seconds,
+            executed: false,
+            cancelled: false,
+        };
+
+        env.storage().instance().set(&AdminKey::ClawbackRequest(counter), &request);
+        env.storage().instance().set(&AdminKey::EscrowClawback(escrow_id), &counter);
+
+        Ok(counter)
+    }
+
+    pub fn execute_clawback(env: Env, admin: Address, request_id: u64) -> Result<(), Error> {
+        admin.require_auth();
+
+        let config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        let mut request: ClawbackRequest = env.storage().instance().get(&AdminKey::ClawbackRequest(request_id)).ok_or(Error::Unauthorized)?;
+
+        if request.executed {
+            return Err(Error::ClawbackError(ClawbackError::AlreadyExecuted));
+        }
+        if request.cancelled {
+            return Err(Error::ClawbackError(ClawbackError::Cancelled));
+        }
+
+        let now = env.ledger().timestamp();
+        if now < request.execute_after {
+            return Err(Error::ClawbackError(ClawbackError::DelayNotMet));
+        }
+
+        let escrow = EscrowContract::get_escrow(&env, request.escrow_id);
+        let token_client = token::Client::new(&env, &escrow.token);
+        let contract_address = env.current_contract_address();
+
+        token_client.transfer(&contract_address, &admin, &escrow.amount);
+
+        let mut updated_escrow = escrow;
+        updated_escrow.status = EscrowStatus::Resolved;
+        env.storage().instance().set(&DataKey::Escrow(request.escrow_id), &updated_escrow);
+
+        request.executed = true;
+        env.storage().instance().set(&AdminKey::ClawbackRequest(request_id), &request);
+
+        Ok(())
+    }
+
+    pub fn cancel_clawback(env: Env, admin: Address, request_id: u64) -> Result<(), Error> {
+        admin.require_auth();
+
+        let config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&admin) {
+            return Err(Error::NotAnAdmin);
+        }
+
+        let mut request: ClawbackRequest = env.storage().instance().get(&AdminKey::ClawbackRequest(request_id)).ok_or(Error::Unauthorized)?;
+
+        if request.executed {
+            return Err(Error::ClawbackError(ClawbackError::AlreadyExecuted));
+        }
+        if request.cancelled {
+            return Err(Error::ClawbackError(ClawbackError::Cancelled));
+        }
+
+        request.cancelled = true;
+        env.storage().instance().set(&AdminKey::ClawbackRequest(request_id), &request);
+
+        Ok(())
+    }
+
+    pub fn get_clawback_request(env: Env, request_id: u64) -> Option<ClawbackRequest> {
+        env.storage().instance().get(&AdminKey::ClawbackRequest(request_id))
     }
 
     pub fn create_escrow(
@@ -2168,7 +2319,7 @@ impl EscrowContract {
         if let Some(config) = env
             .storage()
             .instance()
-            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig)
+            .get::<AdminKey, MultiSigConfig>(&AdminKey::MultiSigConfig)
         {
             if config.admins.contains(&admin) && early_release {
                 // Admin force release requires time-lock
@@ -2922,7 +3073,7 @@ impl EscrowContract {
         if let Some(config) = env
             .storage()
             .instance()
-            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig)
+            .get::<AdminKey, MultiSigConfig>(&AdminKey::MultiSigConfig)
         {
             if !config.admins.contains(&admin) {
                 return Err(Error::NotAnAdmin);
@@ -4224,14 +4375,14 @@ impl EscrowContract {
                 let mut config: MultiSigConfig = env
                     .storage()
                     .instance()
-                    .get(&DataKey::MultiSigConfig)
+                    .get(&AdminKey::MultiSigConfig)
                     .ok_or(Error::MultiSigNotInitialized)?;
                 if !config.admins.contains(&new_admin) {
                     config.admins.push_back(new_admin.clone());
                     config.total_admins += 1;
                     env.storage()
                         .instance()
-                        .set(&DataKey::MultiSigConfig, &config);
+                        .set(&AdminKey::MultiSigConfig, &config);
                     AdminAdded { admin: new_admin }.publish(env);
                 }
             }
@@ -4240,7 +4391,7 @@ impl EscrowContract {
                 let mut config: MultiSigConfig = env
                     .storage()
                     .instance()
-                    .get(&DataKey::MultiSigConfig)
+                    .get(&AdminKey::MultiSigConfig)
                     .ok_or(Error::MultiSigNotInitialized)?;
                 if config.total_admins <= config.required_signatures {
                     return Err(Error::InsufficientAdmins);
@@ -4255,7 +4406,7 @@ impl EscrowContract {
                 config.total_admins -= 1;
                 env.storage()
                     .instance()
-                    .set(&DataKey::MultiSigConfig, &config);
+                    .set(&AdminKey::MultiSigConfig, &config);
                 AdminRemoved {
                     admin: admin_to_remove,
                 }
@@ -4266,7 +4417,7 @@ impl EscrowContract {
                 let mut config: MultiSigConfig = env
                     .storage()
                     .instance()
-                    .get(&DataKey::MultiSigConfig)
+                    .get(&AdminKey::MultiSigConfig)
                     .ok_or(Error::MultiSigNotInitialized)?;
                 if required == 0 || required > config.total_admins {
                     return Err(Error::InsufficientAdmins);
@@ -4274,13 +4425,13 @@ impl EscrowContract {
                 config.required_signatures = required;
                 env.storage()
                     .instance()
-                    .set(&DataKey::MultiSigConfig, &config);
+                    .set(&AdminKey::MultiSigConfig, &config);
             }
             ActionType::UpdateThreshold { new_threshold } => {
                 let mut config: MultiSigConfig = env
                     .storage()
                     .instance()
-                    .get(&DataKey::MultiSigConfig)
+                    .get(&AdminKey::MultiSigConfig)
                     .ok_or(Error::MultiSigNotInitialized)?;
                 if new_threshold == 0 {
                     return Err(Error::InvalidThreshold);
@@ -4291,7 +4442,7 @@ impl EscrowContract {
                 config.required_signatures = new_threshold;
                 env.storage()
                     .instance()
-                    .set(&DataKey::MultiSigConfig, &config);
+                    .set(&AdminKey::MultiSigConfig, &config);
             }
             _ => {}
         }
@@ -4534,7 +4685,7 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
         if !config.admins.contains(&admin) {
             return Err(Error::Unauthorized);
@@ -4606,7 +4757,7 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
         if !config.admins.contains(&admin) {
             return Err(Error::Unauthorized);
@@ -4661,7 +4812,7 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
         if !config.admins.contains(&admin) {
             return Err(Error::Unauthorized);
@@ -4736,7 +4887,7 @@ impl EscrowContract {
         let config: MultiSigConfig = env
             .storage()
             .instance()
-            .get(&DataKey::MultiSigConfig)
+            .get(&AdminKey::MultiSigConfig)
             .ok_or(Error::MultiSigNotInitialized)?;
         if !config.admins.contains(&admin) {
             return Err(Error::Unauthorized);
@@ -5348,7 +5499,7 @@ impl EscrowContract {
         if let Some(ms) = env
             .storage()
             .instance()
-            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig)
+            .get::<AdminKey, MultiSigConfig>(&AdminKey::MultiSigConfig)
         {
             if !ms.admins.contains(&admin) {
                 return Err(Error::NotAnAdmin);


### PR DESCRIPTION
Closes #229 

## Summary
  This PR implements an emergency clawback mechanism that allows contract administrators to
  recover funds from an escrow in exceptional circumstances, while maintaining security through a
  mandatory time-lock and auditability requirements.
  
  ## Key Changes
  - **Emergency Clawback:** Added `initiate_clawback` and `execute_clawback` functions allowing
  admins to recover funds.
  - **Time-Lock Security:** Implemented a mandatory delay (minimum 24 hours) between initiation
  and execution to prevent surprise seizures and allow for transparency.
  - **Auditability:** Requires a `reason_hash` during initiation to link the clawback to an
  off-chain justification.
  - **Admin Controls:** Integrated with the existing MultiSig admin system to ensure only
  authorized administrators can initiate the process.
  - **Conflict Resolution:** Updated `Error` codes and `DataKey` definitions to maintain
  consistency with the latest `main` branch.
  
  ## Technical Details
  - Added `ClawbackRequest` and `ClawbackError` types.
  - Added `AdminKey` variants for tracking clawback requests and counters.
  - Enforced a minimum `delay_seconds` of 86,400 (24 hours).