### PR TITLE
Add refund policy template management with admin create/apply/deactiv…

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -30,6 +30,8 @@ pub enum DataKey {
     // Policy versioning (#134)
     RefundPolicyVersion(Address, u32),
     RefundPolicyVersionCount(Address),
+    RefundPolicyTemplate(u64),
+    RefundPolicyTemplateCount,
     // Payment contract address (#143)
     PaymentContractAddress,
     // Batch refund limit (#135)
@@ -82,6 +84,8 @@ pub enum Error {
     PaymentContractNotSet = 27,
     PaymentOwnershipMismatch = 28,
     CircuitBreakerTripped = 29,
+    TemplateNotFound = 33,
+    TemplateInactive = 34,
 }
 
 #[contractevent]
@@ -217,6 +221,38 @@ pub struct RefundPolicyVersion {
     pub policy: RefundPolicy,
     pub created_at: u64,
     pub created_by: Address,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct RefundPolicyTemplate {
+    pub template_id: u64,
+    pub name: String,
+    pub tiers: Vec<(u32, i128)>,
+    pub default_window_seconds: u64,
+    pub active: bool,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundPolicyTemplateCreated {
+    pub template_id: u64,
+    pub created_by: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundPolicyTemplateDeactivated {
+    pub template_id: u64,
+    pub deactivated_by: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundPolicyTemplateApplied {
+    pub template_id: u64,
+    pub merchant: Address,
+    pub applied_by: Address,
 }
 
 // ── Issue #135: Batch refund result struct ─────────────────────────────────
@@ -1015,9 +1051,19 @@ impl RefundContract {
             active: true,
         };
 
+        Self::store_refund_policy(&env, merchant.clone(), policy, merchant.clone());
+
+        Ok(())
+    }
+
+    fn store_refund_policy(
+        env: &Env,
+        merchant: Address,
+        policy: RefundPolicy,
+        created_by: Address,
+    ) {
         env.storage().instance().set(&DataKey::RefundPolicy(merchant.clone()), &policy);
 
-        // ── Issue #134: version the policy ──────────────────────────────────
         let version_count: u32 = env
             .storage()
             .instance()
@@ -1028,7 +1074,7 @@ impl RefundContract {
             version: new_version,
             policy: policy.clone(),
             created_at: env.ledger().timestamp(),
-            created_by: merchant.clone(),
+            created_by,
         };
         env.storage().instance().set(
             &DataKey::RefundPolicyVersion(merchant.clone(), new_version),
@@ -1042,8 +1088,168 @@ impl RefundContract {
         // Emit RefundPolicySet event
         (RefundPolicySet {
             merchant,
-            refund_window,
-        }).publish(&env);
+            refund_window: policy.refund_window,
+        }).publish(env);
+    }
+
+    pub fn create_policy_template(
+        env: Env,
+        admin: Address,
+        name: String,
+        tiers: Vec<(u32, i128)>,
+        window: u64,
+    ) -> Result<u64, Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let template_count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundPolicyTemplateCount)
+            .unwrap_or(0);
+        let template_id = template_count + 1;
+        let template = RefundPolicyTemplate {
+            template_id,
+            name,
+            tiers,
+            default_window_seconds: window,
+            active: true,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicyTemplate(template_id), &template);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicyTemplateCount, &template_id);
+
+        (RefundPolicyTemplateCreated {
+            template_id,
+            created_by: admin,
+        })
+        .publish(&env);
+
+        Ok(template_id)
+    }
+
+    pub fn apply_template_to_merchant(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+        template_id: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let template: RefundPolicyTemplate = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundPolicyTemplate(template_id))
+            .ok_or(Error::TemplateNotFound)?;
+
+        if !template.active {
+            return Err(Error::TemplateInactive);
+        }
+
+        let policy = RefundPolicy {
+            merchant: merchant.clone(),
+            refund_window: template.default_window_seconds,
+            max_refund_percentage: 10000,
+            requires_admin_approval: true,
+            auto_approve_below: 0,
+            active: true,
+        };
+
+        Self::store_refund_policy(&env, merchant.clone(), policy, admin.clone());
+        (RefundPolicyTemplateApplied {
+            template_id,
+            merchant,
+            applied_by: admin,
+        })
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_policy_template(
+        env: Env,
+        template_id: u64,
+    ) -> Option<RefundPolicyTemplate> {
+        env.storage()
+            .instance()
+            .get(&DataKey::RefundPolicyTemplate(template_id))
+    }
+
+    pub fn list_policy_templates(env: Env) -> Vec<RefundPolicyTemplate> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundPolicyTemplateCount)
+            .unwrap_or(0);
+        let mut templates = Vec::new(&env);
+        for id in 1..=count {
+            if let Some(template) = env
+                .storage()
+                .instance()
+                .get::<_, RefundPolicyTemplate>(&DataKey::RefundPolicyTemplate(id))
+            {
+                if template.active {
+                    templates.push_back(template);
+                }
+            }
+        }
+        templates
+    }
+
+    pub fn deactivate_policy_template(
+        env: Env,
+        admin: Address,
+        template_id: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut template: RefundPolicyTemplate = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundPolicyTemplate(template_id))
+            .ok_or(Error::TemplateNotFound)?;
+
+        if !template.active {
+            return Err(Error::TemplateInactive);
+        }
+
+        template.active = false;
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicyTemplate(template_id), &template);
+
+        (RefundPolicyTemplateDeactivated {
+            template_id,
+            deactivated_by: admin,
+        })
+        .publish(&env);
 
         Ok(())
     }

