### PR TITLE
feat(escrow): implement sub-account milestone tracking with release g…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -93,6 +93,9 @@ pub enum EscrowAuxKey {
     EscrowRenewalConfig,
     EscrowRenewal(u64),
     EscrowRenewalCount(u64),
+    // Sub-account milestones
+    SubAccount(u64, u64),
+    SubAccountCounter(u64),
 }
 
 /// Observer storage keys (separate enum to stay within Soroban symbol limits).
@@ -269,6 +272,9 @@ pub enum Error {
     RollbackAlreadyExecuted = 92,
     RollbackNotYetAvailable = 93,
     StaleThresholdNotConfigured = 94,
+    SubAccountNotFound = 95,
+    SubAccountAlreadyReleased = 96,
+    SubAccountFundingExceedsEscrow = 97,
 }
 
 #[contractevent]
@@ -636,6 +642,17 @@ pub struct Escrow {
     pub escalation_timeout: u64,
     pub auto_resolve_in_favor_of: AutoResolveFavor,
     pub evidence_deadline: Option<u64>, // Deadline for evidence submission in dispute
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct EscrowSubAccount {
+    pub escrow_id: u64,
+    pub sub_id: u64,
+    pub label_hash: BytesN<32>,
+    pub amount: i128,
+    pub released: bool,
+    pub release_condition: Option<String>,
 }
 
 #[derive(Clone)]
@@ -2481,6 +2498,24 @@ impl EscrowContract {
         }
 
         let escrow = EscrowContract::get_escrow(&env, escrow_id);
+
+        // Guard: block full release if any sub-accounts remain unreleased
+        let sub_count: u64 = env
+            .storage()
+            .instance()
+            .get(&EscrowAuxKey::SubAccountCounter(escrow_id))
+            .unwrap_or(0);
+        for sub_id in 1..=sub_count {
+            if let Some(sub) = env
+                .storage()
+                .instance()
+                .get::<EscrowAuxKey, EscrowSubAccount>(&EscrowAuxKey::SubAccount(escrow_id, sub_id))
+            {
+                if !sub.released {
+                    return Err(Error::InvalidStatus);
+                }
+            }
+        }
 
         match escrow.status {
             EscrowStatus::Locked => {
@@ -7452,6 +7487,160 @@ impl EscrowContract {
         }
         EscrowHealth::Healthy
     }
+
+    pub fn create_sub_account(
+        env: Env,
+        merchant: Address,
+        escrow_id: u64,
+        label_hash: BytesN<32>,
+        amount: i128,
+    ) -> Result<u64, Error> {
+        merchant.require_auth();
+
+        let escrow = EscrowContract::get_escrow(&env, escrow_id);
+
+        let sub_count: u64 = env
+            .storage()
+            .instance()
+            .get(&EscrowAuxKey::SubAccountCounter(escrow_id))
+            .unwrap_or(0);
+        let mut allocated: i128 = 0;
+        for sub_id in 1..=sub_count {
+            if let Some(sub) = env
+                .storage()
+                .instance()
+                .get::<EscrowAuxKey, EscrowSubAccount>(&EscrowAuxKey::SubAccount(escrow_id, sub_id))
+            {
+                allocated += sub.amount;
+            }
+        }
+
+        if allocated + amount > escrow.amount {
+            return Err(Error::SubAccountFundingExceedsEscrow);
+        }
+
+        let sub_id = sub_count + 1;
+        let sub = EscrowSubAccount {
+            escrow_id,
+            sub_id,
+            label_hash,
+            amount,
+            released: false,
+            release_condition: None,
+        };
+
+        env.storage()
+            .instance()
+            .set(&EscrowAuxKey::SubAccount(escrow_id, sub_id), &sub);
+        env.storage()
+            .instance()
+            .set(&EscrowAuxKey::SubAccountCounter(escrow_id), &sub_id);
+
+        Ok(sub_id)
+    }
+
+    pub fn fund_sub_account(
+        env: Env,
+        funder: Address,
+        escrow_id: u64,
+        sub_id: u64,
+        amount: i128,
+    ) -> Result<(), Error> {
+        funder.require_auth();
+
+        let escrow = EscrowContract::get_escrow(&env, escrow_id);
+
+        let mut sub: EscrowSubAccount = env
+            .storage()
+            .instance()
+            .get(&EscrowAuxKey::SubAccount(escrow_id, sub_id))
+            .ok_or(Error::SubAccountNotFound)?;
+
+        let sub_count: u64 = env
+            .storage()
+            .instance()
+            .get(&EscrowAuxKey::SubAccountCounter(escrow_id))
+            .unwrap_or(0);
+        let mut allocated: i128 = 0;
+        for id in 1..=sub_count {
+            if id == sub_id {
+                continue;
+            }
+            if let Some(s) = env
+                .storage()
+                .instance()
+                .get::<EscrowAuxKey, EscrowSubAccount>(&EscrowAuxKey::SubAccount(escrow_id, id))
+            {
+                allocated += s.amount;
+            }
+        }
+
+        if allocated + sub.amount + amount > escrow.amount {
+            return Err(Error::SubAccountFundingExceedsEscrow);
+        }
+
+        sub.amount += amount;
+        env.storage()
+            .instance()
+            .set(&EscrowAuxKey::SubAccount(escrow_id, sub_id), &sub);
+
+        Ok(())
+    }
+
+    pub fn release_sub_account(
+        env: Env,
+        admin: Address,
+        escrow_id: u64,
+        sub_id: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        let escrow = EscrowContract::get_escrow(&env, escrow_id);
+
+        let mut sub: EscrowSubAccount = env
+            .storage()
+            .instance()
+            .get(&EscrowAuxKey::SubAccount(escrow_id, sub_id))
+            .ok_or(Error::SubAccountNotFound)?;
+
+        if sub.released {
+            return Err(Error::SubAccountAlreadyReleased);
+        }
+
+        EscrowContract::transfer_if_token_contract(&env, &escrow.token, &escrow.merchant, sub.amount)?;
+
+        sub.released = true;
+        env.storage()
+            .instance()
+            .set(&EscrowAuxKey::SubAccount(escrow_id, sub_id), &sub);
+
+        Ok(())
+    }
+
+    pub fn get_sub_account(env: Env, escrow_id: u64, sub_id: u64) -> Option<EscrowSubAccount> {
+        env.storage()
+            .instance()
+            .get(&EscrowAuxKey::SubAccount(escrow_id, sub_id))
+    }
+
+    pub fn list_sub_accounts(env: Env, escrow_id: u64) -> Vec<EscrowSubAccount> {
+        let sub_count: u64 = env
+            .storage()
+            .instance()
+            .get(&EscrowAuxKey::SubAccountCounter(escrow_id))
+            .unwrap_or(0);
+        let mut result = Vec::new(&env);
+        for sub_id in 1..=sub_count {
+            if let Some(sub) = env
+                .storage()
+                .instance()
+                .get::<EscrowAuxKey, EscrowSubAccount>(&EscrowAuxKey::SubAccount(escrow_id, sub_id))
+            {
+                result.push_back(sub);
+            }
+        }
+        result
+    }
 }
 
 impl EscrowAnalytics {
@@ -7512,3 +7701,6 @@ mod multi_party_rollback_test;
 mod observer_test;
 
 mod health_check_test;
+
+#[cfg(test)]
+mod test_sub_account;

--- a/contracts/escrow/src/test_sub_account.rs
+++ b/contracts/escrow/src/test_sub_account.rs
@@ -1,0 +1,135 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env};
+
+fn setup(env: &Env) -> (EscrowContractClient<'_>, Address, Address, Address, Address) {
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let customer = Address::generate(env);
+    let merchant = Address::generate(env);
+    let token = Address::generate(env);
+    env.mock_all_auths();
+    (client, admin, customer, merchant, token)
+}
+
+fn make_escrow(
+    client: &EscrowContractClient,
+    customer: &Address,
+    merchant: &Address,
+    token: &Address,
+    amount: i128,
+) -> u64 {
+    client.create_escrow(customer, merchant, &amount, token, &9999999_u64, &0_u64)
+}
+
+fn label(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[1u8; 32])
+}
+
+#[test]
+fn test_create_sub_account() {
+    let env = Env::default();
+    let (client, _, customer, merchant, token) = setup(&env);
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
+
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &400);
+    assert_eq!(sub_id, 1);
+
+    let sub = client.get_sub_account(&escrow_id, &sub_id).unwrap();
+    assert_eq!(sub.amount, 400);
+    assert!(!sub.released);
+}
+
+#[test]
+fn test_funding_sub_account() {
+    let env = Env::default();
+    let (client, _, customer, merchant, token) = setup(&env);
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &200);
+
+    client.fund_sub_account(&merchant, &escrow_id, &sub_id, &300);
+
+    let sub = client.get_sub_account(&escrow_id, &sub_id).unwrap();
+    assert_eq!(sub.amount, 500);
+}
+
+#[test]
+fn test_release_sub_account() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let token_id = env.register(soroban_sdk::token::StellarAssetContract, (&admin,));
+    let token_admin = token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&customer, &1000);
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token_id, 1000);
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &500);
+
+    client.release_sub_account(&admin, &escrow_id, &sub_id);
+
+    let sub = client.get_sub_account(&escrow_id, &sub_id).unwrap();
+    assert!(sub.released);
+}
+
+#[test]
+fn test_double_release_rejected() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let token_id = env.register(soroban_sdk::token::StellarAssetContract, (&admin,));
+    let token_admin = token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&customer, &1000);
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token_id, 1000);
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &500);
+
+    client.release_sub_account(&admin, &escrow_id, &sub_id);
+
+    let result = client.try_release_sub_account(&admin, &escrow_id, &sub_id);
+    assert_eq!(result, Err(Ok(Error::SubAccountAlreadyReleased)));
+}
+
+#[test]
+fn test_funding_exceeds_escrow_rejected() {
+    let env = Env::default();
+    let (client, _, customer, merchant, token) = setup(&env);
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
+
+    // Try to allocate more than the escrow holds
+    let result = client.try_create_sub_account(&merchant, &escrow_id, &label(&env), &1001);
+    assert_eq!(result, Err(Ok(Error::SubAccountFundingExceedsEscrow)));
+}
+
+#[test]
+fn test_parent_guard_blocks_release_with_unreleased_sub_accounts() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+    env.ledger().set_timestamp(1000);
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
+    client.create_sub_account(&merchant, &escrow_id, &label(&env), &500);
+
+    // Parent release should fail because sub-account is not yet released
+    let result = client.try_release_escrow(&admin, &escrow_id, &true);
+    assert_eq!(result, Err(Ok(Error::InvalidStatus)));
+}
+
+#[test]
+fn test_list_sub_accounts() {
+    let env = Env::default();
+    let (client, _, customer, merchant, token) = setup(&env);
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
+    client.create_sub_account(&merchant, &escrow_id, &label(&env), &200);
+    client.create_sub_account(&merchant, &escrow_id, &BytesN::from_array(&env, &[2u8; 32]), &300);
+
+    let subs = client.list_sub_accounts(&escrow_id);
+    assert_eq!(subs.len(), 2);
+    assert_eq!(subs.get(0).unwrap().amount, 200);
+    assert_eq!(subs.get(1).unwrap().amount, 300);
+}


