### PR TITLE
Add escrow renewal mechanism for extending expired agreements

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -89,6 +89,10 @@ pub enum DataKey {
     DisputeAppealCounter,
     DisputeRoundKey(u64),
     AppealsByEscrow(u64, u64),
+    // Escrow renewal mechanism
+    EscrowRenewalConfig,
+    EscrowRenewal(u64),
+    EscrowRenewalCount(u64),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -186,6 +190,7 @@ pub struct InsuranceConfig {
     pub enabled: bool,
 }
 
+#[derive(Clone)]
 #[contracttype]
 pub struct InsuranceClaim {
     pub claim_id: u64,
@@ -194,6 +199,30 @@ pub struct InsuranceClaim {
     pub amount: i128,
     pub approved: bool,
     pub paid_at: Option<u64>,
+}
+
+/// Configuration for escrow renewal mechanism
+#[derive(Clone)]
+#[contracttype]
+pub struct EscrowRenewalConfig {
+    pub enabled: bool,
+    pub max_renewals: u32,           // Maximum number of times an escrow can be renewed
+    pub renewal_fee_bps: u32,        // Fee in basis points for renewal
+    pub min_renewal_period: u64,     // Minimum renewal period in seconds
+    pub max_renewal_period: u64,     // Maximum renewal period in seconds
+}
+
+/// Tracks escrow renewal history
+#[derive(Clone)]
+#[contracttype]
+pub struct EscrowRenewal {
+    pub renewal_id: u64,
+    pub escrow_id: u64,
+    pub renewed_by: Address,
+    pub new_expiry_timestamp: u64,
+    pub renewal_fee: i128,
+    pub renewed_at: u64,
+    pub renewal_count: u32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -282,6 +311,11 @@ pub enum Error {
     AppealWindowClosed = 73,
     AppealAlreadyFiled = 74,
     MaxDisputeRoundsReached = 75,
+    // Escrow renewal errors
+    EscrowRenewalNotAllowed = 76,
+    EscrowRenewalConfigNotSet = 77,
+    InvalidRenewalPeriod = 78,
+    MaxRenewalsExceeded = 79,
 }
 
 #[contractevent]
@@ -451,6 +485,28 @@ pub struct AppealResolved {
     pub escrow_id: u64,
     pub in_favor_of: Address,
     pub resolved_at: u64,
+}
+
+/// Event emitted when an escrow is renewed
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowRenewed {
+    pub escrow_id: u64,
+    pub renewed_by: Address,
+    pub new_expiry_timestamp: u64,
+    pub renewal_fee: i128,
+    pub renewal_count: u32,
+}
+
+/// Event emitted when escrow renewal configuration is updated
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowRenewalConfigUpdated {
+    pub max_renewals: u32,
+    pub renewal_fee_bps: u32,
+    pub min_renewal_period: u64,
+    pub max_renewal_period: u64,
+    pub updated_by: Address,
 }
 
 #[derive(Clone)]
@@ -7492,6 +7548,158 @@ impl EscrowContract {
             return EscrowHealth::Stale;
         }
         EscrowHealth::Healthy
+    }
+
+    // ── ESCROW RENEWAL MECHANISM ────────────────────────────────────────────
+
+    /// Sets the escrow renewal configuration
+    pub fn set_escrow_renewal_config(
+        env: Env,
+        admin: Address,
+        enabled: bool,
+        max_renewals: u32,
+        renewal_fee_bps: u32,
+        min_renewal_period: u64,
+        max_renewal_period: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin = env.storage().instance()
+            .get(&AdminKey::MultiSigConfig)
+            .ok_or(Error::MultiSigNotInitialized)?;
+        
+        // Verify admin is authorized
+        if let MultiSigConfig { admins, .. } = stored_admin {
+            if !admins.contains(&admin) {
+                return Err(Error::NotAnAdmin);
+            }
+        }
+
+        if min_renewal_period == 0 || max_renewal_period == 0 || min_renewal_period > max_renewal_period {
+            return Err(Error::InvalidRenewalPeriod);
+        }
+
+        let config = EscrowRenewalConfig {
+            enabled,
+            max_renewals,
+            renewal_fee_bps,
+            min_renewal_period,
+            max_renewal_period,
+        };
+
+        env.storage().instance().set(&DataKey::EscrowRenewalConfig, &config);
+
+        (EscrowRenewalConfigUpdated {
+            max_renewals,
+            renewal_fee_bps,
+            min_renewal_period,
+            max_renewal_period,
+            updated_by: admin,
+        }).publish(&env);
+
+        Ok(())
+    }
+
+    /// Gets the current escrow renewal configuration
+    pub fn get_escrow_renewal_config(env: Env) -> Option<EscrowRenewalConfig> {
+        env.storage().instance().get(&DataKey::EscrowRenewalConfig)
+    }
+
+    /// Renews an expired escrow agreement by extending its expiry timestamp
+    pub fn renew_escrow(
+        env: Env,
+        escrow_id: u64,
+        renewal_period_seconds: u64,
+        requester: Address,
+    ) -> Result<u64, Error> {
+        requester.require_auth();
+
+        let config = env.storage().instance()
+            .get(&DataKey::EscrowRenewalConfig)
+            .ok_or(Error::EscrowRenewalConfigNotSet)?;
+
+        if !config.enabled {
+            return Err(Error::EscrowRenewalNotAllowed);
+        }
+
+        if renewal_period_seconds < config.min_renewal_period || renewal_period_seconds > config.max_renewal_period {
+            return Err(Error::InvalidRenewalPeriod);
+        }
+
+        let mut escrow: Escrow = env.storage().instance()
+            .get(&DataKey::Escrow(escrow_id))
+            .ok_or(Error::EscrowNotFound)?;
+
+        // Only customer or merchant can renew
+        if requester != escrow.customer && requester != escrow.merchant {
+            return Err(Error::Unauthorized);
+        }
+
+        // Escrow must be expired or near expiry to be renewed
+        let now = env.ledger().timestamp();
+        if escrow.expiry_timestamp == 0 || now < escrow.expiry_timestamp - (7 * 24 * 60 * 60) {
+            return Err(Error::EscrowNotExpired);
+        }
+
+        // Check if escrow is already in a terminal state
+        if escrow.status == EscrowStatus::Released || escrow.status == EscrowStatus::Cancelled {
+            return Err(Error::InvalidStatus);
+        }
+
+        // Count existing renewals for this escrow
+        let renewal_count: u64 = env.storage().instance()
+            .get(&DataKey::EscrowRenewalCount(escrow_id))
+            .unwrap_or(0);
+
+        if renewal_count >= config.max_renewals as u64 {
+            return Err(Error::MaxRenewalsExceeded);
+        }
+
+        // Calculate renewal fee
+        let renewal_fee = (escrow.amount * (config.renewal_fee_bps as i128)) / 10000;
+
+        // Update escrow expiry timestamp
+        let new_expiry = now.saturating_add(renewal_period_seconds);
+        escrow.expiry_timestamp = new_expiry;
+        escrow.last_activity_at = now;
+
+        env.storage().instance().set(&DataKey::Escrow(escrow_id), &escrow);
+
+        // Record renewal
+        let renewal_id = renewal_count + 1;
+        let renewal = EscrowRenewal {
+            renewal_id,
+            escrow_id,
+            renewed_by: requester.clone(),
+            new_expiry_timestamp: new_expiry,
+            renewal_fee,
+            renewed_at: now,
+            renewal_count: renewal_count as u32 + 1,
+        };
+
+        env.storage().instance().set(&DataKey::EscrowRenewal(escrow_id), &renewal);
+        env.storage().instance().set(&DataKey::EscrowRenewalCount(escrow_id), &renewal_id);
+
+        (EscrowRenewed {
+            escrow_id,
+            renewed_by: requester,
+            new_expiry_timestamp: new_expiry,
+            renewal_fee,
+            renewal_count: renewal_count as u32 + 1,
+        }).publish(&env);
+
+        Ok(renewal_id)
+    }
+
+    /// Gets the renewal history for an escrow
+    pub fn get_escrow_renewal(env: Env, escrow_id: u64) -> Option<EscrowRenewal> {
+        env.storage().instance().get(&DataKey::EscrowRenewal(escrow_id))
+    }
+
+    /// Gets the renewal count for an escrow
+    pub fn get_escrow_renewal_count(env: Env, escrow_id: u64) -> u64 {
+        env.storage().instance()
+            .get(&DataKey::EscrowRenewalCount(escrow_id))
+            .unwrap_or(0)
     }
 }
 

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -100,6 +100,12 @@ pub enum SystemKey {
     HooksByEventCount(RefundEventType),
     SubscriberHooks(Address, u64),
     SubscriberHookCount(Address),
+    // Platform fee deduction on refund processing
+    RefundFeeConfig,
+    AccumulatedRefundFees,
+    // Per-customer refund cooldown
+    CustomerRefundCooldown(Address),
+    RefundCooldownConfig,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -174,6 +180,12 @@ pub enum Error {
     HookNotOwnedBySubscriber = 43,
     MerchantQuotaExceeded = 44,
     QuotaNotConfigured = 45,
+    // Platform fee deduction errors
+    RefundFeeConfigNotSet = 46,
+    InsufficientRefundForFee = 47,
+    // Cooldown errors
+    RefundCooldownNotMet = 48,
+    RefundCooldownConfigNotSet = 49,
 }
 
 #[contractevent]
@@ -666,6 +678,35 @@ pub struct GlobalRefundRateLimit {
     pub window_seconds: u64,
 }
 
+/// Configuration for platform fee deduction on refund processing
+#[derive(Clone)]
+#[contracttype]
+pub struct RefundFeeConfig {
+    pub fee_bps: u32,           // Fee in basis points (e.g., 100 = 1%)
+    pub min_fee: i128,          // Minimum fee amount
+    pub max_fee: i128,          // Maximum fee amount
+    pub treasury: Address,      // Address to receive fees
+    pub fee_token: Address,     // Token in which fees are collected
+    pub active: bool,           // Whether fee collection is enabled
+}
+
+/// Per-customer refund cooldown configuration
+#[derive(Clone)]
+#[contracttype]
+pub struct RefundCooldownConfig {
+    pub cooldown_seconds: u64,  // Minimum time between refund requests per customer
+    pub enabled: bool,          // Whether cooldown is enforced
+}
+
+/// Tracks the last refund request time for a customer
+#[derive(Clone)]
+#[contracttype]
+pub struct CustomerRefundCooldown {
+    pub customer: Address,
+    pub last_refund_requested_at: u64,
+    pub cooldown_seconds: u64,
+}
+
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AutoApproved {
@@ -834,6 +875,36 @@ pub struct FraudSignalRaised {
 pub struct FraudSignalReviewed {
     pub address: Address,
     pub reviewed_by: Address,
+}
+
+/// Event emitted when platform fee is deducted from a refund
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundFeeDeducted {
+    pub refund_id: u64,
+    pub fee_amount: i128,
+    pub net_refund_amount: i128,
+    pub treasury: Address,
+}
+
+/// Event emitted when refund fee configuration is updated
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundFeeConfigUpdated {
+    pub fee_bps: u32,
+    pub min_fee: i128,
+    pub max_fee: i128,
+    pub updated_by: Address,
+}
+
+/// Event emitted when customer refund cooldown is enforced
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefundCooldownEnforced {
+    pub customer: Address,
+    pub last_refund_at: u64,
+    pub cooldown_seconds: u64,
+    pub available_at: u64,
 }
 
 #[contract]
@@ -3401,6 +3472,10 @@ impl RefundContract {
                 return Err(Error::AddressFlaggedForFraud);
             }
         }
+
+        // Check per-customer refund cooldown
+        Self::check_refund_cooldown(&env, &customer)?;
+
         if env.storage().instance().has(&DataKey::Admin) {
             Self::validate_against_policy(
                 &env,
@@ -3502,11 +3577,14 @@ impl RefundContract {
             refund_id,
             payment_id,
             merchant,
-            customer,
+            customer: customer.clone(),
             amount,
             token,
         })
         .publish(&env);
+
+        // Update customer refund cooldown
+        Self::update_customer_refund_cooldown(&env, &customer)?;
 
         // Issue #144: Invoke notification hooks for Requested event
         Self::invoke_hooks(&env, RefundEventType::Requested, refund_id);
@@ -3565,6 +3643,14 @@ impl RefundContract {
             refund.payment_id,
             refund.amount,
             refund.original_payment_amount,
+        )?;
+
+        // Deduct platform fee from refund amount
+        let (net_refund_amount, _fee_amount) = Self::deduct_refund_fee(
+            env,
+            refund_id,
+            refund.amount,
+            &refund.token,
         )?;
 
         // Enforce merchant refund quota if configured
@@ -4642,6 +4728,245 @@ impl RefundContract {
         }
 
         results
+    }
+
+    // ── PLATFORM FEE DEDUCTION FUNCTIONS ────────────────────────────────────
+
+    /// Sets the platform fee configuration for refund processing
+    pub fn set_refund_fee_config(
+        env: Env,
+        admin: Address,
+        fee_bps: u32,
+        min_fee: i128,
+        max_fee: i128,
+        treasury: Address,
+        fee_token: Address,
+        active: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin = env.storage().instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let config = RefundFeeConfig {
+            fee_bps,
+            min_fee,
+            max_fee,
+            treasury,
+            fee_token,
+            active,
+        };
+        env.storage().instance().set(&SystemKey::RefundFeeConfig, &config);
+
+        (RefundFeeConfigUpdated {
+            fee_bps,
+            min_fee,
+            max_fee,
+            updated_by: admin,
+        }).publish(&env);
+
+        Ok(())
+    }
+
+    /// Gets the current refund fee configuration
+    pub fn get_refund_fee_config(env: Env) -> Option<RefundFeeConfig> {
+        env.storage().instance().get(&SystemKey::RefundFeeConfig)
+    }
+
+    /// Gets accumulated refund fees
+    pub fn get_accumulated_refund_fees(env: Env) -> i128 {
+        env.storage().instance()
+            .get(&SystemKey::AccumulatedRefundFees)
+            .unwrap_or(0)
+    }
+
+    /// Withdraws accumulated refund fees to the treasury
+    pub fn withdraw_refund_fees(env: Env, admin: Address, amount: i128) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin = env.storage().instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let config = env.storage().instance()
+            .get(&SystemKey::RefundFeeConfig)
+            .ok_or(Error::RefundFeeConfigNotSet)?;
+
+        let accumulated: i128 = env.storage().instance()
+            .get(&SystemKey::AccumulatedRefundFees)
+            .unwrap_or(0);
+
+        if amount > accumulated {
+            return Err(Error::InsufficientRefundForFee);
+        }
+
+        let token_client = token::Client::new(&env, &config.fee_token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &config.treasury,
+            &amount,
+        );
+
+        env.storage().instance()
+            .set(&SystemKey::AccumulatedRefundFees, &(accumulated - amount));
+
+        Ok(())
+    }
+
+    /// Internal function to deduct platform fee from refund amount
+    fn deduct_refund_fee(
+        env: &Env,
+        refund_id: u64,
+        refund_amount: i128,
+        token: &Address,
+    ) -> Result<(i128, i128), Error> {
+        let config: Option<RefundFeeConfig> = env.storage().instance().get(&SystemKey::RefundFeeConfig);
+        let config = match config {
+            None => {
+                return Ok((refund_amount, 0));
+            }
+            Some(c) if !c.active => {
+                return Ok((refund_amount, 0));
+            }
+            Some(c) if c.fee_token != *token => {
+                return Ok((refund_amount, 0));
+            }
+            Some(c) => c,
+        };
+
+        let fee = Self::compute_refund_fee(refund_amount, config.fee_bps, config.min_fee, config.max_fee);
+
+        if fee <= 0 {
+            return Ok((refund_amount, 0));
+        }
+
+        let net_amount = refund_amount.checked_sub(fee)
+            .ok_or(Error::InsufficientRefundForFee)?;
+
+        // Update accumulated fees
+        let accumulated: i128 = env.storage().instance()
+            .get(&SystemKey::AccumulatedRefundFees)
+            .unwrap_or(0);
+        env.storage().instance()
+            .set(&SystemKey::AccumulatedRefundFees, &(accumulated + fee));
+
+        (RefundFeeDeducted {
+            refund_id,
+            fee_amount: fee,
+            net_refund_amount: net_amount,
+            treasury: config.treasury,
+        }).publish(env);
+
+        Ok((net_amount, fee))
+    }
+
+    /// Computes the refund fee amount with min/max clamping
+    fn compute_refund_fee(amount: i128, fee_bps: u32, min_fee: i128, max_fee: i128) -> i128 {
+        let raw_fee = (amount * (fee_bps as i128)) / 10000;
+
+        let fee = if min_fee > 0 && raw_fee < min_fee {
+            min_fee
+        } else {
+            raw_fee
+        };
+
+        let fee = if max_fee > 0 && fee > max_fee {
+            max_fee
+        } else {
+            fee
+        };
+
+        if fee < 0 {
+            0
+        } else {
+            fee
+        }
+    }
+
+    // ── PER-CUSTOMER REFUND COOLDOWN FUNCTIONS ──────────────────────────────
+
+    /// Sets the per-customer refund cooldown configuration
+    pub fn set_refund_cooldown_config(
+        env: Env,
+        admin: Address,
+        cooldown_seconds: u64,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin = env.storage().instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let config = RefundCooldownConfig {
+            cooldown_seconds,
+            enabled,
+        };
+        env.storage().instance().set(&SystemKey::RefundCooldownConfig, &config);
+
+        Ok(())
+    }
+
+    /// Gets the current refund cooldown configuration
+    pub fn get_refund_cooldown_config(env: Env) -> Option<RefundCooldownConfig> {
+        env.storage().instance().get(&SystemKey::RefundCooldownConfig)
+    }
+
+    /// Gets the cooldown status for a customer
+    pub fn get_customer_refund_cooldown(env: Env, customer: Address) -> Option<CustomerRefundCooldown> {
+        env.storage().instance().get(&SystemKey::CustomerRefundCooldown(customer))
+    }
+
+    /// Checks if a customer is within the refund cooldown period
+    fn check_refund_cooldown(env: &Env, customer: &Address) -> Result<(), Error> {
+        let config = match env.storage().instance().get(&SystemKey::RefundCooldownConfig) {
+            Some(c) if c.enabled => c,
+            _ => return Ok(()), // Cooldown not enabled
+        };
+
+        if let Some(cooldown) = env.storage().instance().get::<_, CustomerRefundCooldown>(&SystemKey::CustomerRefundCooldown(customer.clone())) {
+            let now = env.ledger().timestamp();
+            let available_at = cooldown.last_refund_requested_at.saturating_add(cooldown.cooldown_seconds);
+
+            if now < available_at {
+                (RefundCooldownEnforced {
+                    customer: customer.clone(),
+                    last_refund_at: cooldown.last_refund_requested_at,
+                    cooldown_seconds: cooldown.cooldown_seconds,
+                    available_at,
+                }).publish(env);
+                return Err(Error::RefundCooldownNotMet);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Updates the customer refund cooldown timestamp
+    fn update_customer_refund_cooldown(env: &Env, customer: &Address) -> Result<(), Error> {
+        let config = match env.storage().instance().get(&SystemKey::RefundCooldownConfig) {
+            Some(c) if c.enabled => c,
+            _ => return Ok(()), // Cooldown not enabled
+        };
+
+        let now = env.ledger().timestamp();
+        let cooldown = CustomerRefundCooldown {
+            customer: customer.clone(),
+            last_refund_requested_at: now,
+            cooldown_seconds: config.cooldown_seconds,
+        };
+
+        env.storage().instance()
+            .set(&SystemKey::CustomerRefundCooldown(customer.clone()), &cooldown);
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Implemented four  major features to enhance the facilpay-contracts platform's refund and escrow management capabilities:

Platform Fee Deduction on Refund Processing - Configurable basis-point fees deducted from refund amounts at processing time
Per-Customer Refund Cooldown - Prevents rapid successive refund requests from the same customer
Escrow Renewal Mechanism - Allows extending expired escrow agreements with configurable renewal parameters
Changes
Refund Contract (
lib.rs
)
New Data Structures
RefundFeeConfig - Configurable platform fee settings (fee_bps, min/max fees, treasury address, token, active flag)
RefundCooldownConfig - Per-customer cooldown configuration (cooldown_seconds, enabled flag)
CustomerRefundCooldown - Tracks last refund request timestamp per customer
New Storage Keys
SystemKey::RefundFeeConfig - Stores platform fee configuration
SystemKey::AccumulatedRefundFees - Tracks accumulated fees for withdrawal
SystemKey::CustomerRefundCooldown(Address) - Tracks cooldown state per customer
SystemKey::RefundCooldownConfig - Stores cooldown configuration
New Events
RefundFeeDeducted - Emitted when platform fee is deducted from refund
RefundFeeConfigUpdated - Emitted when fee configuration changes
RefundCooldownEnforced - Emitted when cooldown prevents a refund request
New Error Codes
RefundFeeConfigNotSet (46) - Fee configuration not initialized
InsufficientRefundForFee (47) - Refund amount insufficient after fee deduction
RefundCooldownNotMet (48) - Customer within cooldown period
RefundCooldownConfigNotSet (49) - Cooldown configuration not initialized
New Public Functions
set_refund_fee_config() - Admin configures platform fees
get_refund_fee_config() - Retrieves current fee configuration
get_accumulated_refund_fees() - Gets total accumulated fees
withdraw_refund_fees() - Admin withdraws accumulated fees to treasury
set_refund_cooldown_config() - Admin configures cooldown period
get_refund_cooldown_config() - Retrieves cooldown configuration
get_customer_refund_cooldown() - Gets customer's cooldown status
Internal Functions
deduct_refund_fee() - Calculates and deducts platform fee from refund amount
compute_refund_fee() - Computes fee with min/max clamping (similar to payment contract pattern)
check_refund_cooldown() - Validates customer is not within cooldown period
update_customer_refund_cooldown() - Updates customer's last refund timestamp
Integration Points
create_refund() - Added cooldown check before creating refund
create_refund() - Updates customer cooldown after successful refund creation
process_refund_internal() - Deducts platform fee before processing refund
Escrow Contract (
lib.rs
)
New Data Structures
EscrowRenewalConfig - Renewal configuration (enabled, max_renewals, renewal_fee_bps, min/max renewal periods)
EscrowRenewal - Tracks renewal history (renewal_id, escrow_id, renewed_by, new_expiry, fee, timestamp, count)
New Storage Keys
DataKey::EscrowRenewalConfig - Stores renewal configuration
DataKey::EscrowRenewal(u64) - Stores renewal record per escrow
DataKey::EscrowRenewalCount(u64) - Tracks renewal count per escrow
New Events
EscrowRenewed - Emitted when escrow is successfully renewed
EscrowRenewalConfigUpdated - Emitted when renewal configuration changes
New Error Codes
EscrowRenewalNotAllowed (76) - Renewal feature disabled
EscrowRenewalConfigNotSet (77) - Renewal configuration not initialized
InvalidRenewalPeriod (78) - Renewal period outside allowed range
MaxRenewalsExceeded (79) - Escrow has reached maximum renewal count
New Public Functions
set_escrow_renewal_config() - Admin configures renewal parameters
get_escrow_renewal_config() - Retrieves renewal configuration
renew_escrow() - Extends expired escrow agreement
get_escrow_renewal() - Gets renewal record for an escrow
get_escrow_renewal_count() - Gets total renewal count for an escrow
Renewal Logic
Only customer or merchant can initiate renewal
Escrow must be expired or near expiry (within 7 days)
Cannot renew terminal state escrows (Released, Cancelled)
Renewal period must be within configured min/max bounds
Enforces maximum renewal count limit
Calculates renewal fee as basis points of escrow amount
Updates escrow expiry timestamp and last_activity_at
Design Patterns
All three features follow established patterns in the codebase:

Fee Deduction - Mirrors payment contract's deduct_fee() pattern with basis-point calculation and min/max clamping
Configuration Management - Admin-only setters with require_auth() and MultiSigConfig validation
Rate Limiting - Cooldown mechanism similar to existing circuit breaker and rate limit patterns
Event Emission - All state changes emit events for off-chain tracking
Storage Hierarchy - Uses DataKey/SystemKey enums for organized state management
Testing Recommendations
Test fee deduction with various amounts and fee configurations
Verify cooldown enforcement across multiple refund requests
Test escrow renewal with edge cases (max renewals, invalid periods, terminal states)
Validate admin authorization for all configuration functions
Test fee accumulation and withdrawal
Verify renewal count tracking and limits
Backward Compatibility
All changes are additive and do not modify existing function signatures or data structures. Features are opt-in via configuration:



closes #223
closes #200
closes #201
closes #208
