### PR TITLE
feat(payment): implement split payment with execute settlement and tests

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -46,6 +46,8 @@ pub enum DataKey {
     PaymentChannelCounter,
     MeteredSubscription(u64),
     MeteredSubscriptionCounter,
+    // Payment split support
+    SplitConfig(u64),
 }
 
 // Customer-specific data keys
@@ -261,6 +263,10 @@ pub enum Error {
     ChannelNotExpired = 78,
     MeteredSubscriptionNotFound = 79,
     BillingCapExceeded = 80,
+    InvalidSplitShares = 85,
+    TooManyRecipients = 86,
+    SplitConfigNotFound = 87,
+    SplitAlreadyExecuted = 88,
 }
 
 #[contractevent]
@@ -428,6 +434,21 @@ pub struct MeteredSubscription {
     pub accumulated_units: u64,
     pub billing_cap: Option<i128>,
     pub last_reset_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct SplitRecipient {
+    pub address: Address,
+    pub share_bps: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct PaymentSplitConfig {
+    pub payment_id: u64,
+    pub recipients: Vec<SplitRecipient>,
+    pub executed: bool,
 }
 
 #[contractevent]
@@ -6970,6 +6991,115 @@ impl PaymentContract {
         }
         BytesN::from_array(env, &pk)
     }
+
+    pub fn create_split_payment(
+        env: Env,
+        customer: Address,
+        merchant: Address,
+        amount: i128,
+        token: Address,
+        recipients: Vec<SplitRecipient>,
+    ) -> Result<u64, Error> {
+        customer.require_auth();
+
+        if recipients.len() > 10 {
+            return Err(Error::TooManyRecipients);
+        }
+
+        let total_bps: u32 = recipients.iter().map(|r| r.share_bps).sum();
+        if total_bps != 10000 {
+            return Err(Error::InvalidSplitShares);
+        }
+
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentCounter)
+            .unwrap_or(0);
+        let payment_id = counter + 1;
+
+        let token_client = token::Client::new(&env, &token);
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&customer, &contract_address, &amount);
+
+        let payment = Payment {
+            id: payment_id,
+            customer: customer.clone(),
+            merchant: merchant.clone(),
+            amount,
+            token,
+            currency: Currency::USDC,
+            status: PaymentStatus::Pending,
+            created_at: env.ledger().timestamp(),
+            expires_at: 0,
+            metadata: String::from_str(&env, ""),
+            notes: String::from_str(&env, ""),
+            refunded_amount: 0,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Payment(payment_id), &payment);
+        env.storage()
+            .instance()
+            .set(&DataKey::PaymentCounter, &payment_id);
+
+        let config = PaymentSplitConfig {
+            payment_id,
+            recipients,
+            executed: false,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::SplitConfig(payment_id), &config);
+
+        Ok(payment_id)
+    }
+
+    pub fn execute_split_settlement(
+        env: Env,
+        admin: Address,
+        payment_id: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let mut config: PaymentSplitConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::SplitConfig(payment_id))
+            .ok_or(Error::SplitConfigNotFound)?;
+
+        if config.executed {
+            return Err(Error::SplitAlreadyExecuted);
+        }
+
+        let payment: Payment = env
+            .storage()
+            .instance()
+            .get(&DataKey::Payment(payment_id))
+            .ok_or(Error::PaymentNotFound)?;
+
+        let token_client = token::Client::new(&env, &payment.token);
+        let contract_address = env.current_contract_address();
+
+        for recipient in config.recipients.iter() {
+            let share = (payment.amount * recipient.share_bps as i128) / 10000;
+            token_client.transfer(&contract_address, &recipient.address, &share);
+        }
+
+        config.executed = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::SplitConfig(payment_id), &config);
+
+        Ok(())
+    }
+
+    pub fn get_split_config(env: Env, payment_id: u64) -> Option<PaymentSplitConfig> {
+        env.storage()
+            .instance()
+            .get(&DataKey::SplitConfig(payment_id))
+    }
 }
 
 mod test;
@@ -6992,3 +7122,6 @@ mod test_cross_contract_escrow_verification;
 
 #[cfg(test)]
 mod test_metered_billing;
+
+#[cfg(test)]
+mod test_split_payment;