### PR DESCRIPTION
📖 Overview
Large escrows covering multiple deliverables can now be broken into independently releasable sub‑accounts. Each milestone receives its own allocation, tracked on‑chain for trustless and auditable partial settlement. This enables granular milestone‑based payouts rather than requiring full escrow release at once.

🔄 What’s Changed
New Structs

EscrowSubAccount — tracks a milestone’s label_hash, allocated amount, release state, and optional release_condition.

New Functions

create_sub_account — allocate a portion of the escrow to a labeled milestone.

fund_sub_account — top up an existing sub‑account’s allocation.

release_sub_account — release a single milestone, transferring its amount to the merchant.

get_sub_account — read a specific sub‑account by escrow and sub‑ID.

list_sub_accounts — list all sub‑accounts for a given escrow.

New Errors

95 SubAccountNotFound — sub‑account ID doesn’t exist.

96 SubAccountAlreadyReleased — release called on an already‑released sub‑account.

97 SubAccountFundingExceedsEscrow — allocation would exceed parent escrow balance.

Parent Escrow Guard

internal_release_escrow now blocks full escrow release while any sub‑account remains unreleased, enforcing milestone completion before final settlement.

🧪 Tests Added
✅ Sub‑account creation with correct initial state.

✅ Funding increases sub‑account amount.

✅ Release transfers tokens and marks sub‑account released.

✅ Double release rejected with SubAccountAlreadyReleased.

✅ Over‑allocation rejected with SubAccountFundingExceedsEscrow.

✅ Parent release blocked while sub‑accounts are unreleased.

✅ Listing returns all sub‑accounts in order.

📌 Issue Link
Closes #220 