--- a/contracts/refund/src/test_policy.rs
+++ b/contracts/refund/src/test_policy.rs
@@ -40,6 +40,120 @@ fn test_set_refund_policy_successfully() {
 }
 
 #[test]
+fn test_create_policy_template_successfully() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    env.mock_all_auths();
+    let tiers: Vec<(u32, i128)> = Vec::new(&env);
+    let template_id = client.create_policy_template(
+        &admin,
+        &String::from_str(&env, "Standard Template"),
+        &tiers,
+        &86400u64,
+    );
+
+    let template = client.get_policy_template(&template_id);
+    assert!(template.is_some());
+    let template = template.unwrap();
+    assert_eq!(template.template_id, template_id);
+    assert_eq!(template.name, String::from_str(&env, "Standard Template"));
+    assert_eq!(template.default_window_seconds, 86400u64);
+    assert!(template.active);
+}
+
+#[test]
+fn test_list_policy_templates_returns_only_active_templates() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    env.mock_all_auths();
+    let tiers: Vec<(u32, i128)> = Vec::new(&env);
+    let template_id_1 = client.create_policy_template(
+        &admin,
+        &String::from_str(&env, "Active Template"),
+        &tiers,
+        &86400u64,
+    );
+    let template_id_2 = client.create_policy_template(
+        &admin,
+        &String::from_str(&env, "Inactive Template"),
+        &tiers,
+        &172800u64,
+    );
+
+    client.deactivate_policy_template(&admin, &template_id_2);
+
+    let templates = client.list_policy_templates();
+    assert_eq!(templates.len(), 1);
+    assert_eq!(templates.get(0).unwrap().template_id, template_id_1);
+}
+
+#[test]
+fn test_apply_template_to_merchant_overwrites_policy_and_preserves_history() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    client.initialize(&admin);
+
+    env.mock_all_auths();
+    client.set_refund_policy(&merchant, &(7u64 * 24u64 * 60u64 * 60u64), &5000, &true, &0i128);
+
+    let tiers: Vec<(u32, i128)> = Vec::new(&env);
+    let template_id = client.create_policy_template(
+        &admin,
+        &String::from_str(&env, "Template Policy"),
+        &tiers,
+        &259200u64,
+    );
+
+    client.apply_template_to_merchant(&admin, &merchant, &template_id);
+
+    let policy = client.get_refund_policy(&merchant).unwrap();
+    assert_eq!(policy.refund_window, 259200u64);
+    assert!(policy.active);
+
+    let version_2 = client.get_refund_policy_version(&merchant, &2u32).unwrap();
+    assert_eq!(version_2.policy.refund_window, 259200u64);
+}
+
+#[test]
+fn test_apply_inactive_policy_template_returns_template_inactive() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    client.initialize(&admin);
+
+    env.mock_all_auths();
+    let tiers: Vec<(u32, i128)> = Vec::new(&env);
+    let template_id = client.create_policy_template(
+        &admin,
+        &String::from_str(&env, "Inactive Template"),
+        &tiers,
+        &86400u64,
+    );
+
+    client.deactivate_policy_template(&admin, &template_id);
+
+    let result = client.try_apply_template_to_merchant(&admin, &merchant, &template_id);
+    assert_eq!(result, Err(Ok(Error::TemplateInactive)));
+}
+
+#[test]
 #[should_panic]
 fn test_set_refund_policy_with_invalid_percentage_should_fail() {
     let env = Env::default();


### PR DESCRIPTION
…ate support and tests.
closes #196 
## PR Summary

Adds refund policy template support to the refund contract so admins can create reusable merchant refund policy templates and apply them quickly.

### What changed

- Added `RefundPolicyTemplate` storage and admin-managed template lifecycle
- Implemented:
  - `create_policy_template`
  - `apply_template_to_merchant`
  - `get_policy_template`
  - `list_policy_templates`
  - `deactivate_policy_template`
- Added new errors:
  - `TemplateNotFound`
  - `TemplateInactive`
- Ensured applying an inactive template fails
- Ensured template application overwrites merchant policy while preserving version history
- `list_policy_templates()` returns only active templates

### Tests

- Template creation
- Template listing filters inactive templates
- Template application replaces existing merchant policy
- Applying inactive template returns `TemplateInactive`