### PR TITLE
feat(payment): Implement merchant payout

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -66,6 +66,7 @@ pub enum DataKey {
     SettlementFinalized(u64),
     AccumulatedFees,
     MerchantFeeRecord(Address),
+    PayoutSchedule(Address),
     FeeWaiver(Address),
     MerchantAnalytics(Address),
     CustomerAnalytics(Address),
@@ -158,6 +159,25 @@ pub enum Currency {
     USDT,
     BTC,
     ETH,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub enum PayoutFrequency {
+    Immediate,
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct PayoutSchedule {
+    pub merchant: Address,
+    pub token: Address,
+    pub frequency: PayoutFrequency,
+    pub next_payout_at: u64,
+    pub accumulated: i128,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -340,6 +360,9 @@ pub enum Error {
     RebateThresholdNotMet = 106,
     RebateAlreadyClaimed = 107,
     RebateConfigNotFound = 108,
+    PayoutScheduleNotFound = 89,
+    PayoutNotYetDue = 90,
+    NothingToSettle = 91,
 }
 
 #[contractevent]
@@ -1825,9 +1848,7 @@ impl PaymentContract {
             return Err(Error::PaymentNotYetDue);
         }
 
-        let token_client = token::Client::new(&env, &scheduled.token);
-        let contract_address = env.current_contract_address();
-        token_client.transfer(&contract_address, &scheduled.merchant, &scheduled.amount);
+        Self::settle_or_accumulate(&env, scheduled.merchant.clone(), scheduled.token.clone(), scheduled.amount)?;
         scheduled.executed = true;
         env.storage()
             .instance()
@@ -1872,6 +1893,99 @@ impl PaymentContract {
             .instance()
             .get(&StateDataKey::ScheduledPayment(payment_id))
             .ok_or(Error::PaymentNotFound)
+    }
+
+    fn settle_or_accumulate(env: &Env, merchant: Address, token: Address, amount: i128) -> Result<(), Error> {
+        // If merchant has a payout schedule for this token and it's not Immediate, accumulate
+        if let Some(mut schedule) = env
+            .storage()
+            .instance()
+            .get::<PayoutSchedule>(&DataKey::PayoutSchedule(merchant.clone()))
+        {
+            if schedule.token == token && schedule.frequency != PayoutFrequency::Immediate {
+                schedule.accumulated += amount;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::PayoutSchedule(merchant.clone()), &schedule);
+                return Ok(());
+            }
+        }
+
+        // Otherwise perform immediate transfer
+        let token_client = token::Client::new(env, &token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&contract_address, &merchant, &amount);
+        Ok(())
+    }
+
+    pub fn set_payout_schedule(
+        env: Env,
+        merchant: Address,
+        frequency: PayoutFrequency,
+        token: Address,
+    ) -> Result<(), Error> {
+        merchant.require_auth();
+        let now = env.ledger().timestamp();
+        let next = match frequency {
+            PayoutFrequency::Immediate => now,
+            PayoutFrequency::Daily => now + SECONDS_PER_DAY,
+            PayoutFrequency::Weekly => now + SECONDS_PER_DAY * 7,
+            PayoutFrequency::Monthly => now + SECONDS_PER_DAY * 30,
+        };
+        let schedule = PayoutSchedule {
+            merchant: merchant.clone(),
+            token: token.clone(),
+            frequency,
+            next_payout_at: next,
+            accumulated: 0,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::PayoutSchedule(merchant), &schedule);
+        Ok(())
+    }
+
+    pub fn get_payout_schedule(env: Env, merchant: Address) -> Option<PayoutSchedule> {
+        env.storage().instance().get(&DataKey::PayoutSchedule(merchant))
+    }
+
+    pub fn trigger_scheduled_payout(env: Env, merchant: Address) -> Result<(), Error> {
+        merchant.require_auth();
+        let mut schedule: PayoutSchedule = env
+            .storage()
+            .instance()
+            .get(&DataKey::PayoutSchedule(merchant.clone()))
+            .ok_or(Error::PayoutScheduleNotFound)?;
+        let now = env.ledger().timestamp();
+        if now < schedule.next_payout_at {
+            return Err(Error::PayoutNotYetDue);
+        }
+        if schedule.accumulated == 0 {
+            return Err(Error::NothingToSettle);
+        }
+        let token_client = token::Client::new(&env, &schedule.token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&contract_address, &merchant, &schedule.accumulated);
+        schedule.accumulated = 0;
+        let period = match schedule.frequency {
+            PayoutFrequency::Immediate => SECONDS_PER_DAY,
+            PayoutFrequency::Daily => SECONDS_PER_DAY,
+            PayoutFrequency::Weekly => SECONDS_PER_DAY * 7,
+            PayoutFrequency::Monthly => SECONDS_PER_DAY * 30,
+        };
+        schedule.next_payout_at = schedule.next_payout_at + period;
+        env.storage()
+            .instance()
+            .set(&DataKey::PayoutSchedule(merchant), &schedule);
+        Ok(())
+    }
+
+    pub fn get_accumulated_balance(env: Env, merchant: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get::<PayoutSchedule>(&DataKey::PayoutSchedule(merchant))
+            .map(|s| s.accumulated)
+            .unwrap_or(0)
     }
 
     fn do_create_payment(
@@ -3136,12 +3250,8 @@ impl PaymentContract {
             .instance()
             .set(&DataKey::Payment(payment_id), &payment);
 
-        // Transfer all collected funds to merchant
-        let token_client = token::Client::new(&env, &payment.token);
-        let contract_address = env.current_contract_address();
-        
-        // Calculate total amount held by contract (should equal payment amount)
-        token_client.transfer(&contract_address, &payment.merchant, &payment.amount);
+        // Transfer or accumulate all collected funds to merchant
+        Self::settle_or_accumulate(&env, payment.merchant.clone(), payment.token.clone(), payment.amount)?;
 
         // Emit payment fully paid event
         (PaymentFullyPaid {
@@ -7376,10 +7486,7 @@ impl PaymentContract {
         }
 
         // Execute the payment
-        let token_client = token::Client::new(&env, &payment.token);
-        let contract_address = env.current_contract_address();
-
-        token_client.transfer(&contract_address, &payment.merchant, &payment.amount);
+        Self::settle_or_accumulate(&env, payment.merchant.clone(), payment.token.clone(), payment.amount)?;
 
         payment.status = PaymentStatus::Completed;
         env.storage()

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -74,6 +74,91 @@ fn test_rate_limit_window_resets_after_duration() {
     assert_eq!(rl.payment_count, 1); // only 1 payment in the new window
 }
 
+// Payout schedule tests
+#[test]
+fn test_immediate_mode_bypasses_accumulation() {
+    let env = Env::default();
+    let (client, _admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    // Merchant opts into Immediate payouts
+    client.set_payout_schedule(&merchant, &PayoutFrequency::Immediate, &token).unwrap();
+
+    // Schedule a payment and execute it
+    env.ledger().set_timestamp(1000);
+    let pid = client
+        .schedule_payment(&customer, &merchant, &token, &50, &1100)
+        .unwrap();
+    env.ledger().set_timestamp(1100);
+    client.execute_scheduled_payment(&pid).unwrap();
+
+    // Immediate mode should not accumulate
+    let acc = client.get_accumulated_balance(&merchant);
+    assert_eq!(acc, 0);
+}
+
+#[test]
+fn test_batch_accumulation_and_premature_trigger() {
+    let env = Env::default();
+    let (client, _admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    // Merchant opts into daily payouts
+    client.set_payout_schedule(&merchant, &PayoutFrequency::Daily, &token).unwrap();
+
+    // Schedule and execute a payment — should accumulate
+    env.ledger().set_timestamp(2000);
+    let pid = client
+        .schedule_payment(&customer, &merchant, &token, &123, &2010)
+        .unwrap();
+    env.ledger().set_timestamp(2010);
+    client.execute_scheduled_payment(&pid).unwrap();
+
+    let acc = client.get_accumulated_balance(&merchant);
+    assert_eq!(acc, 123);
+
+    // Attempt to trigger payout prematurely
+    let res = client.try_trigger_scheduled_payout(&merchant);
+    assert_eq!(res.unwrap_err().unwrap(), Error::PayoutNotYetDue);
+}
+
+#[test]
+fn test_trigger_advances_period_and_resets_accumulated() {
+    let env = Env::default();
+    let (client, _admin, _) = setup_rate_limit_contract(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.set_payout_schedule(&merchant, &PayoutFrequency::Daily, &token).unwrap();
+
+    // Accumulate some funds
+    env.ledger().set_timestamp(3000);
+    let pid = client
+        .schedule_payment(&customer, &merchant, &token, &500, &3010)
+        .unwrap();
+    env.ledger().set_timestamp(3010);
+    client.execute_scheduled_payment(&pid).unwrap();
+
+    // Advance to payout time and trigger
+    let schedule = client.get_payout_schedule(&merchant).unwrap();
+    let next = schedule.next_payout_at;
+    env.ledger().set_timestamp(next + 1);
+    client.trigger_scheduled_payout(&merchant).unwrap();
+
+    // After payout accumulated must be zero and next_payout_at advanced
+    let schedule2 = client.get_payout_schedule(&merchant).unwrap();
+    assert_eq!(schedule2.accumulated, 0);
+    assert!(schedule2.next_payout_at > next);
+}
+
 #[test]
 #[should_panic]
 fn test_rate_limit_exceeded_within_window() {


### PR DESCRIPTION
Implemented merchant payout scheduling with configurable frequencies. Payments now route through `settle_or_accumulate`, which either transfers immediately or accumulates the balance depending on the merchant's schedule. `trigger_scheduled_payout` enforces the due date, transfers the accumulated amount, resets the balance, and advances the next payout window. New error types handle missing schedules, early triggers, and empty balances. Tests cover immediate bypass, accumulation, premature trigger rejection, and period advancement. 
Closed #207