--- a/contracts/payment/src/test_split_payment.rs
+++ b/contracts/payment/src/test_split_payment.rs
@@ -1,0 +1,125 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, token, Address, Env, Vec};
+
+fn setup(env: &Env) -> (PaymentContractClient<'_>, Address, Address) {
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    (client, admin, contract_id)
+}
+
+fn make_token(env: &Env, admin: &Address) -> Address {
+    let token_id = env.register(
+        soroban_sdk::token::StellarAssetContract,
+        (&admin,),
+    );
+    token_id
+}
+
+fn fund(env: &Env, token: &Address, admin: &Address, to: &Address, amount: i128) {
+    let token_admin = token::StellarAssetClient::new(env, token);
+    token_admin.mint(to, &amount);
+    let _ = admin;
+}
+
+#[test]
+fn test_valid_split_payment() {
+    let env = Env::default();
+    let (client, admin, contract_id) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 1000);
+
+    let r1 = SplitRecipient { address: merchant.clone(), share_bps: 7000 };
+    let r2 = SplitRecipient { address: admin.clone(), share_bps: 3000 };
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(r1);
+    recipients.push_back(r2);
+
+    let payment_id = client.create_split_payment(&customer, &merchant, &1000, &token, &recipients);
+    assert_eq!(payment_id, 1);
+
+    let config = client.get_split_config(&payment_id).unwrap();
+    assert_eq!(config.payment_id, 1);
+    assert!(!config.executed);
+
+    client.execute_split_settlement(&admin, &payment_id);
+
+    let config = client.get_split_config(&payment_id).unwrap();
+    assert!(config.executed);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&merchant), 700);
+    assert_eq!(token_client.balance(&admin), 300);
+}
+
+#[test]
+fn test_invalid_split_shares() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 1000);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient { address: merchant.clone(), share_bps: 5000 });
+    recipients.push_back(SplitRecipient { address: admin.clone(), share_bps: 4000 }); // total = 9000, not 10000
+
+    let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
+    assert_eq!(result, Err(Ok(Error::InvalidSplitShares)));
+}
+
+#[test]
+fn test_too_many_recipients() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 1000);
+
+    let mut recipients = Vec::new(&env);
+    for i in 0..11u32 {
+        recipients.push_back(SplitRecipient {
+            address: Address::generate(&env),
+            share_bps: if i < 10 { 900 } else { 1000 },
+        });
+    }
+
+    let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
+    assert_eq!(result, Err(Ok(Error::TooManyRecipients)));
+}
+
+#[test]
+fn test_double_execution_rejected() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 1000);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient { address: merchant.clone(), share_bps: 10000 });
+
+    let payment_id = client.create_split_payment(&customer, &merchant, &1000, &token, &recipients);
+
+    client.execute_split_settlement(&admin, &payment_id);
+
+    let result = client.try_execute_split_settlement(&admin, &payment_id);
+    assert_eq!(result, Err(Ok(Error::SplitAlreadyExecuted)));
+}


### PR DESCRIPTION

  Overview

  Adds on-chain split payment settlement, enabling marketplace platforms to automatically distribute a
  customer payment between a platform fee account and one or more sub-merchants — fully trustless and
  auditable.

  ────────────────────────────────────────────────────────────────────────────────────────────────────

  What's Changed

  New Structs

  - SplitRecipient — holds a recipient address and their share in basis points
  - PaymentSplitConfig — stores the full split configuration for a payment, including execution state

  New Functions

  - create_split_payment — customer authorises a payment; split config is encoded on-chain at creation
  time
  - execute_split_settlement — admin triggers proportional distribution to all recipients
  - get_split_config — read-only query for any payment's split configuration

  New Errors

  ┌──────┬──────────────────────┬─────────────────────────────────────────┐
  │ Code │ Variant              │ Trigger                                 │
  ├──────┼──────────────────────┼─────────────────────────────────────────┤
  │ 85   │ InvalidSplitShares   │ Recipient BPS don't sum to 10000        │
  ├──────┼──────────────────────┼─────────────────────────────────────────┤
  │ 86   │ TooManyRecipients    │ More than 10 recipients provided        │
  ├──────┼──────────────────────┼─────────────────────────────────────────┤
  │ 87   │ SplitConfigNotFound  │ No split config exists for payment ID   │
  ├──────┼──────────────────────┼─────────────────────────────────────────┤
  │ 88   │ SplitAlreadyExecuted │ Settlement called twice on same payment │
  └──────┴──────────────────────┴─────────────────────────────────────────┘

  ────────────────────────────────────────────────────────────────────────────────────────────────────

  How It Works

  1. Customer calls create_split_payment — tokens are escrowed in the contract, split config stored
  on-chain
  2. Admin calls execute_split_settlement — each recipient receives (amount × share_bps) / 10000
  3. Config is marked executed = true, preventing double settlement

  ────────────────────────────────────────────────────────────────────────────────────────────────────

  Tests

  - ✅ Valid split — correct proportional balances after settlement
  - ✅ Mismatched shares — rejects when BPS ≠ 10000
  - ✅ Max recipients — rejects when recipient count > 10
  - ✅ Double execution — rejects second settlement with SplitAlreadyExecuted

  ────────────────────────────────────────────────────────────────────────────────────────────────────

  Closes #206 

  Resolves the marketplace payment splitting issue.
