### PR TITLE
fix: resolve unconditional dispute rejection and multi-hop forward cycle detection

### DIFF
--- a/contracts/escrow/src/hierarchy_test.rs
+++ b/contracts/escrow/src/hierarchy_test.rs
@@ -19,25 +19,12 @@ fn test_two_level_hierarchy_success() {
 
     // Create root parent escrow (level 0)
     let parent_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &2000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &2000_u64, &0_u64, &0_u64, &false,
     );
 
     // Create child escrow (level 1)
-    let child_id = client.create_child_escrow(
-        &admin,
-        &parent_id,
-        &500_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let child_id =
+        client.create_child_escrow(&admin, &parent_id, &500_i128, &token, &customer, &merchant);
 
     // Verify parent release is blocked since child is unresolved (Locked)
     let release_res = client.try_release_escrow(&admin, &parent_id, &false);
@@ -71,55 +58,24 @@ fn test_depth_limit_enforced() {
 
     // Root (level 0)
     let root_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
     // Child (level 1)
-    let lvl1_id = client.create_child_escrow(
-        &admin,
-        &root_id,
-        &500_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let lvl1_id =
+        client.create_child_escrow(&admin, &root_id, &500_i128, &token, &customer, &merchant);
 
     // Grandchild (level 2)
-    let lvl2_id = client.create_child_escrow(
-        &admin,
-        &lvl1_id,
-        &250_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let lvl2_id =
+        client.create_child_escrow(&admin, &lvl1_id, &250_i128, &token, &customer, &merchant);
 
     // Great-grandchild (level 3)
-    let lvl3_id = client.create_child_escrow(
-        &admin,
-        &lvl2_id,
-        &100_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let lvl3_id =
+        client.create_child_escrow(&admin, &lvl2_id, &100_i128, &token, &customer, &merchant);
 
     // Creating under level 3 (would be level 4) should fail with MaxHierarchyDepth
-    let lvl4_res = client.try_create_child_escrow(
-        &admin,
-        &lvl3_id,
-        &50_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let lvl4_res =
+        client.try_create_child_escrow(&admin, &lvl3_id, &50_i128, &token, &customer, &merchant);
     assert_eq!(lvl4_res, Err(Ok(Error::MaxHierarchyDepth)));
 }
 
@@ -138,42 +94,17 @@ fn test_get_escrow_hierarchy() {
     client.initialize(&admin);
 
     let root_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
-    let child_1 = client.create_child_escrow(
-        &admin,
-        &root_id,
-        &500_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let child_1 =
+        client.create_child_escrow(&admin, &root_id, &500_i128, &token, &customer, &merchant);
 
-    let child_2 = client.create_child_escrow(
-        &admin,
-        &root_id,
-        &300_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let child_2 =
+        client.create_child_escrow(&admin, &root_id, &300_i128, &token, &customer, &merchant);
 
-    let grandchild_1 = client.create_child_escrow(
-        &admin,
-        &child_1,
-        &100_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let grandchild_1 =
+        client.create_child_escrow(&admin, &child_1, &100_i128, &token, &customer, &merchant);
 
     let hierarchy = client.get_escrow_hierarchy(&root_id);
     assert_eq!(hierarchy.len(), 4);
@@ -223,13 +154,7 @@ fn test_create_child_escrow_validation() {
     assert_eq!(res, Err(Ok(Error::NotAnAdmin)));
 
     // Non-existent parent fails with ParentEscrowNotFound
-    let res2 = client.try_create_child_escrow(
-        &admin,
-        &999_u64,
-        &100_i128,
-        &token,
-        &customer,
-        &merchant,
-    );
+    let res2 =
+        client.try_create_child_escrow(&admin, &999_u64, &100_i128, &token, &customer, &merchant);
     assert_eq!(res2, Err(Ok(Error::ParentEscrowNotFound)));
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -199,10 +199,10 @@ pub struct InsuranceClaim {
 #[contracttype]
 pub struct EscrowRenewalConfig {
     pub enabled: bool,
-    pub max_renewals: u32,           // Maximum number of times an escrow can be renewed
-    pub renewal_fee_bps: u32,        // Fee in basis points for renewal
-    pub min_renewal_period: u64,     // Minimum renewal period in seconds
-    pub max_renewal_period: u64,     // Maximum renewal period in seconds
+    pub max_renewals: u32, // Maximum number of times an escrow can be renewed
+    pub renewal_fee_bps: u32, // Fee in basis points for renewal
+    pub min_renewal_period: u64, // Minimum renewal period in seconds
+    pub max_renewal_period: u64, // Maximum renewal period in seconds
 }
 
 /// Tracks escrow renewal history
@@ -314,7 +314,7 @@ pub enum Error {
     AlreadyApproved = 25,
     ActionNotReady = 26,
     ContractPaused = 30,
-     ObserverAlreadyAdded = 47,
+    ObserverAlreadyAdded = 47,
     ObserverNotFound = 48,
     AccelerationLimitExceeded = 66,
     TransferNotAllowed = 42,
@@ -1866,16 +1866,31 @@ impl EscrowContract {
             return Err(Error::EscrowNotFound);
         }
 
-        if let Some(request_id) = env.storage().instance().get::<AdminKey, u64>(&AdminKey::EscrowClawback(escrow_id)) {
-            if let Some(request) = env.storage().instance().get::<AdminKey, ClawbackRequest>(&AdminKey::ClawbackRequest(request_id)) {
+        if let Some(request_id) = env
+            .storage()
+            .instance()
+            .get::<AdminKey, u64>(&AdminKey::EscrowClawback(escrow_id))
+        {
+            if let Some(request) = env
+                .storage()
+                .instance()
+                .get::<AdminKey, ClawbackRequest>(&AdminKey::ClawbackRequest(request_id))
+            {
                 if !request.executed && !request.cancelled {
                     return Err(Error::AlreadyProcessed);
                 }
             }
         }
 
-        let counter: u64 = env.storage().instance().get(&AdminKey::ClawbackCounter).unwrap_or(0) + 1;
-        env.storage().instance().set(&AdminKey::ClawbackCounter, &counter);
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&AdminKey::ClawbackCounter)
+            .unwrap_or(0)
+            + 1;
+        env.storage()
+            .instance()
+            .set(&AdminKey::ClawbackCounter, &counter);
 
         let now = env.ledger().timestamp();
         let request = ClawbackRequest {
@@ -1888,8 +1903,12 @@ impl EscrowContract {
             cancelled: false,
         };
 
-        env.storage().instance().set(&AdminKey::ClawbackRequest(counter), &request);
-        env.storage().instance().set(&AdminKey::EscrowClawback(escrow_id), &counter);
+        env.storage()
+            .instance()
+            .set(&AdminKey::ClawbackRequest(counter), &request);
+        env.storage()
+            .instance()
+            .set(&AdminKey::EscrowClawback(escrow_id), &counter);
 
         Ok(counter)
     }
@@ -1902,7 +1921,11 @@ impl EscrowContract {
             return Err(Error::NotAnAdmin);
         }
 
-        let mut request: ClawbackRequest = env.storage().instance().get(&AdminKey::ClawbackRequest(request_id)).ok_or(Error::Unauthorized)?;
+        let mut request: ClawbackRequest = env
+            .storage()
+            .instance()
+            .get(&AdminKey::ClawbackRequest(request_id))
+            .ok_or(Error::Unauthorized)?;
 
         if request.executed {
             return Err(Error::AlreadyProcessed);
@@ -1924,10 +1947,14 @@ impl EscrowContract {
 
         let mut updated_escrow = escrow;
         updated_escrow.status = EscrowStatus::Resolved;
-        env.storage().instance().set(&DataKey::Escrow(request.escrow_id), &updated_escrow);
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(request.escrow_id), &updated_escrow);
 
         request.executed = true;
-        env.storage().instance().set(&AdminKey::ClawbackRequest(request_id), &request);
+        env.storage()
+            .instance()
+            .set(&AdminKey::ClawbackRequest(request_id), &request);
 
         Ok(())
     }
@@ -1940,7 +1967,11 @@ impl EscrowContract {
             return Err(Error::NotAnAdmin);
         }
 
-        let mut request: ClawbackRequest = env.storage().instance().get(&AdminKey::ClawbackRequest(request_id)).ok_or(Error::Unauthorized)?;
+        let mut request: ClawbackRequest = env
+            .storage()
+            .instance()
+            .get(&AdminKey::ClawbackRequest(request_id))
+            .ok_or(Error::Unauthorized)?;
 
         if request.executed {
             return Err(Error::AlreadyProcessed);
@@ -1950,13 +1981,17 @@ impl EscrowContract {
         }
 
         request.cancelled = true;
-        env.storage().instance().set(&AdminKey::ClawbackRequest(request_id), &request);
+        env.storage()
+            .instance()
+            .set(&AdminKey::ClawbackRequest(request_id), &request);
 
         Ok(())
     }
 
     pub fn get_clawback_request(env: Env, request_id: u64) -> Option<ClawbackRequest> {
-        env.storage().instance().get(&AdminKey::ClawbackRequest(request_id))
+        env.storage()
+            .instance()
+            .get(&AdminKey::ClawbackRequest(request_id))
     }
 
     pub fn create_escrow(
@@ -1995,7 +2030,6 @@ impl EscrowContract {
         expiry_timestamp: u64,
         auto_refund_on_expiry: bool,
     ) -> Result<u64, Error> {
-
         // Block new escrow creation during migration
         if let Some(status) = env
             .storage()
@@ -2765,8 +2799,10 @@ impl EscrowContract {
         // completions reward longer-running agreements more; the once-per-escrow
         // guard makes repeated invocations harmless, so errors are ignored here.
         if EscrowContract::get_tenure_config(env.clone()).is_some() {
-            let _ = EscrowContract::apply_tenure_bonus(env.clone(), escrow_id, escrow.merchant.clone());
-            let _ = EscrowContract::apply_tenure_bonus(env.clone(), escrow_id, escrow.customer.clone());
+            let _ =
+                EscrowContract::apply_tenure_bonus(env.clone(), escrow_id, escrow.merchant.clone());
+            let _ =
+                EscrowContract::apply_tenure_bonus(env.clone(), escrow_id, escrow.customer.clone());
         }
 
         // Update global analytics
@@ -2907,8 +2943,9 @@ impl EscrowContract {
                 escrow.last_activity_at = escrow.dispute_started_at;
                 // Set evidence submission deadline to 7 days from dispute start
                 let evidence_deadline_seconds = 7 * 24 * 60 * 60; // 7 days
-                escrow.evidence_deadline = Some(escrow.dispute_started_at + evidence_deadline_seconds);
-                
+                escrow.evidence_deadline =
+                    Some(escrow.dispute_started_at + evidence_deadline_seconds);
+
                 EvidenceDeadlineSet {
                     escrow_id,
                     deadline: escrow.evidence_deadline.unwrap(),
@@ -2978,7 +3015,7 @@ impl EscrowContract {
         if escrow.customer != caller && escrow.merchant != caller {
             return Err(Error::Unauthorized);
         }
-        
+
         // Check evidence submission deadline
         if let Some(deadline) = escrow.evidence_deadline {
             let current_time = env.ledger().timestamp();
@@ -2992,7 +3029,7 @@ impl EscrowContract {
                 return Err(Error::EvidenceDeadlinePassed);
             }
         }
-        
+
         EscrowContract::append_evidence_entry(&env, escrow_id, caller, ipfs_hash)
     }
 
@@ -3250,9 +3287,10 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::EscrowEvidencePage(escrow_id, page_num), &page);
-        env.storage()
-            .instance()
-            .set(&DataKey::EscrowEvidencePageCount(escrow_id), &(page_num + 1));
+        env.storage().instance().set(
+            &DataKey::EscrowEvidencePageCount(escrow_id),
+            &(page_num + 1),
+        );
 
         Ok(page_num + 1)
     }
@@ -3344,16 +3382,18 @@ impl EscrowContract {
         if !multisig.admins.contains(&admin) {
             return Err(Error::NotAnAdmin);
         }
-        let cfg = EscalationConfig { timeout_seconds, favor };
-        env.storage().instance().set(&DataKey::EscalationConfig, &cfg);
+        let cfg = EscalationConfig {
+            timeout_seconds,
+            favor,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::EscalationConfig, &cfg);
         Ok(())
     }
 
     pub fn check_escalation_timeout(env: Env, escrow_id: u64) -> bool {
-        let escrow: Option<Escrow> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Escrow(escrow_id));
+        let escrow: Option<Escrow> = env.storage().instance().get(&DataKey::Escrow(escrow_id));
         let escrow = match escrow {
             Some(e) => e,
             None => return false,
@@ -3460,8 +3500,6 @@ impl EscrowContract {
             if !config.admins.contains(&admin) {
                 return Err(Error::NotAnAdmin);
             }
-            // Admin actions require time-lock for sensitive operations
-            return Err(Error::Unauthorized);
         }
 
         Self::internal_resolve_dispute(env, admin, escrow_id, release_to_merchant)
@@ -3701,9 +3739,10 @@ impl EscrowContract {
             .set(&EscrowAuxKey::DisputeAppealCounter, &(appeals_count + 1));
 
         // Update dispute round to Appeal
-        env.storage()
-            .instance()
-            .set(&EscrowAuxKey::DisputeRoundKey(escrow_id), &DisputeRound::Appeal);
+        env.storage().instance().set(
+            &EscrowAuxKey::DisputeRoundKey(escrow_id),
+            &DisputeRound::Appeal,
+        );
 
         DisputeAppealFiled {
             appeal_id,
@@ -3783,9 +3822,10 @@ impl EscrowContract {
             .set(&EscrowAuxKey::DisputeAppeal(appeal_id), &appeal);
 
         // Update dispute round to Final
-        env.storage()
-            .instance()
-            .set(&EscrowAuxKey::DisputeRoundKey(escrow_id), &DisputeRound::Final);
+        env.storage().instance().set(
+            &EscrowAuxKey::DisputeRoundKey(escrow_id),
+            &DisputeRound::Final,
+        );
 
         // Call internal resolution logic with senior arbitrators
         let now = env.ledger().timestamp();
@@ -3802,7 +3842,12 @@ impl EscrowContract {
             .set(&DataKey::Escrow(escrow_id), &escrow_mut);
 
         // Transfer funds to the party in favor
-        Self::transfer_if_token_contract(&env, &escrow_mut.token, &in_favour_of, escrow_mut.amount)?;
+        Self::transfer_if_token_contract(
+            &env,
+            &escrow_mut.token,
+            &in_favour_of,
+            escrow_mut.amount,
+        )?;
 
         // Handle collateral distribution if any
         if let Some(collateral) = env
@@ -3811,7 +3856,11 @@ impl EscrowContract {
             .get::<DataKey, DisputeCollateral>(&DataKey::DisputeCollateral(escrow_id))
         {
             let token_client = token::Client::new(&env, &collateral.token);
-            token_client.transfer(&env.current_contract_address(), &in_favour_of, &collateral.amount);
+            token_client.transfer(
+                &env.current_contract_address(),
+                &in_favour_of,
+                &collateral.amount,
+            );
 
             if in_favour_of == collateral.disputing_party {
                 CollateralReturned {
@@ -4025,9 +4074,14 @@ impl EscrowContract {
             return Err(Error::EscrowNotFound);
         }
 
-        let mut allowed = EscrowContract::verify_escrow_participant(env.clone(), escrow_id, granter.clone());
+        let mut allowed =
+            EscrowContract::verify_escrow_participant(env.clone(), escrow_id, granter.clone());
         if !allowed {
-            if let Some(cfg) = env.storage().instance().get::<AdminKey, MultiSigConfig>(&AdminKey::MultiSigConfig) {
+            if let Some(cfg) = env
+                .storage()
+                .instance()
+                .get::<AdminKey, MultiSigConfig>(&AdminKey::MultiSigConfig)
+            {
                 allowed = cfg.admins.contains(&granter);
             }
         }
@@ -4087,9 +4141,14 @@ impl EscrowContract {
             return Err(Error::EscrowNotFound);
         }
 
-        let mut allowed = EscrowContract::verify_escrow_participant(env.clone(), escrow_id, granter.clone());
+        let mut allowed =
+            EscrowContract::verify_escrow_participant(env.clone(), escrow_id, granter.clone());
         if !allowed {
-            if let Some(cfg) = env.storage().instance().get::<AdminKey, MultiSigConfig>(&AdminKey::MultiSigConfig) {
+            if let Some(cfg) = env
+                .storage()
+                .instance()
+                .get::<AdminKey, MultiSigConfig>(&AdminKey::MultiSigConfig)
+            {
                 allowed = cfg.admins.contains(&granter);
             }
         }
@@ -4113,10 +4172,10 @@ impl EscrowContract {
                 if existing.observer == observer {
                     let last_index = count.saturating_sub(1);
                     if i != last_index {
-                        if let Some(last) = env
-                            .storage()
-                            .instance()
-                            .get::<ObserverKey, EscrowObserver>(&ObserverKey::Entry(escrow_id, last_index))
+                        if let Some(last) =
+                            env.storage().instance().get::<ObserverKey, EscrowObserver>(
+                                &ObserverKey::Entry(escrow_id, last_index),
+                            )
                         {
                             env.storage()
                                 .instance()
@@ -4317,7 +4376,9 @@ impl EscrowContract {
         config: TenureReputationConfig,
     ) -> Result<(), Error> {
         admin.require_auth();
-        env.storage().instance().set(&DataKey::TenureConfig, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::TenureConfig, &config);
         TenureConfigUpdated {
             base_score: config.base_score,
             weight_per_day: config.weight_per_day,
@@ -4347,10 +4408,7 @@ impl EscrowContract {
             return 0;
         }
 
-        let seconds_active = env
-            .ledger()
-            .timestamp()
-            .saturating_sub(escrow.created_at);
+        let seconds_active = env.ledger().timestamp().saturating_sub(escrow.created_at);
         let days_active = seconds_active / 86_400;
         let earned = days_active.saturating_mul(config.weight_per_day as u64);
         let cap = (config.max_bonus_days as u64).saturating_mul(config.weight_per_day as u64);
@@ -4363,11 +4421,7 @@ impl EscrowContract {
     /// invoked at most once per escrow per participant. Grants the configured
     /// `base_score` plus the duration-weighted bonus to the participant's
     /// reputation. Disputed escrows are ineligible and receive nothing.
-    pub fn apply_tenure_bonus(
-        env: Env,
-        escrow_id: u64,
-        participant: Address,
-    ) -> Result<(), Error> {
+    pub fn apply_tenure_bonus(env: Env, escrow_id: u64, participant: Address) -> Result<(), Error> {
         let config = Self::get_tenure_config(env.clone()).ok_or(Error::EscrowNotFound)?;
 
         let marker = DataKey::TenureBonusApplied(escrow_id, participant.clone());
@@ -4711,7 +4765,10 @@ impl EscrowContract {
             return Err(Error::NotAnAdmin);
         }
 
-        if milestone_bps == 0 || milestone_bps > max_acceleration_bps || max_acceleration_bps > 10000 {
+        if milestone_bps == 0
+            || milestone_bps > max_acceleration_bps
+            || max_acceleration_bps > 10000
+        {
             return Err(Error::InvalidVestingSchedule);
         }
 
@@ -4731,9 +4788,10 @@ impl EscrowContract {
             total_accelerated_bps: 0,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::VestingAccelerationConfig(schedule_id), &acceleration_config);
+        env.storage().instance().set(
+            &DataKey::VestingAccelerationConfig(schedule_id),
+            &acceleration_config,
+        );
 
         Ok(())
     }
@@ -4752,7 +4810,9 @@ impl EscrowContract {
         let mut acceleration_config = env
             .storage()
             .instance()
-            .get::<DataKey, VestingAccelerationConfig>(&DataKey::VestingAccelerationConfig(schedule_id))
+            .get::<DataKey, VestingAccelerationConfig>(&DataKey::VestingAccelerationConfig(
+                schedule_id,
+            ))
             .ok_or(Error::EscrowNotFound)?;
 
         if acceleration_config.total_accelerated_bps >= acceleration_config.max_acceleration_bps {
@@ -4767,9 +4827,10 @@ impl EscrowContract {
         }
 
         acceleration_config.total_accelerated_bps = next_total;
-        env.storage()
-            .instance()
-            .set(&DataKey::VestingAccelerationConfig(schedule_id), &acceleration_config);
+        env.storage().instance().set(
+            &DataKey::VestingAccelerationConfig(schedule_id),
+            &acceleration_config,
+        );
 
         Ok(())
     }
@@ -4796,20 +4857,17 @@ impl EscrowContract {
         let acceleration_config = match env
             .storage()
             .instance()
-            .get::<DataKey, VestingAccelerationConfig>(&DataKey::VestingAccelerationConfig(schedule_id))
-        {
+            .get::<DataKey, VestingAccelerationConfig>(&DataKey::VestingAccelerationConfig(
+                schedule_id,
+            )) {
             Some(config) => config,
             None => return 0,
         };
 
         let base_vested = Self::get_base_vested_amount(&env, schedule_id);
-        let remaining_unvested = vesting_schedule
-            .total_amount
-            .saturating_sub(base_vested);
+        let remaining_unvested = vesting_schedule.total_amount.saturating_sub(base_vested);
 
-        remaining_unvested
-            .saturating_mul(acceleration_config.total_accelerated_bps as i128)
-            / 10000
+        remaining_unvested.saturating_mul(acceleration_config.total_accelerated_bps as i128) / 10000
     }
 
     /// Returns cliff timing and whether the ledger time has reached the cliff.
@@ -5913,9 +5971,10 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::PauseHistoryCount, &(history_count + 1));
-        env.storage()
-            .instance()
-            .set(&DataKey::ActivePauseIndex(function_name.clone()), &history_count);
+        env.storage().instance().set(
+            &DataKey::ActivePauseIndex(function_name.clone()),
+            &history_count,
+        );
         (FunctionPausedEvent {
             function_name,
             paused_by: admin,
@@ -7436,9 +7495,12 @@ impl EscrowContract {
         if !config.admins.contains(&admin) {
             return Err(Error::NotAnAdmin);
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::GlobalExpiryConfig, &GlobalExpiryConfig { default_expiry_seconds });
+        env.storage().instance().set(
+            &DataKey::GlobalExpiryConfig,
+            &GlobalExpiryConfig {
+                default_expiry_seconds,
+            },
+        );
         Ok(())
     }
 
@@ -7528,11 +7590,7 @@ impl EscrowContract {
             .instance()
             .set(&EscrowAuxKey::EscrowTemplateCounter, &template_id);
 
-        TemplateCreated {
-            template_id,
-            owner,
-        }
-        .publish(&env);
+        TemplateCreated { template_id, owner }.publish(&env);
 
         Ok(template_id)
     }
@@ -7621,11 +7679,7 @@ impl EscrowContract {
         })
     }
 
-    pub fn deactivate_template(
-        env: Env,
-        owner: Address,
-        template_id: u64,
-    ) -> Result<(), Error> {
+    pub fn deactivate_template(env: Env, owner: Address, template_id: u64) -> Result<(), Error> {
         owner.require_auth();
 
         let mut template: EscrowTemplate = env
@@ -7919,7 +7973,12 @@ impl EscrowContract {
             return Err(Error::SubAccountAlreadyReleased);
         }
 
-        EscrowContract::transfer_if_token_contract(&env, &escrow.token, &escrow.merchant, sub.amount)?;
+        EscrowContract::transfer_if_token_contract(
+            &env,
+            &escrow.token,
+            &escrow.merchant,
+            sub.amount,
+        )?;
 
         sub.released = true;
         env.storage()
@@ -7993,11 +8052,7 @@ impl EscrowContract {
         Ok(())
     }
 
-    pub fn execute_escrow_swap(
-        env: Env,
-        caller: Address,
-        escrow_id: u64,
-    ) -> Result<i128, Error> {
+    pub fn execute_escrow_swap(env: Env, caller: Address, escrow_id: u64) -> Result<i128, Error> {
         // Authenticate the caller to follow standard signature verification pattern.
         caller.require_auth();
 
@@ -8025,7 +8080,11 @@ impl EscrowContract {
         }
 
         // Call oracle to get the rate (get_rate symbol takes no arguments and returns i128)
-        let rate: i128 = env.invoke_contract(&swap_config.oracle, &Symbol::new(&env, "get_rate"), Vec::new(&env));
+        let rate: i128 = env.invoke_contract(
+            &swap_config.oracle,
+            &Symbol::new(&env, "get_rate"),
+            Vec::new(&env),
+        );
 
         // Output amount scaled by Stellar/Soroban standard 1e7 fixed-point rate representation.
         // The mock oracle and implementation use a 1e7 rate because the issue does not specify oracle decimals.
@@ -8146,7 +8205,9 @@ impl EscrowContract {
             let node = env
                 .storage()
                 .instance()
-                .get::<EscrowAuxKey, EscrowHierarchyNode>(&EscrowAuxKey::EscrowHierarchy(current_id))
+                .get::<EscrowAuxKey, EscrowHierarchyNode>(&EscrowAuxKey::EscrowHierarchy(
+                    current_id,
+                ))
                 .unwrap_or(EscrowHierarchyNode {
                     escrow_id: current_id,
                     parent_id: None,
@@ -8176,7 +8237,13 @@ impl EscrowContract {
             let current_id = queue.get(index).unwrap();
             index += 1;
 
-            if let Some(node) = env.storage().instance().get::<EscrowAuxKey, EscrowHierarchyNode>(&EscrowAuxKey::EscrowHierarchy(current_id)) {
+            if let Some(node) = env
+                .storage()
+                .instance()
+                .get::<EscrowAuxKey, EscrowHierarchyNode>(&EscrowAuxKey::EscrowHierarchy(
+                    current_id,
+                ))
+            {
                 for child_id in node.children.iter() {
                     // Check if child is resolved
                     if !Self::is_escrow_resolved(&env, child_id) {
@@ -8190,7 +8257,11 @@ impl EscrowContract {
     }
 
     fn is_escrow_resolved(env: &Env, escrow_id: u64) -> bool {
-        if let Some(escrow) = env.storage().instance().get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id)) {
+        if let Some(escrow) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Escrow>(&DataKey::Escrow(escrow_id))
+        {
             match escrow.status {
                 EscrowStatus::Released | EscrowStatus::Resolved | EscrowStatus::Cancelled => true,
                 _ => false,
@@ -8226,46 +8297,45 @@ mod hierarchy_test;
 
 // #[cfg(test)]
 // mod dispute_appeal_test;
-// 
+//
 // #[cfg(test)]
 // mod verification_test;
-// 
+//
 // #[cfg(test)]
 // mod timelock_test;
-// 
+//
 // #[cfg(test)]
 // mod collateral_test;
-// 
+//
 // #[cfg(test)]
 // mod beneficiary_transfer_test;
-// 
+//
 // #[cfg(test)]
 // mod multi_party_dispute_test;
-// 
+//
 // #[cfg(test)]
 // mod pause_history_test;
-// 
+//
 // #[cfg(test)]
 // mod expiry_test;
-// 
+//
 // #[cfg(test)]
 // mod multisig_threshold_test;
-// 
+//
 // #[cfg(test)]
 // mod escalation_timeout_test;
-// 
+//
 // #[cfg(test)]
 // mod bulk_evidence_test;
 // mod migration_test;
-// 
+//
 // #[cfg(test)]
 // mod multi_party_rollback_test;
-// 
+//
 // #[cfg(test)]
 // mod observer_test;
-// 
+//
 // mod health_check_test;
-// 
+//
 // #[cfg(test)]
 // mod test_sub_account;
-

--- a/contracts/escrow/src/swap_test.rs
+++ b/contracts/escrow/src/swap_test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, contract, contractimpl};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
 
 #[contract]
 pub struct MockSwapOracle;
@@ -39,27 +39,14 @@ fn test_escrow_swap_successful() {
 
     // Create escrow (8 arguments as defined in lib.rs)
     let escrow_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
     // Set rate to 1.5 (15_000_000)
     oracle_client.set_rate(&15_000_000_i128);
 
     // Configure swap by merchant (min_output = 1400)
-    client.configure_escrow_swap(
-        &merchant,
-        &escrow_id,
-        &target_token,
-        &1400_i128,
-        &oracle,
-    );
+    client.configure_escrow_swap(&merchant, &escrow_id, &target_token, &1400_i128, &oracle);
 
     // Verify config is retrieved correctly
     let config = client.get_swap_config(&escrow_id).unwrap();
@@ -102,26 +89,13 @@ fn test_escrow_swap_successful_by_admin() {
     client.initialize(&admin);
 
     let escrow_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
     oracle_client.set_rate(&15_000_000_i128);
 
     // Configure swap by admin
-    client.configure_escrow_swap(
-        &admin,
-        &escrow_id,
-        &target_token,
-        &1400_i128,
-        &oracle,
-    );
+    client.configure_escrow_swap(&admin, &escrow_id, &target_token, &1400_i128, &oracle);
 
     // Execute swap by admin
     let output = client.execute_escrow_swap(&admin, &escrow_id);
@@ -150,27 +124,14 @@ fn test_escrow_swap_below_minimum_fails() {
     client.initialize(&admin);
 
     let escrow_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
     // Set rate to 1.2 (12_000_000) -> output = 1200
     oracle_client.set_rate(&12_000_000_i128);
 
     // Configure swap (min_output = 1300)
-    client.configure_escrow_swap(
-        &merchant,
-        &escrow_id,
-        &target_token,
-        &1300_i128,
-        &oracle,
-    );
+    client.configure_escrow_swap(&merchant, &escrow_id, &target_token, &1300_i128, &oracle);
 
     // Executing should fail with SwapOutputBelowMinimum
     let res = client.try_execute_escrow_swap(&merchant, &escrow_id);
@@ -195,25 +156,12 @@ fn test_escrow_swap_double_execution_fails() {
     client.initialize(&admin);
 
     let escrow_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
     oracle_client.set_rate(&15_000_000_i128);
 
-    client.configure_escrow_swap(
-        &merchant,
-        &escrow_id,
-        &target_token,
-        &1400_i128,
-        &oracle,
-    );
+    client.configure_escrow_swap(&merchant, &escrow_id, &target_token, &1400_i128, &oracle);
 
     // Execute first time: success
     let output = client.execute_escrow_swap(&merchant, &escrow_id);
@@ -242,14 +190,7 @@ fn test_escrow_swap_unauthorized_config_fails() {
     client.initialize(&admin);
 
     let escrow_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
     // Non-merchant, non-admin tries to configure swap: fails with Unauthorized
@@ -281,23 +222,10 @@ fn test_escrow_swap_unauthorized_execute_fails() {
     client.initialize(&admin);
 
     let escrow_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
-    client.configure_escrow_swap(
-        &merchant,
-        &escrow_id,
-        &target_token,
-        &1400_i128,
-        &oracle,
-    );
+    client.configure_escrow_swap(&merchant, &escrow_id, &target_token, &1400_i128, &oracle);
 
     // Non-merchant, non-admin tries to execute swap: fails with Unauthorized
     let res = client.try_execute_escrow_swap(&unauthorized_caller, &escrow_id);
@@ -319,14 +247,7 @@ fn test_escrow_swap_config_not_found_fails() {
     client.initialize(&admin);
 
     let escrow_id = client.create_escrow(
-        &customer,
-        &merchant,
-        &1000_i128,
-        &token,
-        &1000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
     );
 
     // Execute swap directly without configuring first: fails with SwapConfigNotFound

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -5,7 +5,6 @@ use soroban_sdk::{
     Env, IntoVal, InvokeError, String, Symbol, TryFromVal, Val, Vec,
 };
 
-
 // Core payment data keys (≤50 variants for Soroban XDR spec limit)
 #[derive(Clone)]
 #[contracttype]
@@ -376,7 +375,8 @@ impl TryFrom<soroban_sdk::Error> for Error {
     fn try_from(error: soroban_sdk::Error) -> Result<Self, soroban_sdk::Error> {
         if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) {
             let code = error.get_code();
-            if matches!(code, 1..=21 | 23..=48 | 50..=56 | 58..=80 | 85..=91 | 95..=96 | 100..=102 | 106..=111 | 114..=123) {
+            if matches!(code, 1..=21 | 23..=48 | 50..=56 | 58..=80 | 85..=91 | 95..=96 | 100..=102 | 106..=111 | 114..=123)
+            {
                 // SAFETY: Error is #[repr(u32)] and all valid discriminants are covered by the matches! guard above
                 Ok(unsafe { core::mem::transmute::<u32, Error>(code) })
             } else {
@@ -430,7 +430,10 @@ impl TryFrom<&soroban_sdk::InvokeError> for Error {
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Error {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
-    fn try_from_val(env: &soroban_sdk::Env, val: &soroban_sdk::Val) -> Result<Self, soroban_sdk::ConversionError> {
+    fn try_from_val(
+        env: &soroban_sdk::Env,
+        val: &soroban_sdk::Val,
+    ) -> Result<Self, soroban_sdk::ConversionError> {
         use soroban_sdk::TryIntoVal;
         let error: soroban_sdk::Error = val.try_into_val(env)?;
         error.try_into().map_err(|_| soroban_sdk::ConversionError)
@@ -439,7 +442,10 @@ impl soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val> for Error {
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, Error> for soroban_sdk::Val {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
-    fn try_from_val(_env: &soroban_sdk::Env, val: &Error) -> Result<Self, soroban_sdk::ConversionError> {
+    fn try_from_val(
+        _env: &soroban_sdk::Env,
+        val: &Error,
+    ) -> Result<Self, soroban_sdk::ConversionError> {
         let error: soroban_sdk::Error = val.into();
         Ok(error.into())
     }
@@ -447,7 +453,10 @@ impl soroban_sdk::TryFromVal<soroban_sdk::Env, Error> for soroban_sdk::Val {
 impl soroban_sdk::TryFromVal<soroban_sdk::Env, &Error> for soroban_sdk::Val {
     type Error = soroban_sdk::ConversionError;
     #[inline(always)]
-    fn try_from_val(env: &soroban_sdk::Env, val: &&Error) -> Result<Self, soroban_sdk::ConversionError> {
+    fn try_from_val(
+        env: &soroban_sdk::Env,
+        val: &&Error,
+    ) -> Result<Self, soroban_sdk::ConversionError> {
         <_ as soroban_sdk::TryFromVal<soroban_sdk::Env, Error>>::try_from_val(env, *val)
     }
 }
@@ -1365,8 +1374,8 @@ pub struct PaymentForwarded {
 #[contracttype]
 pub struct PaymentMemo {
     pub payment_id: u64,
-    pub memo_ref: String,           // Reference to memo content (IPFS CID, URL, etc.)
-    pub memo_hash: BytesN<32>,      // SHA-256 hash of memo plaintext (immutable)
+    pub memo_ref: String,      // Reference to memo content (IPFS CID, URL, etc.)
+    pub memo_hash: BytesN<32>, // SHA-256 hash of memo plaintext (immutable)
     pub reference_hash: BytesN<32>, // Hash linking memo to payment (for integrity)
     pub created_at: u64,
     pub updated_at: u64,
@@ -1571,11 +1580,11 @@ impl PaymentContract {
         if !config.admins.contains(&admin) {
             return Err(Error::Unauthorized);
         }
-        
+
         env.storage()
             .instance()
             .set(&MerchantDataKey::VerificationLevel(merchant), &level);
-            
+
         Ok(())
     }
 
@@ -1603,11 +1612,12 @@ impl PaymentContract {
         if !config.admins.contains(&admin) {
             return Err(Error::Unauthorized);
         }
-        
-        env.storage()
-            .instance()
-            .set(&MerchantDataKey::VerificationTierLimit(limits.level.clone()), &limits);
-            
+
+        env.storage().instance().set(
+            &MerchantDataKey::VerificationTierLimit(limits.level.clone()),
+            &limits,
+        );
+
         Ok(())
     }
 
@@ -1992,7 +2002,12 @@ impl PaymentContract {
             return Err(Error::PaymentNotYetDue);
         }
 
-        Self::settle_or_accumulate(&env, scheduled.merchant.clone(), scheduled.token.clone(), scheduled.amount)?;
+        Self::settle_or_accumulate(
+            &env,
+            scheduled.merchant.clone(),
+            scheduled.token.clone(),
+            scheduled.amount,
+        )?;
         scheduled.executed = true;
         env.storage()
             .instance()
@@ -2039,18 +2054,26 @@ impl PaymentContract {
             .ok_or(Error::PaymentNotFound)
     }
 
-    fn settle_or_accumulate(env: &Env, merchant: Address, token: Address, amount: i128) -> Result<(), Error> {
+    fn settle_or_accumulate(
+        env: &Env,
+        merchant: Address,
+        token: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
         // If merchant has a payout schedule for this token and it's not Immediate, accumulate
         if let Some(mut schedule) = env
             .storage()
             .instance()
-            .get::<MerchantDataKey, PayoutSchedule>(&MerchantDataKey::PayoutSchedule(merchant.clone()))
+            .get::<MerchantDataKey, PayoutSchedule>(&MerchantDataKey::PayoutSchedule(
+                merchant.clone(),
+            ))
         {
             if schedule.token == token && schedule.frequency != PayoutFrequency::Immediate {
                 schedule.accumulated += amount;
-                env.storage()
-                    .instance()
-                    .set(&MerchantDataKey::PayoutSchedule(merchant.clone()), &schedule);
+                env.storage().instance().set(
+                    &MerchantDataKey::PayoutSchedule(merchant.clone()),
+                    &schedule,
+                );
                 return Ok(());
             }
         }
@@ -2090,7 +2113,9 @@ impl PaymentContract {
     }
 
     pub fn get_payout_schedule(env: Env, merchant: Address) -> Option<PayoutSchedule> {
-        env.storage().instance().get(&MerchantDataKey::PayoutSchedule(merchant))
+        env.storage()
+            .instance()
+            .get(&MerchantDataKey::PayoutSchedule(merchant))
     }
 
     pub fn trigger_scheduled_payout(env: Env, merchant: Address) -> Result<(), Error> {
@@ -2729,7 +2754,9 @@ impl PaymentContract {
         if let Some(dispute) = env
             .storage()
             .instance()
-            .get::<StateDataKey, EscrowedPaymentDispute>(&StateDataKey::EscrowedPaymentDispute(payment_id))
+            .get::<StateDataKey, EscrowedPaymentDispute>(&StateDataKey::EscrowedPaymentDispute(
+                payment_id,
+            ))
         {
             if !dispute.resolved {
                 return Err(Error::InvalidStatus);
@@ -2815,7 +2842,7 @@ impl PaymentContract {
         // Transfer token amount back to customer (automatic refund)
         let token_client = token::Client::new(&env, &payment.token);
         let contract_address = env.current_contract_address();
-        
+
         // Check if contract has sufficient balance (in case of partial payments)
         let contract_balance = token_client.balance(&contract_address);
         let refund_amount = if contract_balance >= payment.amount {
@@ -2871,7 +2898,9 @@ impl PaymentContract {
             if env
                 .storage()
                 .instance()
-                .get::<StateDataKey, LargePaymentProposal>(&StateDataKey::LargePaymentProposal(payment_id))
+                .get::<StateDataKey, LargePaymentProposal>(&StateDataKey::LargePaymentProposal(
+                    payment_id,
+                ))
                 .is_some()
             {
                 return Err(Error::PaymentRequiresMultiSig);
@@ -2950,7 +2979,8 @@ impl PaymentContract {
         );
 
         // Check finality delay config (#219)
-        let finality: Option<FinalityConfig> = env.storage().instance().get(&DataKey::FinalityConfig);
+        let finality: Option<FinalityConfig> =
+            env.storage().instance().get(&DataKey::FinalityConfig);
         if let Some(ref fc) = finality {
             if fc.active && payment.amount >= fc.min_amount_threshold {
                 // Hold funds — create PendingSettlement instead of transferring
@@ -2968,7 +2998,9 @@ impl PaymentContract {
                 let idx: u64 = env
                     .storage()
                     .instance()
-                    .get(&MerchantDataKey::PendingSettlementCount(payment.merchant.clone()))
+                    .get(&MerchantDataKey::PendingSettlementCount(
+                        payment.merchant.clone(),
+                    ))
                     .unwrap_or(0);
                 env.storage().instance().set(
                     &MerchantDataKey::PendingSettlementIndex(payment.merchant.clone(), idx),
@@ -3027,12 +3059,13 @@ impl PaymentContract {
         );
 
         // Check if merchant has an active payment forward config
-        if let Ok(forward_config) = PaymentContract::get_forward_config(env.clone(), payment.merchant.clone())
+        if let Ok(forward_config) =
+            PaymentContract::get_forward_config(env.clone(), payment.merchant.clone())
         {
             if forward_config.active {
                 // Calculate the forward amount based on forward_bps
                 let forward_amount = (net_amount * (forward_config.forward_bps as i128)) / 10000;
-                
+
                 // Transfer the forward amount from merchant to forward_to address
                 if forward_amount > 0 {
                     token_client.transfer(
@@ -3106,10 +3139,19 @@ impl PaymentContract {
         .publish(env);
 
         // Accrue loyalty points for completed payments if loyalty is configured.
-        PaymentContract::maybe_accrue_loyalty_points(&env, payment.customer.clone(), payment.amount);
+        PaymentContract::maybe_accrue_loyalty_points(
+            &env,
+            payment.customer.clone(),
+            payment.amount,
+        );
 
         // Accrue fee rebate for merchant if rebate programme is active
-        PaymentContract::maybe_accrue_fee_rebate(env, payment.merchant.clone(), payment.amount, fee_amount);
+        PaymentContract::maybe_accrue_fee_rebate(
+            env,
+            payment.merchant.clone(),
+            payment.amount,
+            fee_amount,
+        );
 
         // Attempt to trigger auto-escrow if a rule exists
         // Ignore errors - if there's no rule, payment is below minimum, or already triggered,
@@ -3136,13 +3178,22 @@ impl PaymentContract {
             return Err(Error::InvalidForwardBps);
         }
 
-        // Check for forward loops: if forward_to already has a forward config, reject it
-        if env
-            .storage()
-            .instance()
-            .has(&DataKey::PaymentForwardConfig(forward_to.clone()))
+        // Detect cycles (including self-referential) by walking the forward chain up to 10 hops.
         {
-            return Err(Error::ForwardLoop);
+            let mut current = forward_to.clone();
+            for _ in 0..10u32 {
+                if current == merchant {
+                    return Err(Error::ForwardLoop);
+                }
+                match env
+                    .storage()
+                    .instance()
+                    .get::<DataKey, PaymentForwardConfig>(&DataKey::PaymentForwardConfig(current))
+                {
+                    Some(next) => current = next.forward_to,
+                    None => break,
+                }
+            }
         }
 
         // Create and store the forward config
@@ -3193,10 +3244,7 @@ impl PaymentContract {
         Ok(())
     }
 
-    pub fn get_forward_config(
-        env: Env,
-        merchant: Address,
-    ) -> Result<PaymentForwardConfig, Error> {
+    pub fn get_forward_config(env: Env, merchant: Address) -> Result<PaymentForwardConfig, Error> {
         env.storage()
             .instance()
             .get(&DataKey::PaymentForwardConfig(merchant))
@@ -3332,7 +3380,12 @@ impl PaymentContract {
     }
 
     // Partial payment functions (#112)
-    pub fn pay_installment(env: Env, customer: Address, payment_id: u64, amount: i128) -> Result<(), Error> {
+    pub fn pay_installment(
+        env: Env,
+        customer: Address,
+        payment_id: u64,
+        amount: i128,
+    ) -> Result<(), Error> {
         Self::require_not_paused(&env, "pay_installment")?;
         customer.require_auth();
 
@@ -3354,7 +3407,7 @@ impl PaymentContract {
 
         // Get current outstanding balance
         let outstanding_balance = PaymentContract::get_outstanding_balance(env.clone(), payment_id);
-        
+
         if outstanding_balance <= 0 {
             return Err(Error::PaymentAlreadyFullyPaid);
         }
@@ -3388,14 +3441,16 @@ impl PaymentContract {
         };
 
         // Store partial payment record
-        env.storage()
-            .instance()
-            .set(&StateDataKey::PartialPaymentRecord(payment_id, new_installment_number), &partial_payment);
-        
+        env.storage().instance().set(
+            &StateDataKey::PartialPaymentRecord(payment_id, new_installment_number),
+            &partial_payment,
+        );
+
         // Update installment counter
-        env.storage()
-            .instance()
-            .set(&DataKey::PartialPaymentCounter(payment_id), &new_installment_number);
+        env.storage().instance().set(
+            &DataKey::PartialPaymentCounter(payment_id),
+            &new_installment_number,
+        );
 
         // Update outstanding balance
         env.storage()
@@ -3443,7 +3498,11 @@ impl PaymentContract {
 
     pub fn get_outstanding_balance(env: Env, payment_id: u64) -> i128 {
         // First check if we have an outstanding balance stored
-        if let Some(balance) = env.storage().instance().get(&DataKey::OutstandingBalance(payment_id)) {
+        if let Some(balance) = env
+            .storage()
+            .instance()
+            .get(&DataKey::OutstandingBalance(payment_id))
+        {
             return balance;
         }
 
@@ -3460,14 +3519,16 @@ impl PaymentContract {
             if let Some(record) = env
                 .storage()
                 .instance()
-                .get::<StateDataKey, PartialPaymentRecord>(&StateDataKey::PartialPaymentRecord(payment_id, i))
+                .get::<StateDataKey, PartialPaymentRecord>(&StateDataKey::PartialPaymentRecord(
+                    payment_id, i,
+                ))
             {
                 total_paid += record.amount_paid;
             }
         }
 
         let outstanding = payment.amount - total_paid;
-        
+
         // Cache the calculated balance
         env.storage()
             .instance()
@@ -3478,7 +3539,7 @@ impl PaymentContract {
 
     pub fn finalize_installment_payment(env: Env, payment_id: u64) -> Result<(), Error> {
         let mut payment = PaymentContract::get_payment(&env, payment_id);
-        
+
         if payment.status != PaymentStatus::Pending {
             return Err(Error::InvalidStatus);
         }
@@ -3502,7 +3563,12 @@ impl PaymentContract {
             .set(&DataKey::Payment(payment_id), &payment);
 
         // Transfer or accumulate all collected funds to merchant
-        Self::settle_or_accumulate(&env, payment.merchant.clone(), payment.token.clone(), payment.amount)?;
+        Self::settle_or_accumulate(
+            &env,
+            payment.merchant.clone(),
+            payment.token.clone(),
+            payment.amount,
+        )?;
 
         // Emit payment fully paid event
         (PaymentFullyPaid {
@@ -4423,10 +4489,7 @@ impl PaymentContract {
         Ok(())
     }
 
-    pub fn execute_metered_billing(
-        env: Env,
-        subscription_id: u64,
-    ) -> Result<i128, Error> {
+    pub fn execute_metered_billing(env: Env, subscription_id: u64) -> Result<i128, Error> {
         let mut sub: MeteredSubscription = env
             .storage()
             .instance()
@@ -4450,12 +4513,7 @@ impl PaymentContract {
 
         let token_client = token::Client::new(&env, &sub.token);
         let contract_address = env.current_contract_address();
-        token_client.transfer_from(
-            &contract_address,
-            &sub.customer,
-            &sub.merchant,
-            &amount,
-        );
+        token_client.transfer_from(&contract_address, &sub.customer, &sub.merchant, &amount);
 
         sub.accumulated_units = 0;
         sub.last_reset_at = env.ledger().timestamp();
@@ -5337,7 +5395,10 @@ impl PaymentContract {
             .instance()
             .get::<_, MerchantRateLimit>(&DataKey::MerchantRateLimit(merchant.clone()))
         {
-            (custom_limit.max_transactions_per_hour, custom_limit.max_amount_per_hour)
+            (
+                custom_limit.max_transactions_per_hour,
+                custom_limit.max_amount_per_hour,
+            )
         } else {
             // Fallback to global config
             let config: Option<RateLimitConfig> =
@@ -5357,7 +5418,11 @@ impl PaymentContract {
         {
             let now = env.ledger().timestamp();
             let reset_needed = l.window_start > 0 && now >= l.window_start + 3600;
-            let current_transactions = if reset_needed { 0 } else { l.current_transactions };
+            let current_transactions = if reset_needed {
+                0
+            } else {
+                l.current_transactions
+            };
             let current_amount = if reset_needed { 0 } else { l.current_amount };
 
             if max_tx > 0 && current_transactions >= max_tx {
@@ -5386,7 +5451,10 @@ impl PaymentContract {
             .instance()
             .get::<_, MerchantRateLimit>(&DataKey::MerchantRateLimit(merchant.clone()))
         {
-            (custom_limit.max_transactions_per_hour, custom_limit.max_amount_per_hour)
+            (
+                custom_limit.max_transactions_per_hour,
+                custom_limit.max_amount_per_hour,
+            )
         } else {
             let config: Option<RateLimitConfig> =
                 env.storage().instance().get(&DataKey::RateLimitConfig);
@@ -5415,7 +5483,7 @@ impl PaymentContract {
         limit.max_amount_per_hour = max_amt;
 
         let now = env.ledger().timestamp();
-        
+
         if limit.window_start > 0 && now >= limit.window_start + 3600 {
             limit.current_transactions = 0;
             limit.current_amount = 0;
@@ -5424,10 +5492,14 @@ impl PaymentContract {
             limit.window_start = now;
         }
 
-        if limit.max_transactions_per_hour > 0 && limit.current_transactions >= limit.max_transactions_per_hour {
+        if limit.max_transactions_per_hour > 0
+            && limit.current_transactions >= limit.max_transactions_per_hour
+        {
             return Err(Error::MerchantRateLimitExceeded);
         }
-        if limit.max_amount_per_hour > 0 && limit.current_amount + amount > limit.max_amount_per_hour {
+        if limit.max_amount_per_hour > 0
+            && limit.current_amount + amount > limit.max_amount_per_hour
+        {
             return Err(Error::AmountRateLimitExceeded);
         }
 
@@ -6193,7 +6265,8 @@ impl PaymentContract {
         payment_amount: i128,
         fee_amount: i128,
     ) {
-        let config: Option<FeeRebateConfig> = env.storage().instance().get(&DataKey::FeeRebateConfig);
+        let config: Option<FeeRebateConfig> =
+            env.storage().instance().get(&DataKey::FeeRebateConfig);
         let config = match config {
             Some(c) if c.active => c,
             _ => return,
@@ -6441,7 +6514,9 @@ impl PaymentContract {
             }
 
             // Check rate limits
-            if let Err(e) = PaymentContract::check_rate_limit_internal(&env, &entry.customer, entry.amount) {
+            if let Err(e) =
+                PaymentContract::check_rate_limit_internal(&env, &entry.customer, entry.amount)
+            {
                 results.push_back(BatchResult {
                     payment_id: 0,
                     success: false,
@@ -6874,11 +6949,9 @@ impl PaymentContract {
 
         let mut pairs: Vec<(Address, i128)> = Vec::new(&env);
         for i in 0..count {
-            if let Some(merchant) = env
-                .storage()
-                .instance()
-                .get::<CustomerDataKey, Address>(&CustomerDataKey::MerchantList(customer.clone(), i))
-            {
+            if let Some(merchant) = env.storage().instance().get::<CustomerDataKey, Address>(
+                &CustomerDataKey::MerchantList(customer.clone(), i),
+            ) {
                 let vol: i128 = env
                     .storage()
                     .instance()
@@ -6938,9 +7011,14 @@ impl PaymentContract {
         let mut out = Vec::new(&env);
         let mut bucket_start = PaymentContract::hour_bucket_start(from);
         while bucket_start < to {
-            if let Some(bucket) = env.storage().instance().get::<MerchantDataKey, AnalyticsBucket>(
-                &MerchantDataKey::AnalyticsBucket(merchant.clone(), bucket_start),
-            ) {
+            if let Some(bucket) = env
+                .storage()
+                .instance()
+                .get::<MerchantDataKey, AnalyticsBucket>(&MerchantDataKey::AnalyticsBucket(
+                    merchant.clone(),
+                    bucket_start,
+                ))
+            {
                 out.push_back(bucket);
             }
             bucket_start += 3600;
@@ -7404,7 +7482,11 @@ impl PaymentContract {
             .get(&StateDataKey::AutoEscrowRule(merchant))
     }
 
-    pub fn remove_auto_escrow_rule(env: Env, admin: Address, merchant: Address) -> Result<(), Error> {
+    pub fn remove_auto_escrow_rule(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+    ) -> Result<(), Error> {
         Self::require_not_paused(&env, "remove_auto_escrow_rule")?;
         admin.require_auth();
 
@@ -7455,7 +7537,9 @@ impl PaymentContract {
         let rule = env
             .storage()
             .instance()
-            .get::<StateDataKey, AutoEscrowRule>(&StateDataKey::AutoEscrowRule(payment.merchant.clone()))
+            .get::<StateDataKey, AutoEscrowRule>(&StateDataKey::AutoEscrowRule(
+                payment.merchant.clone(),
+            ))
             .ok_or(Error::AutoEscrowRuleNotFound)?;
 
         // Rule must be active
@@ -7597,7 +7681,9 @@ impl PaymentContract {
         if env
             .storage()
             .instance()
-            .get::<StateDataKey, LargePaymentProposal>(&StateDataKey::LargePaymentProposal(payment_id))
+            .get::<StateDataKey, LargePaymentProposal>(&StateDataKey::LargePaymentProposal(
+                payment_id,
+            ))
             .is_some()
         {
             return Err(Error::AlreadyProcessed);
@@ -7907,14 +7993,14 @@ impl PaymentContract {
         if let Some(existing) = existing_memo {
             // Memo already set - emit update event with new version
             let new_version = existing.version + 1;
-            
+
             // Create reference hash linking memo to payment for integrity verification
             let mut ref_bytes = Bytes::new(&env);
             ref_bytes.extend_from_array(&payment_id.to_be_bytes());
             ref_bytes.push_back(b':');
             ref_bytes.append(&existing.memo_hash.clone().into());
             let reference_hash = env.crypto().sha256(&ref_bytes);
-            
+
             let updated_memo = PaymentMemo {
                 payment_id,
                 memo_ref: memo_ref.clone(),
@@ -7945,7 +8031,7 @@ impl PaymentContract {
             ref_bytes.push_back(b':');
             ref_bytes.append(&memo_hash.clone().into());
             let reference_hash = env.crypto().sha256(&ref_bytes);
-            
+
             let memo = PaymentMemo {
                 payment_id,
                 memo_ref: memo_ref.clone(),
@@ -7981,11 +8067,7 @@ impl PaymentContract {
 
     /// Verify memo integrity by comparing provided hash against stored memo hash
     /// Returns true if hashes match, false otherwise
-    pub fn verify_memo_integrity(
-        env: Env,
-        payment_id: u64,
-        plaintext_hash: BytesN<32>,
-    ) -> bool {
+    pub fn verify_memo_integrity(env: Env, payment_id: u64, plaintext_hash: BytesN<32>) -> bool {
         let memo: Option<PaymentMemo> = env
             .storage()
             .instance()
@@ -8016,16 +8098,22 @@ impl PaymentContract {
     }
 
     // Dynamic fee calculation functions (#124)
-    pub fn calculate_risk_score(env: Env, customer: Address, merchant: Address, amount: i128, currency: Currency) -> u32 {
+    pub fn calculate_risk_score(
+        env: Env,
+        customer: Address,
+        merchant: Address,
+        amount: i128,
+        currency: Currency,
+    ) -> u32 {
         let config: RiskFeeConfig = env
             .storage()
             .instance()
             .get(&DataKey::RiskFeeConfig)
             .unwrap_or(RiskFeeConfig {
-                base_fee_bps: 100, // 1%
-                large_amount_threshold: 1000000, // 10,000 USDC/USDT
-                large_amount_surcharge_bps: 50, // 0.5%
-                new_customer_surcharge_bps: 100, // 1%
+                base_fee_bps: 100,                 // 1%
+                large_amount_threshold: 1000000,   // 10,000 USDC/USDT
+                large_amount_surcharge_bps: 50,    // 0.5%
+                new_customer_surcharge_bps: 100,   // 1%
                 high_risk_currency_surcharge: 200, // 2%
             });
 
@@ -8057,7 +8145,13 @@ impl PaymentContract {
         risk_score
     }
 
-    pub fn get_effective_fee_for_payment(env: Env, customer: Address, merchant: Address, amount: i128, currency: Currency) -> u32 {
+    pub fn get_effective_fee_for_payment(
+        env: Env,
+        customer: Address,
+        merchant: Address,
+        amount: i128,
+        currency: Currency,
+    ) -> u32 {
         let config: RiskFeeConfig = env
             .storage()
             .instance()
@@ -8081,7 +8175,11 @@ impl PaymentContract {
         }
     }
 
-    pub fn set_risk_fee_config(env: Env, admin: Address, config: RiskFeeConfig) -> Result<(), Error> {
+    pub fn set_risk_fee_config(
+        env: Env,
+        admin: Address,
+        config: RiskFeeConfig,
+    ) -> Result<(), Error> {
         admin.require_auth();
 
         // Verify admin is the contract admin
@@ -8236,7 +8334,8 @@ impl PaymentContract {
         msg.append(&merchant_amount.to_xdr(&env));
         msg.append(&nonce.to_xdr(&env));
 
-        env.crypto().ed25519_verify(&channel.customer_pk, &msg, &signature);
+        env.crypto()
+            .ed25519_verify(&channel.customer_pk, &msg, &signature);
 
         let customer_refund = channel.deposited - merchant_amount;
         let token_client = token::Client::new(&env, &channel.token);
@@ -8511,13 +8610,13 @@ impl PaymentContract {
             .get(&DataKey::SweepCounter)
             .unwrap_or(0);
         let mut result = Vec::new(&env);
-        let start = if total > limit as u64 { total - limit as u64 + 1 } else { 1 };
+        let start = if total > limit as u64 {
+            total - limit as u64 + 1
+        } else {
+            1
+        };
         for i in start..=total {
-            if let Some(record) = env
-                .storage()
-                .instance()
-                .get(&DataKey::SweepHistory(i))
-            {
+            if let Some(record) = env.storage().instance().get(&DataKey::SweepHistory(i)) {
                 result.push_back(record);
             }
         }
@@ -8598,13 +8697,21 @@ impl PaymentContract {
             None => true,
             Some(l) => {
                 let now = env.ledger().timestamp();
-                let used = if now > l.period_start + l.period_seconds { 0 } else { l.used };
+                let used = if now > l.period_start + l.period_seconds {
+                    0
+                } else {
+                    l.used
+                };
                 used + amount <= l.limit_amount
             }
         }
     }
 
-    fn check_and_update_spend_limit(env: &Env, customer: &Address, amount: i128) -> Result<(), Error> {
+    fn check_and_update_spend_limit(
+        env: &Env,
+        customer: &Address,
+        amount: i128,
+    ) -> Result<(), Error> {
         let limit: Option<CustomerSpendLimit> = env
             .storage()
             .instance()
@@ -8688,9 +8795,10 @@ impl PaymentContract {
         env.storage()
             .instance()
             .set(&DataKey::SubscriptionGroup(group_id), &group);
-        env.storage()
-            .instance()
-            .set(&DataKey::SubscriptionGroupMembership(subscription_id), &group_id);
+        env.storage().instance().set(
+            &DataKey::SubscriptionGroupMembership(subscription_id),
+            &group_id,
+        );
         Ok(())
     }
 
@@ -8752,7 +8860,11 @@ impl PaymentContract {
                 }
             }
         }
-        if earliest == u64::MAX { 0 } else { earliest }
+        if earliest == u64::MAX {
+            0
+        } else {
+            earliest
+        }
     }
 
     // ── FINALITY DELAY (#219) ─────────────────────────────────────────────────
@@ -8778,9 +8890,7 @@ impl PaymentContract {
     }
 
     pub fn get_finality_config(env: Env) -> Option<FinalityConfig> {
-        env.storage()
-            .instance()
-            .get(&DataKey::FinalityConfig)
+        env.storage().instance().get(&DataKey::FinalityConfig)
     }
 
     pub fn finalize_pending_settlement(env: Env, payment_id: u64) -> Result<(), Error> {
@@ -8820,11 +8930,9 @@ impl PaymentContract {
             .unwrap_or(0);
         let mut result = Vec::new(&env);
         for i in 0..count {
-            if let Some(payment_id) = env
-                .storage()
-                .instance()
-                .get::<MerchantDataKey, u64>(&MerchantDataKey::PendingSettlementIndex(merchant.clone(), i))
-            {
+            if let Some(payment_id) = env.storage().instance().get::<MerchantDataKey, u64>(
+                &MerchantDataKey::PendingSettlementIndex(merchant.clone(), i),
+            ) {
                 if !env
                     .storage()
                     .instance()
@@ -8992,17 +9100,27 @@ impl PaymentContract {
             return Err(Error::InvalidAmount);
         }
 
-        if env.storage().persistent().has(&DataKey::PaymentTag(payment_id)) {
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::PaymentTag(payment_id))
+        {
             return Err(Error::AlreadyProcessed);
         }
 
-        env.storage().persistent().set(&DataKey::PaymentTag(payment_id), &tags);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PaymentTag(payment_id), &tags);
 
         Ok(())
     }
 
     pub fn get_payment_tags(env: Env, payment_id: u64) -> Vec<BytesN<32>> {
-        match env.storage().persistent().get::<_, Vec<BytesN<32>>>(&DataKey::PaymentTag(payment_id)) {
+        match env
+            .storage()
+            .persistent()
+            .get::<_, Vec<BytesN<32>>>(&DataKey::PaymentTag(payment_id))
+        {
             Some(tags) => tags,
             None => Vec::new(&env),
         }
@@ -9043,7 +9161,9 @@ impl PaymentContract {
             return Err(Error::PaymentNotFound);
         }
 
-        env.storage().persistent().set(&DataKey::PaymentTag(payment_id), &new_tags);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PaymentTag(payment_id), &new_tags);
 
         Ok(())
     }
@@ -9065,7 +9185,11 @@ impl PaymentContract {
         }
 
         // Check if invoice already attached
-        if env.storage().persistent().has(&DataKey::PaymentInvoice(payment_id)) {
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::PaymentInvoice(payment_id))
+        {
             return Err(Error::AlreadyProcessed);
         }
 
@@ -9075,7 +9199,9 @@ impl PaymentContract {
             if item.quantity == 0 || item.amount < 0 {
                 return Err(Error::InvalidAmount);
             }
-            subtotal = subtotal.checked_add(item.amount).ok_or(Error::InvalidAmount)?;
+            subtotal = subtotal
+                .checked_add(item.amount)
+                .ok_or(Error::InvalidAmount)?;
         }
 
         // Verify total
@@ -9104,9 +9230,15 @@ impl PaymentContract {
             issued_at: env.ledger().timestamp(),
         };
 
-        env.storage().persistent().set(&DataKey::PaymentInvoice(payment_id), &invoice);
-        env.storage().persistent().set(&DataKey::InvoiceCounter, &invoice_id);
-        env.storage().persistent().set(&DataKey::InvoicePaymentId(invoice_id), &payment_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PaymentInvoice(payment_id), &invoice);
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvoiceCounter, &invoice_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvoicePaymentId(invoice_id), &payment_id);
 
         Ok(invoice_id)
     }
@@ -9116,11 +9248,15 @@ impl PaymentContract {
             .storage()
             .persistent()
             .get(&DataKey::InvoicePaymentId(invoice_id))?;
-        env.storage().persistent().get(&DataKey::PaymentInvoice(payment_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::PaymentInvoice(payment_id))
     }
 
     pub fn get_payment_invoice(env: Env, payment_id: u64) -> Option<PaymentInvoice> {
-        env.storage().persistent().get(&DataKey::PaymentInvoice(payment_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::PaymentInvoice(payment_id))
     }
 
     pub fn verify_invoice_total(env: Env, invoice_id: u64) -> bool {
@@ -9158,9 +9294,9 @@ mod test_cross_contract_escrow_verification;
 #[cfg(test)]
 mod test_metered_billing;
 
+mod test_fee_sweep;
 #[cfg(test)]
 mod test_split_payment;
-mod test_fee_sweep;
 
 #[cfg(test)]
 mod test_spend_limits;

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -83,7 +83,9 @@ fn test_immediate_mode_bypasses_accumulation() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &50);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &50, &10000);
 
@@ -92,8 +94,7 @@ fn test_immediate_mode_bypasses_accumulation() {
 
     // Schedule a payment and execute it
     env.ledger().set_timestamp(1000);
-    let pid = client
-        .schedule_payment(&customer, &merchant, &token, &50, &1100);
+    let pid = client.schedule_payment(&customer, &merchant, &token, &50, &1100);
     env.ledger().set_timestamp(1100);
     client.execute_scheduled_payment(&pid);
 
@@ -110,7 +111,9 @@ fn test_batch_accumulation_and_premature_trigger() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &123);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &123, &10000);
 
@@ -119,8 +122,7 @@ fn test_batch_accumulation_and_premature_trigger() {
 
     // Schedule and execute a payment — should accumulate
     env.ledger().set_timestamp(2000);
-    let pid = client
-        .schedule_payment(&customer, &merchant, &token, &123, &2010);
+    let pid = client.schedule_payment(&customer, &merchant, &token, &123, &2010);
     env.ledger().set_timestamp(2010);
     client.execute_scheduled_payment(&pid);
 
@@ -140,7 +142,9 @@ fn test_trigger_advances_period_and_resets_accumulated() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &500);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &500, &10000);
 
@@ -148,8 +152,7 @@ fn test_trigger_advances_period_and_resets_accumulated() {
 
     // Accumulate some funds
     env.ledger().set_timestamp(3000);
-    let pid = client
-        .schedule_payment(&customer, &merchant, &token, &500, &3010);
+    let pid = client.schedule_payment(&customer, &merchant, &token, &500, &3010);
     env.ledger().set_timestamp(3010);
     client.execute_scheduled_payment(&pid);
 
@@ -691,7 +694,9 @@ fn test_loyalty_points_accrue_on_payment_completion() {
     );
     client.complete_payment(&admin, &payment_id);
 
-    let balance = client.get_loyalty_balance(&customer).expect("balance exists");
+    let balance = client
+        .get_loyalty_balance(&customer)
+        .expect("balance exists");
     assert_eq!(balance.points, 100);
     assert_eq!(balance.customer, customer);
 }
@@ -2141,7 +2146,9 @@ fn test_expire_pending_payment_success() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     let amount = 1000_i128;
     let expiration_duration = 10_u64;
 
@@ -2348,7 +2355,9 @@ fn test_payment_expired_event_emitted() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     let amount = 1000_i128;
     let expiration_duration = 10_u64;
 
@@ -2385,7 +2394,9 @@ fn test_multiple_payments_different_expiration_times() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     let amount = 1000_i128;
 
     env.mock_all_auths();
@@ -3618,7 +3629,10 @@ fn test_merchant_rate_limit_enforcement() {
         &meta,
     );
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::MerchantRateLimitExceeded);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::MerchantRateLimitExceeded
+    );
 }
 
 #[test]
@@ -3938,7 +3952,12 @@ fn test_dunning_successful_retry_fires_dunning_resolved() {
     // Fund the customer so the retry succeeds
     let asset_client = token::StellarAssetClient::new(&env, &token_address);
     asset_client.mint(&customer, &100_000i128);
-    token::Client::new(&env, &token_address).approve(&customer, &contract_id, &100_000i128, &10_000);
+    token::Client::new(&env, &token_address).approve(
+        &customer,
+        &contract_id,
+        &100_000i128,
+        &10_000,
+    );
 
     env.ledger().set_timestamp(dunning.next_retry_at + 1);
     client.execute_recurring_payment(&sub_id);
@@ -4826,7 +4845,9 @@ fn test_create_payment_batch_optimized_same_token_grouping() {
     let customer1 = Address::generate(&env);
     let customer2 = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     let sa = token::StellarAssetClient::new(&env, &token);
     let tc = token::Client::new(&env, &token);
     env.mock_all_auths();
@@ -4882,8 +4903,12 @@ fn test_create_payment_batch_optimized_cross_token_isolation() {
     let customer = Address::generate(&env);
     let merchant1 = Address::generate(&env);
     let merchant2 = Address::generate(&env);
-    let token1 = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
-    let token2 = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token1 = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let token2 = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     env.mock_all_auths();
 
     client.initialize(&admin);
@@ -6057,7 +6082,9 @@ fn test_complete_conditional_payment_success() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &1000);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &1000, &10000);
 
@@ -6271,7 +6298,8 @@ fn test_grant_fee_waiver() {
     // Check event immediately — each invocation resets events
     let events = env.events().all();
     assert!(events.iter().any(|e| {
-        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "fee_waiver_granted"))
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok()
+            == Some(Symbol::new(&env, "fee_waiver_granted"))
     }));
 
     // Verify waiver was granted
@@ -6365,7 +6393,8 @@ fn test_revoke_fee_waiver() {
     // Check event immediately — each invocation resets events
     let events = env.events().all();
     assert!(events.iter().any(|e| {
-        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "fee_waiver_revoked"))
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok()
+            == Some(Symbol::new(&env, "fee_waiver_revoked"))
     }));
 
     // Verify waiver was revoked
@@ -6425,7 +6454,8 @@ fn test_expired_waiver_ignored() {
     // Verify expiration event was published
     let events = env.events().all();
     assert!(events.iter().any(|e| {
-        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "fee_waiver_expired"))
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok()
+            == Some(Symbol::new(&env, "fee_waiver_expired"))
     }));
 }
 
@@ -6523,14 +6553,17 @@ fn test_calculate_fee_respects_min_fee_with_waiver() {
     let (client, admin, _) = setup_fee_waiver_contract(&env);
 
     // Override fee config with min_fee=100 for this test
-    client.set_fee_config(&admin, &FeeConfig {
-        fee_bps: 200,
-        min_fee: 100,
-        max_fee: 10000,
-        treasury: Address::generate(&env),
-        fee_token: Address::generate(&env),
-        active: true,
-    });
+    client.set_fee_config(
+        &admin,
+        &FeeConfig {
+            fee_bps: 200,
+            min_fee: 100,
+            max_fee: 10000,
+            treasury: Address::generate(&env),
+            fee_token: Address::generate(&env),
+            active: true,
+        },
+    );
 
     let merchant = Address::generate(&env);
     let reason = String::from_str(&env, "99% waiver");
@@ -6575,14 +6608,16 @@ fn test_fee_waiver_events() {
     client.grant_fee_waiver(&admin, &merchant, &5000, &1000000000, &reason);
     let events_grant = env.events().all();
     assert!(events_grant.iter().any(|e| {
-        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "fee_waiver_granted"))
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok()
+            == Some(Symbol::new(&env, "fee_waiver_granted"))
     }));
 
     // Revoke waiver — check event immediately
     client.revoke_fee_waiver(&admin, &merchant);
     let events_revoke = env.events().all();
     assert!(events_revoke.iter().any(|e| {
-        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "fee_waiver_revoked"))
+        Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok()
+            == Some(Symbol::new(&env, "fee_waiver_revoked"))
     }));
 }
 
@@ -6643,7 +6678,9 @@ fn test_small_payment_completes_normally() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &500);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &500, &10000);
     let meta = String::from_str(&env, "");
@@ -6677,7 +6714,9 @@ fn test_threshold_zero_disables_multisig() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &5000);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &5000, &10000);
     let meta = String::from_str(&env, "");
@@ -6711,7 +6750,9 @@ fn test_large_payment_approval_flow() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &2000);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &2000, &10000);
     let meta = String::from_str(&env, "");
@@ -6963,14 +7004,21 @@ fn test_large_payment_events() {
 
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &2000);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &2000, &10000);
     let meta = String::from_str(&env, "");
 
     // Set threshold to 1000 — check event immediately
     client.set_large_payment_threshold(&admin, &1000);
-    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "large_payment_threshold_updated"))));
+    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(
+        &env,
+        &e.1.get(0).unwrap_or_default()
+    )
+    .ok()
+        == Some(Symbol::new(&env, "large_payment_threshold_updated"))));
 
     // Create a large payment
     let payment_id = client.create_payment(
@@ -6985,15 +7033,30 @@ fn test_large_payment_events() {
 
     // Propose large payment — check event immediately
     client.propose_large_payment(&merchant, &payment_id);
-    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "large_payment_proposed"))));
+    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(
+        &env,
+        &e.1.get(0).unwrap_or_default()
+    )
+    .ok()
+        == Some(Symbol::new(&env, "large_payment_proposed"))));
 
     // Approve with admin — check event immediately
     client.approve_large_payment(&admin, &payment_id);
-    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "large_payment_approved"))));
+    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(
+        &env,
+        &e.1.get(0).unwrap_or_default()
+    )
+    .ok()
+        == Some(Symbol::new(&env, "large_payment_approved"))));
 
     // Execute — check event immediately
     client.execute_large_payment(&payment_id);
-    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(&env, &e.1.get(0).unwrap_or_default()).ok() == Some(Symbol::new(&env, "large_payment_executed"))));
+    assert!(env.events().all().iter().any(|e| Symbol::try_from_val(
+        &env,
+        &e.1.get(0).unwrap_or_default()
+    )
+    .ok()
+        == Some(Symbol::new(&env, "large_payment_executed"))));
 }
 
 // ── AUTO-ESCROW TESTS ──────────────────────────────────────────────────────
@@ -7022,7 +7085,7 @@ fn test_set_auto_escrow_rule() {
     // Verify rule was set
     let rule = client.get_auto_escrow_rule(&merchant);
     assert!(rule.is_some());
-    
+
     let rule = rule.unwrap();
     assert_eq!(rule.merchant, merchant);
     assert_eq!(rule.escrow_bps, 1000);
@@ -7084,7 +7147,9 @@ fn test_auto_escrow_skips_below_minimum() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let sa = token::StellarAssetClient::new(&env, &token);
     sa.mint(&customer, &500);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &500, &10000);
@@ -7121,7 +7186,9 @@ fn test_auto_escrow_triggers_on_complete_payment() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &1000);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &1000, &10000);
 
@@ -7160,7 +7227,9 @@ fn test_auto_escrow_idempotency_guard() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &1000);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &1000, &10000);
 
@@ -7200,7 +7269,9 @@ fn test_auto_escrow_correct_amount_calculation() {
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &1000);
     token::Client::new(&env, &token).approve(&customer, &contract_id, &1000, &10000);
 

--- a/contracts/payment/src/test_fee_rebate.rs
+++ b/contracts/payment/src/test_fee_rebate.rs
@@ -97,7 +97,15 @@ fn test_no_accrual_below_threshold() {
     // Threshold = 5000; payment = 1000 (below threshold)
     client.configure_fee_rebate(&admin, &rebate_config(5_000, 2000, 86_400));
 
-    do_payment(&env, &client, &admin, &customer, &merchant, &token_addr, 1_000);
+    do_payment(
+        &env,
+        &client,
+        &admin,
+        &customer,
+        &merchant,
+        &token_addr,
+        1_000,
+    );
 
     let accrual = client.get_rebate_accrual(&merchant);
     // Either None or zero accrued_rebate
@@ -114,7 +122,15 @@ fn test_accrual_above_threshold() {
     client.configure_fee_rebate(&admin, &rebate_config(500, 2000, 86_400));
 
     // Payment of 1000 → fee = 10 → rebate = 20% of 10 = 2
-    do_payment(&env, &client, &admin, &customer, &merchant, &token_addr, 1_000);
+    do_payment(
+        &env,
+        &client,
+        &admin,
+        &customer,
+        &merchant,
+        &token_addr,
+        1_000,
+    );
 
     let accrual = client.get_rebate_accrual(&merchant).unwrap();
     assert!(accrual.accrued_rebate > 0);
@@ -127,7 +143,15 @@ fn test_claim_rebate() {
     let (env, client, admin, token_addr, customer, merchant) = setup();
 
     client.configure_fee_rebate(&admin, &rebate_config(500, 2000, 86_400));
-    do_payment(&env, &client, &admin, &customer, &merchant, &token_addr, 1_000);
+    do_payment(
+        &env,
+        &client,
+        &admin,
+        &customer,
+        &merchant,
+        &token_addr,
+        1_000,
+    );
 
     let accrual_before = client.get_rebate_accrual(&merchant).unwrap();
     assert!(accrual_before.accrued_rebate > 0);
@@ -146,7 +170,15 @@ fn test_double_claim_guard() {
     let (env, client, admin, token_addr, customer, merchant) = setup();
 
     client.configure_fee_rebate(&admin, &rebate_config(500, 2000, 86_400));
-    do_payment(&env, &client, &admin, &customer, &merchant, &token_addr, 1_000);
+    do_payment(
+        &env,
+        &client,
+        &admin,
+        &customer,
+        &merchant,
+        &token_addr,
+        1_000,
+    );
 
     client.claim_fee_rebate(&merchant);
 
@@ -162,7 +194,15 @@ fn test_period_reset() {
     // 10-second period
     client.configure_fee_rebate(&admin, &rebate_config(500, 2000, 10));
 
-    do_payment(&env, &client, &admin, &customer, &merchant, &token_addr, 1_000);
+    do_payment(
+        &env,
+        &client,
+        &admin,
+        &customer,
+        &merchant,
+        &token_addr,
+        1_000,
+    );
 
     let accrual_before = client.get_rebate_accrual(&merchant).unwrap();
     assert!(accrual_before.accrued_rebate > 0);
@@ -174,9 +214,22 @@ fn test_period_reset() {
     let token_sa = StellarAssetClient::new(&env, &token_addr);
     let token = TokenClient::new(&env, &token_addr);
     token_sa.mint(&customer, &1_000_000);
-    token.approve(&customer, &contract_id_from_client(&client), &1_000_000, &10_000);
+    token.approve(
+        &customer,
+        &contract_id_from_client(&client),
+        &1_000_000,
+        &10_000,
+    );
 
-    do_payment(&env, &client, &admin, &customer, &merchant, &token_addr, 1_000);
+    do_payment(
+        &env,
+        &client,
+        &admin,
+        &customer,
+        &merchant,
+        &token_addr,
+        1_000,
+    );
 
     let accrual_after = client.get_rebate_accrual(&merchant).unwrap();
     // Period was reset: period_volume should equal only the new payment

--- a/contracts/payment/src/test_fee_sweep.rs
+++ b/contracts/payment/src/test_fee_sweep.rs
@@ -13,18 +13,22 @@ fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
     client.initialize(&admin);
     let token = soroban_sdk::token::StellarAssetClient::new(
         &env,
-        &env.register_stellar_asset_contract_v2(admin.clone()).address(),
+        &env.register_stellar_asset_contract_v2(admin.clone())
+            .address(),
     );
     let token_addr = token.address.clone();
     token.mint(&contract_id, &1_000_000);
-    client.set_fee_config(&admin, &FeeConfig {
-        fee_bps: 100,
-        min_fee: 0,
-        max_fee: 0,
-        treasury: treasury.clone(),
-        fee_token: token_addr,
-        active: true,
-    });
+    client.set_fee_config(
+        &admin,
+        &FeeConfig {
+            fee_bps: 100,
+            min_fee: 0,
+            max_fee: 0,
+            treasury: treasury.clone(),
+            fee_token: token_addr,
+            active: true,
+        },
+    );
     (env, client, admin, treasury)
 }
 

--- a/contracts/payment/src/test_finality_delay.rs
+++ b/contracts/payment/src/test_finality_delay.rs
@@ -1,5 +1,8 @@
 #![cfg(test)]
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
 
 use crate::{Currency, Error, FinalityConfig, PaymentContract, PaymentContractClient};
 
@@ -9,7 +12,9 @@ fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
     let contract_id = env.register_contract(None, PaymentContract);
     let client = PaymentContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&contract_id, &10_000_000);
     client.initialize(&admin);
@@ -19,11 +24,14 @@ fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
 #[test]
 fn test_configure_finality_delay() {
     let (_, client, admin, _) = setup();
-    client.configure_finality_delay(&admin, &FinalityConfig {
-        delay_seconds: 86400,
-        min_amount_threshold: 100,
-        active: true,
-    });
+    client.configure_finality_delay(
+        &admin,
+        &FinalityConfig {
+            delay_seconds: 86400,
+            min_amount_threshold: 100,
+            active: true,
+        },
+    );
     let cfg = client.get_finality_config().unwrap();
     assert_eq!(cfg.delay_seconds, 86400);
     assert!(cfg.active);
@@ -37,11 +45,14 @@ fn test_complete_payment_creates_pending_settlement() {
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&customer, &10_000);
 
-    client.configure_finality_delay(&admin, &FinalityConfig {
-        delay_seconds: 3600,
-        min_amount_threshold: 100,
-        active: true,
-    });
+    client.configure_finality_delay(
+        &admin,
+        &FinalityConfig {
+            delay_seconds: 3600,
+            min_amount_threshold: 100,
+            active: true,
+        },
+    );
 
     let payment_id = client.create_payment(
         &customer,
@@ -67,11 +78,14 @@ fn test_finalize_before_release_at_fails() {
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&customer, &10_000);
 
-    client.configure_finality_delay(&admin, &FinalityConfig {
-        delay_seconds: 3600,
-        min_amount_threshold: 100,
-        active: true,
-    });
+    client.configure_finality_delay(
+        &admin,
+        &FinalityConfig {
+            delay_seconds: 3600,
+            min_amount_threshold: 100,
+            active: true,
+        },
+    );
 
     let payment_id = client.create_payment(
         &customer,
@@ -96,11 +110,14 @@ fn test_finalize_after_delay_succeeds() {
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&customer, &10_000);
 
-    client.configure_finality_delay(&admin, &FinalityConfig {
-        delay_seconds: 3600,
-        min_amount_threshold: 100,
-        active: true,
-    });
+    client.configure_finality_delay(
+        &admin,
+        &FinalityConfig {
+            delay_seconds: 3600,
+            min_amount_threshold: 100,
+            active: true,
+        },
+    );
 
     let payment_id = client.create_payment(
         &customer,
@@ -130,14 +147,22 @@ fn test_threshold_bypass_settles_immediately() {
     let merchant = Address::generate(&env);
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&customer, &10_000);
-    soroban_sdk::token::Client::new(&env, &token_addr).approve(&customer, &client.address, &50, &10_000);
+    soroban_sdk::token::Client::new(&env, &token_addr).approve(
+        &customer,
+        &client.address,
+        &50,
+        &10_000,
+    );
 
     // min_amount_threshold = 1000, payment = 50 → bypass
-    client.configure_finality_delay(&admin, &FinalityConfig {
-        delay_seconds: 3600,
-        min_amount_threshold: 1000,
-        active: true,
-    });
+    client.configure_finality_delay(
+        &admin,
+        &FinalityConfig {
+            delay_seconds: 3600,
+            min_amount_threshold: 1000,
+            active: true,
+        },
+    );
 
     let payment_id = client.create_payment(
         &customer,

--- a/contracts/payment/src/test_issue_113_115_119_120.rs
+++ b/contracts/payment/src/test_issue_113_115_119_120.rs
@@ -47,8 +47,7 @@ fn test_schedule_payment_flow_and_guards() {
     token_client.approve(&customer, &client.address, &1_000, &10_000);
 
     env.ledger().set_timestamp(100);
-    let payment_id = client
-        .schedule_payment(&customer, &merchant, &token_address, &1_000, &150);
+    let payment_id = client.schedule_payment(&customer, &merchant, &token_address, &1_000, &150);
     assert_eq!(token_client.balance(&customer), 4_000);
     assert_eq!(token_client.balance(&client.address), 1_000);
 
@@ -76,10 +75,8 @@ fn test_cancel_scheduled_payment_refunds_customer() {
     token_client.approve(&customer, &client.address, &1_200, &10_000);
 
     env.ledger().set_timestamp(50);
-    let payment_id = client
-        .schedule_payment(&customer, &merchant, &token_address, &1_200, &90);
-    client
-        .cancel_scheduled_payment(&customer, &payment_id);
+    let payment_id = client.schedule_payment(&customer, &merchant, &token_address, &1_200, &90);
+    client.cancel_scheduled_payment(&customer, &payment_id);
 
     let scheduled = client.get_scheduled_payment(&payment_id);
     assert!(scheduled.cancelled);
@@ -91,8 +88,7 @@ fn test_cancel_scheduled_payment_refunds_customer() {
 fn test_oracle_refresh_and_manual_fallback() {
     let (env, client, admin) = setup();
     env.ledger().set_timestamp(1_005);
-    client
-        .set_conversion_rate(&admin, &Currency::BTC, &90_0000000);
+    client.set_conversion_rate(&admin, &Currency::BTC, &90_0000000);
 
     let oracle_id = env.register(MockOracleContract, ());
     let feed = BytesN::from_array(&env, &[1; 32]);
@@ -125,10 +121,8 @@ fn test_oracle_refresh_and_manual_fallback() {
         max_staleness_seconds: 100,
         enabled: false,
     };
-    client
-        .set_conversion_rate(&admin, &Currency::USDC, &1_0000000);
-    client
-        .set_oracle_rate_config(&admin, &disabled_cfg);
+    client.set_conversion_rate(&admin, &Currency::USDC, &1_0000000);
+    client.set_oracle_rate_config(&admin, &disabled_cfg);
     let fallback = client.refresh_conversion_rate(&Currency::USDC);
     assert_eq!(fallback, 1_0000000);
 }
@@ -138,7 +132,9 @@ fn test_cross_contract_condition_success_and_failure() {
     let (env, client, admin) = setup();
     let customer = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(Address::generate(&env)).address();
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
     token::StellarAssetClient::new(&env, &token).mint(&customer, &100);
     token::Client::new(&env, &token).approve(&customer, &client.address, &100, &10_000);
     let meta = String::from_str(&env, "cond");
@@ -146,36 +142,32 @@ fn test_cross_contract_condition_success_and_failure() {
     let good_id = env.register(FreshStateContract, ());
     let good_hash = BytesN::from_array(&env, &[7; 32]);
     let condition = ConditionType::CrossContractState(good_id, good_hash);
-    let payment_id = client
-        .create_conditional_payment(
-            &customer,
-            &merchant,
-            &100,
-            &token,
-            &Currency::USDC,
-            &300,
-            &meta,
-            &condition,
-        );
-    client
-        .execute_if_condition_met(&payment_id);
-    client
-        .execute_if_condition_met(&payment_id);
+    let payment_id = client.create_conditional_payment(
+        &customer,
+        &merchant,
+        &100,
+        &token,
+        &Currency::USDC,
+        &300,
+        &meta,
+        &condition,
+    );
+    client.execute_if_condition_met(&payment_id);
+    client.execute_if_condition_met(&payment_id);
 
     let bad_target = Address::generate(&env);
     let bad_cond =
         ConditionType::CrossContractState(bad_target, BytesN::from_array(&env, &[9; 32]));
-    let payment_id2 = client
-        .create_conditional_payment(
-            &customer,
-            &merchant,
-            &50,
-            &token,
-            &Currency::USDC,
-            &300,
-            &meta,
-            &bad_cond,
-        );
+    let payment_id2 = client.create_conditional_payment(
+        &customer,
+        &merchant,
+        &50,
+        &token,
+        &Currency::USDC,
+        &300,
+        &meta,
+        &bad_cond,
+    );
     let eval = client.try_evaluate_condition(&payment_id2);
     assert_eq!(eval.err(), Some(Ok(Error::ConditionEvaluationFailed)));
 
@@ -192,32 +184,29 @@ fn test_analytics_range_and_top_merchants() {
     let meta = String::from_str(&env, "");
 
     env.ledger().set_timestamp(3_600);
-    let p1 = client
-        .create_payment(
-            &customer,
-            &merchant_a,
-            &1_000,
-            &token,
-            &Currency::USDC,
-            &0,
-            &meta,
-        );
+    let p1 = client.create_payment(
+        &customer,
+        &merchant_a,
+        &1_000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
     let _ = client.cancel_payment(&customer, &p1);
 
     env.ledger().set_timestamp(7_200);
-    let _ = client
-        .create_payment(
-            &customer,
-            &merchant_b,
-            &5_000,
-            &token,
-            &Currency::USDC,
-            &0,
-            &meta,
-        );
+    let _ = client.create_payment(
+        &customer,
+        &merchant_b,
+        &5_000,
+        &token,
+        &Currency::USDC,
+        &0,
+        &meta,
+    );
 
-    let range = client
-        .get_merchant_analytics_range(&merchant_a, &3_600, &10_800);
+    let range = client.get_merchant_analytics_range(&merchant_a, &3_600, &10_800);
     assert_eq!(range.len(), 1);
     assert_eq!(range.get(0).unwrap().total_volume, 1_000);
     assert_eq!(range.get(0).unwrap().failed_count, 1);

--- a/contracts/payment/src/test_metered_billing.rs
+++ b/contracts/payment/src/test_metered_billing.rs
@@ -1,10 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{
-    testutils::Address as _,
-    token, Address, Env, String,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
 
 fn setup(env: &Env) -> (PaymentContractClient, Address, Address, Address, Address) {
     let id = env.register(PaymentContract, ());

--- a/contracts/payment/src/test_payment_channel.rs
+++ b/contracts/payment/src/test_payment_channel.rs
@@ -18,7 +18,9 @@ fn test_close_expired_channel() {
     let admin = Address::generate(&env);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let token_client = token::Client::new(&env, &token_id);
 
@@ -32,7 +34,14 @@ fn test_close_expired_channel() {
     env.ledger().set_timestamp(expires_at - 10);
 
     let dummy_pk = BytesN::<32>::from_array(&env, &[0u8; 32]);
-    let channel_id = client.open_channel(&customer, &merchant, &token_id, &1000i128, &expires_at, &dummy_pk);
+    let channel_id = client.open_channel(
+        &customer,
+        &merchant,
+        &token_id,
+        &1000i128,
+        &expires_at,
+        &dummy_pk,
+    );
 
     // Fast forward
     env.ledger().set_timestamp(expires_at + 1);
@@ -45,7 +54,7 @@ fn test_close_expired_channel() {
 
 #[test]
 fn test_payment_channel_full_lifecycle() {
-    use ed25519_dalek::{SigningKey, Signer};
+    use ed25519_dalek::{Signer, SigningKey};
     use rand::rngs::OsRng;
 
     let env = Env::default();
@@ -58,7 +67,9 @@ fn test_payment_channel_full_lifecycle() {
     let customer = Address::generate(&env);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
 
     let contract_id = env.register(PaymentContract, ());
@@ -117,7 +128,7 @@ fn test_payment_channel_full_lifecycle() {
 
 #[test]
 fn test_settle_channel_invalid_nonce() {
-    use ed25519_dalek::{SigningKey, Signer};
+    use ed25519_dalek::{Signer, SigningKey};
     use rand::rngs::OsRng;
 
     let env = Env::default();
@@ -128,7 +139,9 @@ fn test_settle_channel_invalid_nonce() {
     let customer = Address::generate(&env);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
 
     let contract_id = env.register(PaymentContract, ());

--- a/contracts/payment/src/test_payment_forward.rs
+++ b/contracts/payment/src/test_payment_forward.rs
@@ -1,12 +1,19 @@
 #![cfg(test)]
 mod tests {
     use crate::{
-        PaymentContract, Error, Currency, PaymentStatus, FeeConfig,
-        PaymentContractClient,
+        Currency, Error, FeeConfig, PaymentContract, PaymentContractClient, PaymentStatus,
     };
     use soroban_sdk::{testutils::Address as AddressTestUtils, token, Address, Env, String};
 
-    fn setup_env() -> (Env, PaymentContractClient<'static>, Address, Address, Address, Address, Address) {
+    fn setup_env() -> (
+        Env,
+        PaymentContractClient<'static>,
+        Address,
+        Address,
+        Address,
+        Address,
+        Address,
+    ) {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();
 
@@ -21,7 +28,9 @@ mod tests {
         client.initialize(&admin);
 
         let token_admin = Address::generate(&env);
-        let token = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
 
         let fee_config = FeeConfig {
             fee_bps: 100,
@@ -95,10 +104,12 @@ mod tests {
     fn test_set_payment_forward_loop_detection() {
         let (env, client, _admin, _customer, merchant, forward_to, _token) = setup_env();
 
-        // Set up a forward config for forward_to (pointing elsewhere)
-        client.set_payment_forward(&forward_to, &Address::generate(&env), &5000);
+        // Build a 3-hop chain that closes back to merchant: forward_to (B) → C → merchant (A)
+        let c = Address::generate(&env);
+        client.set_payment_forward(&c, &merchant, &5000); // C → A
+        client.set_payment_forward(&forward_to, &c, &5000); // B → C
 
-        // Try to set merchant to forward to forward_to (which already has a forward)
+        // merchant (A) → forward_to (B) → C → merchant (A) is a cycle
         let result = client.try_set_payment_forward(&merchant, &forward_to, &5000);
         assert_eq!(result, Err(Ok(Error::ForwardLoop)));
     }
@@ -151,7 +162,8 @@ mod tests {
 
         client.set_payment_forward(&merchant, &forward_to, &5000);
 
-        let payment_id = create_and_complete_payment(&env, &client, &admin, &customer, &merchant, 1_000, &token);
+        let payment_id =
+            create_and_complete_payment(&env, &client, &admin, &customer, &merchant, 1_000, &token);
 
         let payment = client.get_payment(&payment_id);
         assert_eq!(payment.status, PaymentStatus::Completed);
@@ -163,7 +175,9 @@ mod tests {
 
         client.set_payment_forward(&merchant, &forward_to, &2500);
 
-        let payment_id = create_and_complete_payment(&env, &client, &admin, &customer, &merchant, 1_000_000, &token);
+        let payment_id = create_and_complete_payment(
+            &env, &client, &admin, &customer, &merchant, 1_000_000, &token,
+        );
 
         let payment = client.get_payment(&payment_id);
         assert_eq!(payment.status, PaymentStatus::Completed);

--- a/contracts/payment/src/test_spend_limits.rs
+++ b/contracts/payment/src/test_spend_limits.rs
@@ -1,5 +1,8 @@
 #![cfg(test)]
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
 
 use crate::{Currency, Error, PaymentContract, PaymentContractClient};
 
@@ -66,7 +69,9 @@ fn test_spend_limit_enforced_on_create_payment() {
     let merchant = Address::generate(&env);
 
     // Register a token
-    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&customer, &10_000);
 

--- a/contracts/payment/src/test_split_payment.rs
+++ b/contracts/payment/src/test_split_payment.rs
@@ -33,8 +33,14 @@ fn test_valid_split_payment() {
 
     fund(&env, &token, &admin, &customer, 1000);
 
-    let r1 = SplitRecipient { address: merchant.clone(), share_bps: 7000 };
-    let r2 = SplitRecipient { address: admin.clone(), share_bps: 3000 };
+    let r1 = SplitRecipient {
+        address: merchant.clone(),
+        share_bps: 7000,
+    };
+    let r2 = SplitRecipient {
+        address: admin.clone(),
+        share_bps: 3000,
+    };
     let mut recipients = Vec::new(&env);
     recipients.push_back(r1);
     recipients.push_back(r2);
@@ -68,8 +74,14 @@ fn test_invalid_split_shares() {
     fund(&env, &token, &admin, &customer, 1000);
 
     let mut recipients = Vec::new(&env);
-    recipients.push_back(SplitRecipient { address: merchant.clone(), share_bps: 5000 });
-    recipients.push_back(SplitRecipient { address: admin.clone(), share_bps: 4000 }); // total = 9000, not 10000
+    recipients.push_back(SplitRecipient {
+        address: merchant.clone(),
+        share_bps: 5000,
+    });
+    recipients.push_back(SplitRecipient {
+        address: admin.clone(),
+        share_bps: 4000,
+    }); // total = 9000, not 10000
 
     let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
     assert_eq!(result, Err(Ok(Error::InvalidSplitShares)));
@@ -110,7 +122,10 @@ fn test_double_execution_rejected() {
     fund(&env, &token, &admin, &customer, 1000);
 
     let mut recipients = Vec::new(&env);
-    recipients.push_back(SplitRecipient { address: merchant.clone(), share_bps: 10000 });
+    recipients.push_back(SplitRecipient {
+        address: merchant.clone(),
+        share_bps: 10000,
+    });
 
     let payment_id = client.create_split_payment(&customer, &merchant, &1000, &token, &recipients);
 

--- a/contracts/payment/src/test_subscription_groups.rs
+++ b/contracts/payment/src/test_subscription_groups.rs
@@ -52,7 +52,9 @@ fn test_add_and_remove_from_group() {
     let (env, client, admin) = setup();
     let owner = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&owner, &100_000);
 
@@ -73,7 +75,9 @@ fn test_subscription_already_in_group() {
     let (env, client, admin) = setup();
     let owner = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&owner, &100_000);
 
@@ -90,7 +94,9 @@ fn test_group_size_limit() {
     let (env, client, admin) = setup();
     let owner = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&owner, &10_000_000);
 
@@ -120,7 +126,9 @@ fn test_get_group_next_billing() {
     let (env, client, admin) = setup();
     let owner = Address::generate(&env);
     let merchant = Address::generate(&env);
-    let token_addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     let token = soroban_sdk::token::StellarAssetClient::new(&env, &token_addr);
     token.mint(&owner, &100_000);
 

--- a/contracts/payment/src/test_trial.rs
+++ b/contracts/payment/src/test_trial.rs
@@ -89,7 +89,12 @@ fn test_first_post_trial_payment_sets_converted() {
     let token_address = token_contract.address();
     let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
     asset_client.mint(&customer, &100_000i128);
-    soroban_sdk::token::Client::new(&env, &token_address).approve(&customer, &contract_id, &100_000i128, &10_000);
+    soroban_sdk::token::Client::new(&env, &token_address).approve(
+        &customer,
+        &contract_id,
+        &100_000i128,
+        &10_000,
+    );
 
     let trial_secs = 3600u64;
     let interval = 1800u64;

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -18,7 +18,12 @@ std::thread_local! {
 // to avoid LengthExceedsMax error from large #[contracttype] enums
 pub type StorageKey = (Symbol, Option<Address>, Option<u64>, Option<u32>);
 
-pub fn make_key(prefix: &str, addr: Option<Address>, id: Option<u64>, sub_id: Option<u32>) -> StorageKey {
+pub fn make_key(
+    prefix: &str,
+    addr: Option<Address>,
+    id: Option<u64>,
+    sub_id: Option<u32>,
+) -> StorageKey {
     (Symbol::new(&Env::default(), prefix), addr, id, sub_id)
 }
 
@@ -834,20 +839,20 @@ pub struct GlobalRefundRateLimit {
 #[derive(Clone)]
 #[contracttype]
 pub struct RefundFeeConfig {
-    pub fee_bps: u32,           // Fee in basis points (e.g., 100 = 1%)
-    pub min_fee: i128,          // Minimum fee amount
-    pub max_fee: i128,          // Maximum fee amount
-    pub treasury: Address,      // Address to receive fees
-    pub fee_token: Address,     // Token in which fees are collected
-    pub active: bool,           // Whether fee collection is enabled
+    pub fee_bps: u32,       // Fee in basis points (e.g., 100 = 1%)
+    pub min_fee: i128,      // Minimum fee amount
+    pub max_fee: i128,      // Maximum fee amount
+    pub treasury: Address,  // Address to receive fees
+    pub fee_token: Address, // Token in which fees are collected
+    pub active: bool,       // Whether fee collection is enabled
 }
 
 /// Per-customer refund cooldown configuration
 #[derive(Clone)]
 #[contracttype]
 pub struct RefundCooldownConfig {
-    pub cooldown_seconds: u64,  // Minimum time between refund requests per customer
-    pub enabled: bool,          // Whether cooldown is enforced
+    pub cooldown_seconds: u64, // Minimum time between refund requests per customer
+    pub enabled: bool,         // Whether cooldown is enforced
 }
 
 /// Tracks the last refund request time for a customer
@@ -1192,7 +1197,9 @@ impl RefundContract {
             updated_at: env.ledger().timestamp(),
             default_window_seconds: 30 * 24 * 60 * 60, // 30 days
         };
-        env.storage().instance().set(&DataKey::DefaultRefundPolicy, &default_policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::DefaultRefundPolicy, &default_policy);
 
         // Store default settings for admin separately
         Self::set_inherit_from_parent_inner(&env, &admin, false);
@@ -1210,7 +1217,7 @@ impl RefundContract {
         token: Address,
         reason: String,
         reason_code: RefundReasonCode,
-        payment_created_at: u64
+        payment_created_at: u64,
     ) -> Result<u64, Error> {
         // Require merchant authentication
         merchant.require_auth();
@@ -1249,7 +1256,10 @@ impl RefundContract {
 
     pub fn get_refund(env: &Env, refund_id: u64) -> Result<Refund, Error> {
         // Retrieve refund from storage by ID
-        env.storage().instance().get(&DataKey::Refund(refund_id)).ok_or(Error::RefundNotFound)
+        env.storage()
+            .instance()
+            .get(&DataKey::Refund(refund_id))
+            .ok_or(Error::RefundNotFound)
     }
 
     pub fn approve_refund(env: Env, admin: Address, refund_id: u64) -> Result<(), Error> {
@@ -1263,7 +1273,7 @@ impl RefundContract {
         env: Env,
         admin: Address,
         refund_id: u64,
-        rejection_reason: String
+        rejection_reason: String,
     ) -> Result<(), Error> {
         // Require admin authentication
         admin.require_auth();
@@ -1288,9 +1298,14 @@ impl RefundContract {
         refund.rejected_at = Some(env.ledger().timestamp());
 
         // Store updated refund back to storage
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(&env, RefundStatus::Rejected, refund_id);
-        env.storage().instance().set(&SystemKey::RefundRejectedAt(refund_id), &env.ledger().timestamp());
+        env.storage().instance().set(
+            &SystemKey::RefundRejectedAt(refund_id),
+            &env.ledger().timestamp(),
+        );
 
         // Emit RefundRejected event
         (RefundRejected {
@@ -1298,7 +1313,8 @@ impl RefundContract {
             rejected_by: admin,
             rejected_at: env.ledger().timestamp(),
             rejection_reason,
-        }).publish(&env);
+        })
+        .publish(&env);
 
         // Issue #144: Invoke notification hooks
         Self::invoke_hooks(&env, RefundEventType::Rejected, refund_id);
@@ -1326,7 +1342,11 @@ impl RefundContract {
         if refund.status != RefundStatus::Rejected {
             return Err(Error::RefundNotRejected);
         }
-        if env.storage().instance().has(&SystemKey::AppealByRefund(refund_id)) {
+        if env
+            .storage()
+            .instance()
+            .has(&SystemKey::AppealByRefund(refund_id))
+        {
             return Err(Error::AppealAlreadyFiled);
         }
 
@@ -1340,7 +1360,11 @@ impl RefundContract {
             return Err(Error::AppealWindowExpired);
         }
 
-        let counter: u64 = env.storage().instance().get(&SystemKey::AppealCounter).unwrap_or(0);
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&SystemKey::AppealCounter)
+            .unwrap_or(0);
         let appeal_id = counter + 1;
         let appeal = RefundAppeal {
             appeal_id,
@@ -1351,9 +1375,15 @@ impl RefundContract {
             resolved: false,
             outcome: None,
         };
-        env.storage().instance().set(&SystemKey::Appeal(appeal_id), &appeal);
-        env.storage().instance().set(&SystemKey::AppealCounter, &appeal_id);
-        env.storage().instance().set(&SystemKey::AppealByRefund(refund_id), &appeal_id);
+        env.storage()
+            .instance()
+            .set(&SystemKey::Appeal(appeal_id), &appeal);
+        env.storage()
+            .instance()
+            .set(&SystemKey::AppealCounter, &appeal_id);
+        env.storage()
+            .instance()
+            .set(&SystemKey::AppealByRefund(refund_id), &appeal_id);
 
         let customer_count: u64 = env
             .storage()
@@ -1417,7 +1447,9 @@ impl RefundContract {
 
             Self::remove_from_status_index(&env, RefundStatus::Rejected, refund.id)?;
             refund.status = RefundStatus::Approved;
-            env.storage().instance().set(&DataKey::Refund(refund.id), &refund);
+            env.storage()
+                .instance()
+                .set(&DataKey::Refund(refund.id), &refund);
             Self::add_to_status_index(&env, RefundStatus::Approved, refund.id);
 
             Self::process_refund_internal(&env, admin.clone(), refund.id)?;
@@ -1425,7 +1457,9 @@ impl RefundContract {
 
         appeal.resolved = true;
         appeal.outcome = Some(uphold);
-        env.storage().instance().set(&SystemKey::Appeal(appeal_id), &appeal);
+        env.storage()
+            .instance()
+            .set(&SystemKey::Appeal(appeal_id), &appeal);
 
         (AppealResolved {
             appeal_id,
@@ -1671,11 +1705,14 @@ impl RefundContract {
         admin: Address,
         customer: Address,
         max_per_window: u32,
-        window_seconds: u64
+        window_seconds: u64,
     ) -> Result<(), Error> {
         admin.require_auth();
-        
-        let mut limit = env.storage().instance().get(&DataKey::CustomerRefundRateLimit(customer.clone()))
+
+        let mut limit = env
+            .storage()
+            .instance()
+            .get(&DataKey::CustomerRefundRateLimit(customer.clone()))
             .unwrap_or(CustomerRefundRateLimit {
                 customer: customer.clone(),
                 window_start: env.ledger().timestamp(),
@@ -1683,16 +1720,20 @@ impl RefundContract {
                 max_requests_per_window: max_per_window,
                 window_seconds,
             });
-            
+
         limit.max_requests_per_window = max_per_window;
         limit.window_seconds = window_seconds;
-        
-        env.storage().instance().set(&DataKey::CustomerRefundRateLimit(customer), &limit);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::CustomerRefundRateLimit(customer), &limit);
         Ok(())
     }
 
     pub fn get_customer_rate_limit_status(env: Env, customer: Address) -> CustomerRefundRateLimit {
-        env.storage().instance().get(&DataKey::CustomerRefundRateLimit(customer.clone()))
+        env.storage()
+            .instance()
+            .get(&DataKey::CustomerRefundRateLimit(customer.clone()))
             .unwrap_or(CustomerRefundRateLimit {
                 customer,
                 window_start: 0,
@@ -1706,16 +1747,18 @@ impl RefundContract {
         env: Env,
         admin: Address,
         max_per_window: u32,
-        window_seconds: u64
+        window_seconds: u64,
     ) -> Result<(), Error> {
         admin.require_auth();
-        
+
         let limit = GlobalRefundRateLimit {
             max_requests_per_window: max_per_window,
             window_seconds,
         };
-        
-        env.storage().instance().set(&DataKey::GlobalRefundRateLimit, &limit);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::GlobalRefundRateLimit, &limit);
         Ok(())
     }
 
@@ -1752,9 +1795,10 @@ impl RefundContract {
             score: 100, // Starting score
             last_active: env.ledger().timestamp(),
         };
-        env.storage()
-            .instance()
-            .set(&ArbitrationKey::ArbitratorReputation(arbitrator), &reputation);
+        env.storage().instance().set(
+            &ArbitrationKey::ArbitratorReputation(arbitrator),
+            &reputation,
+        );
 
         Ok(())
     }
@@ -1810,7 +1854,11 @@ impl RefundContract {
 
                 // Transfer stake from caller to contract
                 let stake_token_client = token::Client::new(&env, &config.token);
-                stake_token_client.transfer(&caller, &env.current_contract_address(), &config.amount);
+                stake_token_client.transfer(
+                    &caller,
+                    &env.current_contract_address(),
+                    &config.amount,
+                );
 
                 // Record the stake
                 let stake = ArbitrationStake {
@@ -1926,9 +1974,10 @@ impl RefundContract {
             reasoning_hash,
             voted_at: env.ledger().timestamp(),
         };
-        env.storage()
-            .instance()
-            .set(&ArbitrationKey::ArbitratorVote(case_id, arbitrator.clone()), &vote);
+        env.storage().instance().set(
+            &ArbitrationKey::ArbitratorVote(case_id, arbitrator.clone()),
+            &vote,
+        );
 
         let mut voted: Vec<Address> = env
             .storage()
@@ -1998,14 +2047,14 @@ impl RefundContract {
 
         // Distribute fees according to configuration
         let num_voters = total_votes as i128;
-        
+
         // Get all arbitrators who voted (needed for both fee distribution and reputation updates)
         let all_voters: Vec<Address> = env
             .storage()
             .instance()
             .get(&ArbitrationKey::ArbitratorsVoted(case_id))
             .unwrap_or_else(|| Vec::new(&env));
-        
+
         if num_voters > 0 {
             let pool_token: Address = env
                 .storage()
@@ -2020,11 +2069,18 @@ impl RefundContract {
                 .instance()
                 .get(&ArbitrationKey::ArbitrationFeeConfig);
 
-            let (arbitrator_share, treasury_share, treasury_address) = if let Some(ref config) = fee_config {
+            let (arbitrator_share, treasury_share, treasury_address) = if let Some(ref config) =
+                fee_config
+            {
                 // Calculate shares based on basis points
-                let arbitrator_amount = (case.fee_pool * config.arbitrator_share_bps as i128) / 10000;
+                let arbitrator_amount =
+                    (case.fee_pool * config.arbitrator_share_bps as i128) / 10000;
                 let treasury_amount = (case.fee_pool * config.treasury_share_bps as i128) / 10000;
-                (arbitrator_amount, treasury_amount, Some(config.treasury_address.clone()))
+                (
+                    arbitrator_amount,
+                    treasury_amount,
+                    Some(config.treasury_address.clone()),
+                )
             } else {
                 // Default: 100% to arbitrators, 0% to treasury
                 (case.fee_pool, 0, None)
@@ -2038,7 +2094,7 @@ impl RefundContract {
                     .instance()
                     .get(&ArbitrationKey::ArbitratorVote(case_id, voter.clone()))
                     .unwrap();
-                
+
                 // Check if this voter was in the majority
                 let in_majority = if approved {
                     vote.voted_for_refund
@@ -2077,9 +2133,10 @@ impl RefundContract {
                         .instance()
                         .get(&ArbitrationKey::AccumulatedTreasuryFees)
                         .unwrap_or(0);
-                    env.storage()
-                        .instance()
-                        .set(&ArbitrationKey::AccumulatedTreasuryFees, &(accumulated + treasury_share));
+                    env.storage().instance().set(
+                        &ArbitrationKey::AccumulatedTreasuryFees,
+                        &(accumulated + treasury_share),
+                    );
                 }
             }
 
@@ -2224,16 +2281,18 @@ impl RefundContract {
             } else {
                 // Calculate weighted average
                 let total_time = reputation.avg_resolution_time * (reputation.total_cases - 1);
-                reputation.avg_resolution_time = (total_time + case_duration) / reputation.total_cases;
+                reputation.avg_resolution_time =
+                    (total_time + case_duration) / reputation.total_cases;
             }
 
             // Update last active timestamp
             reputation.last_active = current_time;
 
             // Store updated reputation
-            env.storage()
-                .instance()
-                .set(&ArbitrationKey::ArbitratorReputation(voter.clone()), &reputation);
+            env.storage().instance().set(
+                &ArbitrationKey::ArbitratorReputation(voter.clone()),
+                &reputation,
+            );
 
             // Emit score update event
             ArbitratorScoreUpdated {
@@ -2249,13 +2308,23 @@ impl RefundContract {
         Ok(())
     }
 
-    pub fn set_arbitration_timeout(env: Env, admin: Address, timeout_seconds: u64) -> Result<(), Error> {
+    pub fn set_arbitration_timeout(
+        env: Env,
+        admin: Address,
+        timeout_seconds: u64,
+    ) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::Unauthorized)?;
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
-        env.storage().instance().set(&ArbitrationKey::ArbitrationTimeoutConfig, &timeout_seconds);
+        env.storage()
+            .instance()
+            .set(&ArbitrationKey::ArbitrationTimeoutConfig, &timeout_seconds);
         Ok(())
     }
 
@@ -2289,7 +2358,9 @@ impl RefundContract {
 
         let approved = case.default_favor_customer;
         case.status = ArbitrationStatus::Decided;
-        env.storage().instance().set(&ArbitrationKey::ArbitrationCase(case_id), &case);
+        env.storage()
+            .instance()
+            .set(&ArbitrationKey::ArbitrationCase(case_id), &case);
 
         if approved {
             let mut refund: Refund = env
@@ -2298,7 +2369,9 @@ impl RefundContract {
                 .get(&DataKey::Refund(case.refund_id))
                 .unwrap();
             refund.status = RefundStatus::Approved;
-            env.storage().instance().set(&DataKey::Refund(case.refund_id), &refund);
+            env.storage()
+                .instance()
+                .set(&DataKey::Refund(case.refund_id), &refund);
         }
 
         ArbitrationTimedOut {
@@ -2319,7 +2392,9 @@ impl RefundContract {
         policy: RefundPolicy,
         created_by: Address,
     ) {
-        env.storage().instance().set(&DataKey::RefundPolicy(merchant.clone()), &policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicy(merchant.clone()), &policy);
 
         let version_count: u32 = env
             .storage()
@@ -2346,7 +2421,8 @@ impl RefundContract {
         (RefundPolicySet {
             merchant,
             tiers_count: policy.tiers.len() as u32,
-        }).publish(env);
+        })
+        .publish(env);
     }
 
     pub fn create_policy_template(
@@ -2452,10 +2528,7 @@ impl RefundContract {
         Ok(())
     }
 
-    pub fn get_policy_template(
-        env: Env,
-        template_id: u64,
-    ) -> Option<RefundPolicyTemplate> {
+    pub fn get_policy_template(env: Env, template_id: u64) -> Option<RefundPolicyTemplate> {
         env.storage()
             .instance()
             .get(&DataKey::RefundPolicyTemplate(template_id))
@@ -2522,7 +2595,10 @@ impl RefundContract {
     }
 
     /// Get the reputation information for a specific arbitrator
-    pub fn get_arbitrator_reputation(env: Env, arbitrator: Address) -> Option<ArbitratorReputation> {
+    pub fn get_arbitrator_reputation(
+        env: Env,
+        arbitrator: Address,
+    ) -> Option<ArbitratorReputation> {
         env.storage()
             .instance()
             .get(&ArbitrationKey::ArbitratorReputation(arbitrator))
@@ -2532,7 +2608,7 @@ impl RefundContract {
     /// Returns up to `limit` arbitrators
     pub fn get_top_arbitrators(env: Env, limit: u32) -> Vec<ArbitratorReputation> {
         let mut results = Vec::new(&env);
-        
+
         // Get all arbitrators from the arbitrator list
         let arbitrators: Vec<Address> = env
             .storage()
@@ -2550,7 +2626,9 @@ impl RefundContract {
             if let Some(reputation) = env
                 .storage()
                 .instance()
-                .get::<ArbitrationKey, ArbitratorReputation>(&ArbitrationKey::ArbitratorReputation(arbitrator.clone()))
+                .get::<ArbitrationKey, ArbitratorReputation>(&ArbitrationKey::ArbitratorReputation(
+                    arbitrator.clone(),
+                ))
             {
                 reputations.push_back(reputation);
             }
@@ -2563,7 +2641,7 @@ impl RefundContract {
             for j in 0..(len - i - 1) {
                 let rep_j = reputations.get(j).unwrap();
                 let rep_j_plus_1 = reputations.get(j + 1).unwrap();
-                
+
                 if rep_j.score < rep_j_plus_1.score {
                     // Swap
                     let temp = rep_j_plus_1.clone();
@@ -2708,14 +2786,11 @@ impl RefundContract {
         amount: i128,
         token: &Address,
     ) -> Result<(i128, i128), Error> {
-        let config: RefundFeeConfig = match env
-            .storage()
-            .instance()
-            .get(&SystemKey::RefundFeeConfig)
-        {
-            Some(c) => c,
-            None => return Ok((amount, 0)),
-        };
+        let config: RefundFeeConfig =
+            match env.storage().instance().get(&SystemKey::RefundFeeConfig) {
+                Some(c) => c,
+                None => return Ok((amount, 0)),
+            };
         if !config.active {
             return Ok((amount, 0));
         }
@@ -2736,9 +2811,10 @@ impl RefundContract {
                 .instance()
                 .get(&SystemKey::AccumulatedRefundFees)
                 .unwrap_or(0);
-            env.storage()
-                .instance()
-                .set(&SystemKey::AccumulatedRefundFees, &accumulated.saturating_add(fee));
+            env.storage().instance().set(
+                &SystemKey::AccumulatedRefundFees,
+                &accumulated.saturating_add(fee),
+            );
             (RefundFeeDeducted {
                 refund_id,
                 fee_amount: fee,
@@ -2820,7 +2896,7 @@ impl RefundContract {
         env: &Env,
         status: RefundStatus,
         limit: u64,
-        offset: u64
+        offset: u64,
     ) -> Vec<Refund> {
         let mut results: Vec<Refund> = Vec::new(env);
         let total = Self::get_refund_count_by_status(env, status.clone());
@@ -2832,17 +2908,15 @@ impl RefundContract {
         let end = core::cmp::min(total, offset.saturating_add(limit));
         let mut index = offset;
         while index < end {
-            if
-                let Some(refund_id) = env
+            if let Some(refund_id) = env
+                .storage()
+                .instance()
+                .get::<_, u64>(&DataKey::RefundsByStatus(status.clone(), index))
+            {
+                if let Some(refund) = env
                     .storage()
                     .instance()
-                    .get::<_, u64>(&DataKey::RefundsByStatus(status.clone(), index))
-            {
-                if
-                    let Some(refund) = env
-                        .storage()
-                        .instance()
-                        .get::<_, Refund>(&DataKey::Refund(refund_id))
+                    .get::<_, Refund>(&DataKey::Refund(refund_id))
                 {
                     results.push_back(refund);
                 }
@@ -2853,7 +2927,12 @@ impl RefundContract {
         results
     }
 
-    pub fn get_merchant_refunds(env: Env, merchant: Address, limit: u64, offset: u64) -> Vec<Refund> {
+    pub fn get_merchant_refunds(
+        env: Env,
+        merchant: Address,
+        limit: u64,
+        offset: u64,
+    ) -> Vec<Refund> {
         let mut results: Vec<Refund> = Vec::new(&env);
         let total = Self::get_merchant_refund_count(&env, &merchant);
 
@@ -2864,13 +2943,16 @@ impl RefundContract {
         let end = core::cmp::min(total, offset.saturating_add(limit));
         let mut index = offset;
         while index < end {
-            if
-                let Some(refund_id) = env
+            if let Some(refund_id) = env
+                .storage()
+                .instance()
+                .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
+            {
+                if let Some(refund) = env
                     .storage()
                     .instance()
-                    .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
-            {
-                if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(refund_id)) {
+                    .get::<_, Refund>(&DataKey::Refund(refund_id))
+                {
                     results.push_back(refund);
                 }
             }
@@ -2885,7 +2967,7 @@ impl RefundContract {
         merchant: Address,
         status: RefundStatus,
         limit: u64,
-        offset: u64
+        offset: u64,
     ) -> Vec<Refund> {
         Self::get_merchant_refunds_by_status_internal(&env, &merchant, status, limit, offset)
     }
@@ -2911,13 +2993,16 @@ impl RefundContract {
 
         let mut index = 0u64;
         while index < total_requests {
-            if
-                let Some(refund_id) = env
+            if let Some(refund_id) = env
+                .storage()
+                .instance()
+                .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
+            {
+                if let Some(refund) = env
                     .storage()
                     .instance()
-                    .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
-            {
-                if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(refund_id)) {
+                    .get::<_, Refund>(&DataKey::Refund(refund_id))
+                {
                     match refund.status {
                         RefundStatus::Approved => {
                             total_approved += 1;
@@ -2952,7 +3037,7 @@ impl RefundContract {
         env: &Env,
         code: RefundReasonCode,
         limit: u64,
-        offset: u64
+        offset: u64,
     ) -> Vec<Refund> {
         let mut results: Vec<Refund> = Vec::new(env);
         if limit == 0 {
@@ -2969,7 +3054,11 @@ impl RefundContract {
         let mut collected: u64 = 0;
         let mut id: u64 = 1;
         while id <= total_refunds && collected < limit {
-            if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(id)) {
+            if let Some(refund) = env
+                .storage()
+                .instance()
+                .get::<_, Refund>(&DataKey::Refund(id))
+            {
                 if refund.reason_code == code {
                     if matched >= offset {
                         results.push_back(refund);
@@ -3000,7 +3089,11 @@ impl RefundContract {
 
         let mut id: u64 = 1;
         while id <= total_refunds {
-            if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(id)) {
+            if let Some(refund) = env
+                .storage()
+                .instance()
+                .get::<_, Refund>(&DataKey::Refund(id))
+            {
                 match refund.reason_code {
                     RefundReasonCode::ProductDefect => product_defect += 1,
                     RefundReasonCode::NonDelivery => non_delivery += 1,
@@ -3039,11 +3132,18 @@ impl RefundContract {
     }
 
     pub fn get_refund_count_by_status(env: &Env, status: RefundStatus) -> u64 {
-        env.storage().instance().get(&DataKey::RefundStatusCount(status)).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::RefundStatusCount(status))
+            .unwrap_or(0)
     }
 
     pub fn get_total_refunded_amount(env: &Env, payment_id: u64) -> i128 {
-        let total_refunds: u64 = env.storage().instance().get(&DataKey::RefundCounter).unwrap_or(0);
+        let total_refunds: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundCounter)
+            .unwrap_or(0);
         let mut total: i128 = 0;
 
         let mut id: u64 = 1;
@@ -3067,7 +3167,7 @@ impl RefundContract {
         env: &Env,
         payment_id: u64,
         requested_amount: i128,
-        original_amount: i128
+        original_amount: i128,
     ) -> Result<bool, Error> {
         let total_refunded = Self::get_total_refunded_amount(env, payment_id);
         if requested_amount.saturating_add(total_refunded) > original_amount {
@@ -3128,7 +3228,9 @@ impl RefundContract {
             default_window_seconds: 30 * 24 * 60 * 60,
         };
 
-        env.storage().instance().set(&DataKey::RefundPolicy(merchant.clone()), &policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicy(merchant.clone()), &policy);
 
         // ── Issue #134: version the policy ──────────────────────────────────
         let version_count: u32 = env
@@ -3156,7 +3258,8 @@ impl RefundContract {
         (RefundPolicySet {
             merchant,
             tiers_count: sorted_tiers.len() as u32,
-        }).publish(&env);
+        })
+        .publish(&env);
 
         Ok(())
     }
@@ -3192,7 +3295,10 @@ impl RefundContract {
             if let Some(pv) = env
                 .storage()
                 .instance()
-                .get::<PolicyKey, RefundPolicyVersion>(&PolicyKey::RefundPolicyVersion(merchant.clone(), v))
+                .get::<PolicyKey, RefundPolicyVersion>(&PolicyKey::RefundPolicyVersion(
+                    merchant.clone(),
+                    v,
+                ))
             {
                 if pv.created_at <= timestamp {
                     result = Some(pv);
@@ -3202,10 +3308,7 @@ impl RefundContract {
         result
     }
 
-    pub fn get_refund_policy_history(
-        env: Env,
-        merchant: Address,
-    ) -> Vec<RefundPolicyVersion> {
+    pub fn get_refund_policy_history(env: Env, merchant: Address) -> Vec<RefundPolicyVersion> {
         let count: u32 = env
             .storage()
             .instance()
@@ -3216,7 +3319,10 @@ impl RefundContract {
             if let Some(pv) = env
                 .storage()
                 .instance()
-                .get::<PolicyKey, RefundPolicyVersion>(&PolicyKey::RefundPolicyVersion(merchant.clone(), v))
+                .get::<PolicyKey, RefundPolicyVersion>(&PolicyKey::RefundPolicyVersion(
+                    merchant.clone(),
+                    v,
+                ))
             {
                 history.push_back(pv);
             }
@@ -3225,7 +3331,9 @@ impl RefundContract {
     }
 
     pub fn get_refund_policy(env: &Env, merchant: Address) -> Option<RefundPolicy> {
-        env.storage().instance().get(&DataKey::RefundPolicy(merchant))
+        env.storage()
+            .instance()
+            .get(&DataKey::RefundPolicy(merchant))
     }
 
     // ── Issue #93: Default refund policy management ────────────────────────
@@ -3258,16 +3366,12 @@ impl RefundContract {
 
     /// Get the global default refund policy (returns None if not set).
     pub fn get_default_refund_policy(env: Env) -> Option<RefundPolicy> {
-        env.storage()
-            .instance()
-            .get(&DataKey::DefaultRefundPolicy)
+        env.storage().instance().get(&DataKey::DefaultRefundPolicy)
     }
 
     /// Internal helper used by request_refund / validate_against_policy.
     fn get_default_refund_policy_inner(env: &Env) -> Option<RefundPolicy> {
-        env.storage()
-            .instance()
-            .get(&DataKey::DefaultRefundPolicy)
+        env.storage().instance().get(&DataKey::DefaultRefundPolicy)
     }
 
     /// Remove the global default refund policy. Admin-only.
@@ -3366,7 +3470,9 @@ impl RefundContract {
         }
 
         policy.active = false;
-        env.storage().instance().set(&DataKey::RefundPolicy(merchant.clone()), &policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundPolicy(merchant.clone()), &policy);
 
         // Emit RefundPolicyDeactivated event
         (RefundPolicyDeactivated { merchant }).publish(&env);
@@ -3378,7 +3484,7 @@ impl RefundContract {
         env: Env,
         admin: Address,
         refund_id: u64,
-        reason: String
+        reason: String,
     ) -> Result<(), Error> {
         // Require admin authentication
         admin.require_auth();
@@ -3406,16 +3512,16 @@ impl RefundContract {
             .instance()
             .get(&DataKey::AdminOverrideHistoryCount)
             .unwrap_or(0);
-        
+
         let executed_at = env.ledger().timestamp();
-        
+
         // Create hash of override details for immutability verification
         let mut hash_data = Bytes::new(&env);
         hash_data.append(&Bytes::from_slice(&env, &refund_id.to_be_bytes()));
         hash_data.append(&Bytes::from_slice(&env, &refund.amount.to_be_bytes()));
         hash_data.append(&Bytes::from_slice(&env, &executed_at.to_be_bytes()));
         let transaction_hash = env.crypto().sha256(&hash_data);
-        
+
         let audit_entry = AdminOverrideHistory {
             override_id,
             refund_id,
@@ -3426,12 +3532,12 @@ impl RefundContract {
             executed_at,
             transaction_hash: transaction_hash.into(),
         };
-        
+
         // Store immutable audit log entry
         env.storage()
             .instance()
             .set(&DataKey::AdminOverrideHistory(override_id), &audit_entry);
-        
+
         // Increment counter
         env.storage()
             .instance()
@@ -3647,11 +3753,7 @@ impl RefundContract {
         Ok(chain)
     }
 
-    pub fn get_applicable_refund_bps(
-        env: Env,
-        merchant: Address,
-        payment_id: u64,
-    ) -> u32 {
+    pub fn get_applicable_refund_bps(env: Env, merchant: Address, payment_id: u64) -> u32 {
         let payment = match Self::get_external_payment(&env, payment_id) {
             Ok(p) => p,
             Err(_) => return 0,
@@ -3688,7 +3790,7 @@ impl RefundContract {
         merchant: &Address,
         amount: i128,
         original_amount: i128,
-        payment_created_at: u64
+        payment_created_at: u64,
     ) -> Result<(), Error> {
         let policy: RefundPolicy = Self::get_effective_refund_policy(env.clone(), merchant.clone())
             .ok_or(Error::PolicyNotFound)?;
@@ -3731,17 +3833,21 @@ impl RefundContract {
 
     fn add_to_status_index(env: &Env, status: RefundStatus, refund_id: u64) {
         let count = Self::get_refund_count_by_status(env, status.clone());
-        env.storage().instance().set(&DataKey::RefundsByStatus(status.clone(), count), &refund_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundsByStatus(status.clone(), count), &refund_id);
         env.storage()
             .instance()
             .set(&DataKey::RefundStatusCount(status.clone()), &(count + 1));
-        env.storage().instance().set(&DataKey::RefundStatusIndex(refund_id), &count);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundStatusIndex(refund_id), &count);
     }
 
     fn remove_from_status_index(
         env: &Env,
         status: RefundStatus,
-        refund_id: u64
+        refund_id: u64,
     ) -> Result<(), Error> {
         let count = Self::get_refund_count_by_status(env, status.clone());
         if count == 0 {
@@ -3770,9 +3876,15 @@ impl RefundContract {
                 .set(&DataKey::RefundStatusIndex(last_refund_id), &index);
         }
 
-        env.storage().instance().remove(&DataKey::RefundsByStatus(status.clone(), last_index));
-        env.storage().instance().remove(&DataKey::RefundStatusIndex(refund_id));
-        env.storage().instance().set(&DataKey::RefundStatusCount(status), &last_index);
+        env.storage()
+            .instance()
+            .remove(&DataKey::RefundsByStatus(status.clone(), last_index));
+        env.storage()
+            .instance()
+            .remove(&DataKey::RefundStatusIndex(refund_id));
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundStatusCount(status), &last_index);
 
         Ok(())
     }
@@ -3798,7 +3910,9 @@ impl RefundContract {
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::BatchRefundLimit, &limit);
+        env.storage()
+            .instance()
+            .set(&DataKey::BatchRefundLimit, &limit);
         Ok(())
     }
 
@@ -3929,11 +4043,7 @@ impl RefundContract {
             .get(&DataKey::PaymentContractAddress)
     }
 
-    pub fn verify_payment_ownership(
-        env: Env,
-        payment_id: u64,
-        customer: Address,
-    ) -> bool {
+    pub fn verify_payment_ownership(env: Env, payment_id: u64, customer: Address) -> bool {
         let payment_contract: Address = match env
             .storage()
             .instance()
@@ -3946,7 +4056,11 @@ impl RefundContract {
         // That function returns bool: true if payment exists, belongs to customer, and is Completed.
         let func = Symbol::new(&env, "check_payment_customer");
         let args = (payment_id, customer).into_val(&env);
-        match env.try_invoke_contract::<bool, soroban_sdk::InvokeError>(&payment_contract, &func, args) {
+        match env.try_invoke_contract::<bool, soroban_sdk::InvokeError>(
+            &payment_contract,
+            &func,
+            args,
+        ) {
             Ok(Ok(result)) => result,
             _ => false,
         }
@@ -3983,11 +4097,7 @@ impl RefundContract {
             .get::<DataKey, Address>(&DataKey::PaymentContractAddress)
             .is_some()
         {
-            let owned = Self::verify_payment_ownership(
-                env.clone(),
-                payment_id,
-                customer.clone(),
-            );
+            let owned = Self::verify_payment_ownership(env.clone(), payment_id, customer.clone());
             if !owned {
                 return Err(Error::PaymentOwnershipMismatch);
             }
@@ -3996,10 +4106,10 @@ impl RefundContract {
         Self::can_refund_payment(&env, payment_id, amount, original_payment_amount)?;
         Self::check_and_update_circuit_breaker(&env, amount, original_payment_amount)?;
         Self::check_and_update_customer_refund_rate_limit(&env, customer.clone())?;
-        
+
         // Check payment refund cap
         Self::check_payment_refund_cap(&env, payment_id, amount)?;
-        
+
         // Check for fraud signals (#137)
         if let Some(fraud_signal) = Self::check_fraud_signals(env.clone(), customer.clone()) {
             if !fraud_signal.reviewed {
@@ -4023,18 +4133,25 @@ impl RefundContract {
             )?;
         }
 
-        let counter: u64 = env.storage().instance().get(&DataKey::RefundCounter).unwrap_or(0);
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RefundCounter)
+            .unwrap_or(0);
         let refund_id = counter + 1;
 
         let initial_status = if force_approved {
             RefundStatus::Approved
         } else {
-            let effective_merchant = if let Some(policy) = Self::get_effective_refund_policy(env.clone(), merchant.clone()) {
+            let effective_merchant = if let Some(policy) =
+                Self::get_effective_refund_policy(env.clone(), merchant.clone())
+            {
                 policy.merchant
             } else {
                 merchant.clone()
             };
-            let requires_approval = Self::get_requires_admin_approval_inner(&env, &effective_merchant);
+            let requires_approval =
+                Self::get_requires_admin_approval_inner(&env, &effective_merchant);
             let auto_below = Self::get_auto_approve_below_inner(&env, &effective_merchant);
             if !requires_approval && amount <= auto_below {
                 RefundStatus::Approved
@@ -4048,7 +4165,11 @@ impl RefundContract {
             .instance()
             .get::<RefundExtKey, RefundTTLConfig>(&RefundExtKey::RefundTTLConfig)
             .filter(|cfg| cfg.active)
-            .map(|cfg| env.ledger().timestamp().saturating_add(cfg.default_ttl_seconds));
+            .map(|cfg| {
+                env.ledger()
+                    .timestamp()
+                    .saturating_add(cfg.default_ttl_seconds)
+            });
 
         let refund = Refund {
             id: refund_id,
@@ -4076,8 +4197,12 @@ impl RefundContract {
             expires_at: ttl_expires_at,
         };
 
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
-        env.storage().instance().set(&DataKey::RefundCounter, &refund_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::RefundCounter, &refund_id);
         Self::add_to_status_index(&env, initial_status.clone(), refund_id);
 
         let merchant_count: u64 = env
@@ -4148,7 +4273,11 @@ impl RefundContract {
         Ok(refund_id)
     }
 
-    fn approve_refund_internal(env: &Env, approved_by: Address, refund_id: u64) -> Result<(), Error> {
+    fn approve_refund_internal(
+        env: &Env,
+        approved_by: Address,
+        refund_id: u64,
+    ) -> Result<(), Error> {
         let mut refund: Refund = env
             .storage()
             .instance()
@@ -4170,7 +4299,9 @@ impl RefundContract {
         refund.status = RefundStatus::Approved;
         // Issue #147: Set approved_at timestamp
         refund.approved_at = Some(env.ledger().timestamp());
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(env, RefundStatus::Approved, refund_id);
 
         (RefundApproved {
@@ -4186,7 +4317,11 @@ impl RefundContract {
         Ok(())
     }
 
-    fn process_refund_internal(env: &Env, processed_by: Address, refund_id: u64) -> Result<(), Error> {
+    fn process_refund_internal(
+        env: &Env,
+        processed_by: Address,
+        refund_id: u64,
+    ) -> Result<(), Error> {
         let mut refund: Refund = env
             .storage()
             .instance()
@@ -4205,12 +4340,8 @@ impl RefundContract {
         )?;
 
         // Deduct platform fee from refund amount
-        let (net_refund_amount, _fee_amount) = Self::deduct_refund_fee(
-            env,
-            refund_id,
-            refund.amount,
-            &refund.token,
-        )?;
+        let (net_refund_amount, _fee_amount) =
+            Self::deduct_refund_fee(env, refund_id, refund.amount, &refund.token)?;
 
         // Enforce merchant refund quota if configured
         if let Some(mut quota) = env
@@ -4232,16 +4363,19 @@ impl RefundContract {
                 return Err(Error::RefundExceedsPolicy);
             }
             quota.used = new_used;
-            env.storage()
-                .instance()
-                .set(&DataKey::MerchantRefundQuota(refund.merchant.clone()), &quota);
+            env.storage().instance().set(
+                &DataKey::MerchantRefundQuota(refund.merchant.clone()),
+                &quota,
+            );
         }
 
         Self::remove_from_status_index(env, RefundStatus::Approved, refund_id)?;
         refund.status = RefundStatus::Processed;
         // Issue #147: Set processed_at timestamp
         refund.processed_at = Some(env.ledger().timestamp());
-        env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(env, RefundStatus::Processed, refund_id);
 
         (RefundProcessed {
@@ -4304,12 +4438,16 @@ impl RefundContract {
     // ── ANALYTICS FUNCTIONS ────────────────────────────────────────────────
 
     pub fn get_refund_analytics(env: Env) -> RefundAnalytics {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&DataKey::RefundAnalyticsKey)
             .unwrap_or(RefundAnalytics {
-                total_refunds_requested: 0, total_refunds_approved: 0,
-                total_refunds_rejected: 0, total_refunds_processed: 0,
-                total_refund_volume: 0, approval_rate_bps: 0,
+                total_refunds_requested: 0,
+                total_refunds_approved: 0,
+                total_refunds_rejected: 0,
+                total_refunds_processed: 0,
+                total_refund_volume: 0,
+                approval_rate_bps: 0,
             })
     }
 
@@ -4317,15 +4455,20 @@ impl RefundContract {
 
     pub fn pause_contract(env: Env, admin: Address, reason: String) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
         let now = env.ledger().timestamp();
-        let pause_state = if let Some(mut state) = env.storage().instance()
-            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey) {
+        let pause_state = if let Some(mut state) = env
+            .storage()
+            .instance()
+            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey)
+        {
             state.globally_paused = true;
             state.paused_at = now;
             state.paused_by = admin.clone();
@@ -4340,8 +4483,12 @@ impl RefundContract {
                 pause_reason: reason.clone(),
             }
         };
-        env.storage().instance().set(&SystemKey::PauseStateKey, &pause_state);
-        let history_count: u64 = env.storage().instance()
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseStateKey, &pause_state);
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&SystemKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -4352,27 +4499,45 @@ impl RefundContract {
             changed_at: now,
             reason: reason.clone(),
         };
-        env.storage().instance().set(&SystemKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&SystemKey::PauseHistoryCount, &(history_count + 1));
-        (ContractPausedEvent { paused_by: admin, reason, paused_at: now }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryCount, &(history_count + 1));
+        (ContractPausedEvent {
+            paused_by: admin,
+            reason,
+            paused_at: now,
+        })
+        .publish(&env);
         Ok(())
     }
 
     pub fn unpause_contract(env: Env, admin: Address) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
-        if let Some(mut state) = env.storage().instance()
-            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey) {
+        if let Some(mut state) = env
+            .storage()
+            .instance()
+            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey)
+        {
             state.globally_paused = false;
-            env.storage().instance().set(&SystemKey::PauseStateKey, &state);
+            env.storage()
+                .instance()
+                .set(&SystemKey::PauseStateKey, &state);
         }
         let now = env.ledger().timestamp();
-        let history_count: u64 = env.storage().instance()
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&SystemKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -4383,9 +4548,17 @@ impl RefundContract {
             changed_at: now,
             reason: String::from_str(&env, ""),
         };
-        env.storage().instance().set(&SystemKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&SystemKey::PauseHistoryCount, &(history_count + 1));
-        (ContractUnpausedEvent { unpaused_by: admin, unpaused_at: now }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryCount, &(history_count + 1));
+        (ContractUnpausedEvent {
+            unpaused_by: admin,
+            unpaused_at: now,
+        })
+        .publish(&env);
         Ok(())
     }
 
@@ -4396,15 +4569,20 @@ impl RefundContract {
         reason: String,
     ) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
         let now = env.ledger().timestamp();
-        let mut pause_state = if let Some(state) = env.storage().instance()
-            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey) {
+        let mut pause_state = if let Some(state) = env
+            .storage()
+            .instance()
+            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey)
+        {
             state
         } else {
             PauseState {
@@ -4416,10 +4594,16 @@ impl RefundContract {
             }
         };
         if !pause_state.paused_functions.contains(&function_name) {
-            pause_state.paused_functions.push_back(function_name.clone());
+            pause_state
+                .paused_functions
+                .push_back(function_name.clone());
         }
-        env.storage().instance().set(&SystemKey::PauseStateKey, &pause_state);
-        let history_count: u64 = env.storage().instance()
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseStateKey, &pause_state);
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&SystemKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -4430,26 +4614,36 @@ impl RefundContract {
             changed_at: now,
             reason: reason.clone(),
         };
-        env.storage().instance().set(&SystemKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&SystemKey::PauseHistoryCount, &(history_count + 1));
-        (FunctionPausedEvent { function_name, paused_by: admin, reason }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryCount, &(history_count + 1));
+        (FunctionPausedEvent {
+            function_name,
+            paused_by: admin,
+            reason,
+        })
+        .publish(&env);
         Ok(())
     }
 
-    pub fn unpause_function(
-        env: Env,
-        admin: Address,
-        function_name: String,
-    ) -> Result<(), Error> {
+    pub fn unpause_function(env: Env, admin: Address, function_name: String) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin = env.storage().instance()
+        let stored_admin = env
+            .storage()
+            .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
-        if let Some(mut state) = env.storage().instance()
-            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey) {
+        if let Some(mut state) = env
+            .storage()
+            .instance()
+            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey)
+        {
             let mut new_paused = Vec::new(&env);
             for fn_name in state.paused_functions.iter() {
                 if fn_name != function_name {
@@ -4457,10 +4651,14 @@ impl RefundContract {
                 }
             }
             state.paused_functions = new_paused;
-            env.storage().instance().set(&SystemKey::PauseStateKey, &state);
+            env.storage()
+                .instance()
+                .set(&SystemKey::PauseStateKey, &state);
         }
         let now = env.ledger().timestamp();
-        let history_count: u64 = env.storage().instance()
+        let history_count: u64 = env
+            .storage()
+            .instance()
             .get(&SystemKey::PauseHistoryCount)
             .unwrap_or(0);
         let entry = PauseHistory {
@@ -4471,14 +4669,23 @@ impl RefundContract {
             changed_at: now,
             reason: String::from_str(&env, ""),
         };
-        env.storage().instance().set(&SystemKey::PauseHistoryEntry(history_count), &entry);
-        env.storage().instance().set(&SystemKey::PauseHistoryCount, &(history_count + 1));
-        (FunctionUnpausedEvent { function_name, unpaused_by: admin }).publish(&env);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryEntry(history_count), &entry);
+        env.storage()
+            .instance()
+            .set(&SystemKey::PauseHistoryCount, &(history_count + 1));
+        (FunctionUnpausedEvent {
+            function_name,
+            unpaused_by: admin,
+        })
+        .publish(&env);
         Ok(())
     }
 
     pub fn get_pause_state(env: Env) -> PauseState {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&SystemKey::PauseStateKey)
             .unwrap_or(PauseState {
                 globally_paused: false,
@@ -4490,11 +4697,18 @@ impl RefundContract {
     }
 
     pub fn is_function_paused(env: Env, function_name: String) -> bool {
-        if let Some(state) = env.storage().instance()
-            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey) {
-            if state.globally_paused { return true; }
+        if let Some(state) = env
+            .storage()
+            .instance()
+            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey)
+        {
+            if state.globally_paused {
+                return true;
+            }
             for fn_name in state.paused_functions.iter() {
-                if fn_name == function_name { return true; }
+                if fn_name == function_name {
+                    return true;
+                }
             }
         }
         false
@@ -4512,8 +4726,11 @@ impl RefundContract {
     }
 
     fn require_not_paused(env: &Env, function_name: &str) -> Result<(), Error> {
-        if let Some(state) = env.storage().instance()
-            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey) {
+        if let Some(state) = env
+            .storage()
+            .instance()
+            .get::<SystemKey, PauseState>(&SystemKey::PauseStateKey)
+        {
             if state.globally_paused {
                 return Err(Error::ContractPaused);
             }
@@ -4550,7 +4767,8 @@ impl RefundContract {
     }
 
     pub fn get_circuit_breaker_state(env: Env) -> CircuitBreakerState {
-        let mut state = env.storage()
+        let mut state = env
+            .storage()
             .instance()
             .get::<SystemKey, CircuitBreakerState>(&SystemKey::CircuitBreakerStateKey)
             .unwrap_or(CircuitBreakerState {
@@ -4564,8 +4782,10 @@ impl RefundContract {
         {
             if TEST_TRIPPED.with(|t| t.load(core::sync::atomic::Ordering::SeqCst)) {
                 state.tripped = true;
-                state.trip_count = TEST_TRIP_COUNT.with(|tc| tc.load(core::sync::atomic::Ordering::SeqCst));
-                let resets_at = TEST_RESETS_AT.with(|r| r.load(core::sync::atomic::Ordering::SeqCst));
+                state.trip_count =
+                    TEST_TRIP_COUNT.with(|tc| tc.load(core::sync::atomic::Ordering::SeqCst));
+                let resets_at =
+                    TEST_RESETS_AT.with(|r| r.load(core::sync::atomic::Ordering::SeqCst));
                 if resets_at > 0 {
                     state.resets_at = Some(resets_at);
                 }
@@ -4630,9 +4850,20 @@ impl RefundContract {
         }
     }
 
-    fn check_and_update_customer_refund_rate_limit(env: &Env, customer: Address) -> Result<(), Error> {
-        let global_limit_opt = env.storage().instance().get::<DataKey, GlobalRefundRateLimit>(&DataKey::GlobalRefundRateLimit);
-        let customer_limit_opt = env.storage().instance().get::<DataKey, CustomerRefundRateLimit>(&DataKey::CustomerRefundRateLimit(customer.clone()));
+    fn check_and_update_customer_refund_rate_limit(
+        env: &Env,
+        customer: Address,
+    ) -> Result<(), Error> {
+        let global_limit_opt = env
+            .storage()
+            .instance()
+            .get::<DataKey, GlobalRefundRateLimit>(&DataKey::GlobalRefundRateLimit);
+        let customer_limit_opt = env
+            .storage()
+            .instance()
+            .get::<DataKey, CustomerRefundRateLimit>(&DataKey::CustomerRefundRateLimit(
+                customer.clone(),
+            ));
         if global_limit_opt.is_none() && customer_limit_opt.is_none() {
             return Ok(());
         }
@@ -4658,7 +4889,9 @@ impl RefundContract {
             return Err(Error::RefundRateLimitExceeded);
         }
         limit.request_count += 1;
-        env.storage().instance().set(&DataKey::CustomerRefundRateLimit(customer), &limit);
+        env.storage()
+            .instance()
+            .set(&DataKey::CustomerRefundRateLimit(customer), &limit);
         Ok(())
     }
 
@@ -4696,7 +4929,8 @@ impl RefundContract {
                     #[cfg(test)]
                     {
                         TEST_TRIPPED.with(|t| t.store(false, core::sync::atomic::Ordering::SeqCst));
-                        TEST_TRIP_COUNT.with(|tc| tc.store(0, core::sync::atomic::Ordering::SeqCst));
+                        TEST_TRIP_COUNT
+                            .with(|tc| tc.store(0, core::sync::atomic::Ordering::SeqCst));
                         TEST_RESETS_AT.with(|r| r.store(0, core::sync::atomic::Ordering::SeqCst));
                     }
                 } else {
@@ -4716,8 +4950,12 @@ impl RefundContract {
 
         if now >= window_start + config.measurement_window_seconds || window_start == 0 {
             env.storage().instance().set(&SystemKey::WindowStart, &now);
-            env.storage().instance().set(&SystemKey::WindowRefundVolume, &0i128);
-            env.storage().instance().set(&SystemKey::WindowPaymentVolume, &0i128);
+            env.storage()
+                .instance()
+                .set(&SystemKey::WindowRefundVolume, &0i128);
+            env.storage()
+                .instance()
+                .set(&SystemKey::WindowPaymentVolume, &0i128);
         }
 
         let new_refund_vol: i128 = env
@@ -4752,8 +4990,14 @@ impl RefundContract {
             #[cfg(test)]
             {
                 TEST_TRIPPED.with(|t| t.store(true, core::sync::atomic::Ordering::SeqCst));
-                TEST_TRIP_COUNT.with(|tc| tc.store(state.trip_count, core::sync::atomic::Ordering::SeqCst));
-                TEST_RESETS_AT.with(|r| r.store(now + config.cooldown_seconds, core::sync::atomic::Ordering::SeqCst));
+                TEST_TRIP_COUNT
+                    .with(|tc| tc.store(state.trip_count, core::sync::atomic::Ordering::SeqCst));
+                TEST_RESETS_AT.with(|r| {
+                    r.store(
+                        now + config.cooldown_seconds,
+                        core::sync::atomic::Ordering::SeqCst,
+                    )
+                });
             }
             CircuitBreakerTrippedEvent {
                 refund_rate_bps: rate_bps,
@@ -4868,7 +5112,7 @@ impl RefundContract {
 
     pub fn get_flagged_addresses(env: Env) -> Vec<FraudSignal> {
         let mut flagged = Vec::new(&env);
-        
+
         // In a real implementation, we'd iterate through all addresses
         // For now, we'll return an empty vector as this is a placeholder
         // In production, this would use an index to efficiently retrieve flagged addresses
@@ -4962,14 +5206,15 @@ impl RefundContract {
             last_refund_requested_at: env.ledger().timestamp(),
             cooldown_seconds: config.cooldown_seconds,
         };
-        env.storage()
-            .instance()
-            .set(&SystemKey::CustomerRefundCooldown(customer.clone()), &record);
+        env.storage().instance().set(
+            &SystemKey::CustomerRefundCooldown(customer.clone()),
+            &record,
+        );
         Ok(())
     }
 
     // Issue #147: Customer refund history functions
-    
+
     /// Get paginated refund history for a customer, sorted newest-first
     pub fn get_customer_refund_history(
         env: Env,
@@ -4986,20 +5231,20 @@ impl RefundContract {
 
         // Calculate range for newest-first ordering
         let end = core::cmp::min(total, offset.saturating_add(limit));
-        
+
         // Iterate in reverse order (newest first)
         let mut collected = 0u64;
         let mut skipped = 0u64;
         let mut index = total;
-        
+
         while index > 0 && collected < limit {
             index -= 1;
-            
+
             if skipped < offset {
                 skipped += 1;
                 continue;
             }
-            
+
             if let Some(refund_id) = env
                 .storage()
                 .instance()
@@ -5053,11 +5298,12 @@ impl RefundContract {
 
                     if refund.status == RefundStatus::Processed {
                         total_amount_refunded += refund.amount;
-                        
+
                         // Calculate processing time if we have both timestamps
                         if let Some(processed_at) = refund.processed_at {
                             let processing_time = processed_at.saturating_sub(refund.requested_at);
-                            total_processing_time = total_processing_time.saturating_add(processing_time);
+                            total_processing_time =
+                                total_processing_time.saturating_add(processing_time);
                             processed_count += 1;
                         }
                     }
@@ -5081,7 +5327,10 @@ impl RefundContract {
     }
 
     fn get_merchant_refund_count(env: &Env, merchant: &Address) -> u64 {
-        env.storage().instance().get(&DataKey::MerchantRefundCount(merchant.clone())).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::MerchantRefundCount(merchant.clone()))
+            .unwrap_or(0)
     }
 
     // Issue #144: Notification hook functions
@@ -5107,7 +5356,7 @@ impl RefundContract {
                 .instance()
                 .get(&SystemKey::HooksByEventCount(event_type.clone()))
                 .unwrap_or(0);
-            
+
             if count >= Self::MAX_HOOKS_PER_EVENT {
                 return Err(Error::MaxHooksPerEventReached);
             }
@@ -5120,7 +5369,7 @@ impl RefundContract {
             .get(&SystemKey::NotificationHookCounter)
             .unwrap_or(0)
             + 1;
-        
+
         env.storage()
             .instance()
             .set(&SystemKey::NotificationHookCounter, &hook_id);
@@ -5145,14 +5394,16 @@ impl RefundContract {
                 .instance()
                 .get(&SystemKey::HooksByEventCount(event_type.clone()))
                 .unwrap_or(0);
-            
-            env.storage()
-                .instance()
-                .set(&SystemKey::HooksByEvent(event_type.clone(), count as u64), &hook_id);
-            
-            env.storage()
-                .instance()
-                .set(&SystemKey::HooksByEventCount(event_type.clone()), &(count + 1));
+
+            env.storage().instance().set(
+                &SystemKey::HooksByEvent(event_type.clone(), count as u64),
+                &hook_id,
+            );
+
+            env.storage().instance().set(
+                &SystemKey::HooksByEventCount(event_type.clone()),
+                &(count + 1),
+            );
         }
 
         // Index by subscriber
@@ -5161,14 +5412,16 @@ impl RefundContract {
             .instance()
             .get(&SystemKey::SubscriberHookCount(subscriber.clone()))
             .unwrap_or(0);
-        
-        env.storage()
-            .instance()
-            .set(&SystemKey::SubscriberHooks(subscriber.clone(), subscriber_count as u64), &hook_id);
-        
-        env.storage()
-            .instance()
-            .set(&SystemKey::SubscriberHookCount(subscriber.clone()), &(subscriber_count + 1));
+
+        env.storage().instance().set(
+            &SystemKey::SubscriberHooks(subscriber.clone(), subscriber_count as u64),
+            &hook_id,
+        );
+
+        env.storage().instance().set(
+            &SystemKey::SubscriberHookCount(subscriber.clone()),
+            &(subscriber_count + 1),
+        );
 
         // Emit event
         (HookRegistered {
@@ -5182,11 +5435,7 @@ impl RefundContract {
     }
 
     /// Deregister a notification hook
-    pub fn deregister_hook(
-        env: Env,
-        subscriber: Address,
-        hook_id: u64,
-    ) -> Result<(), Error> {
+    pub fn deregister_hook(env: Env, subscriber: Address, hook_id: u64) -> Result<(), Error> {
         subscriber.require_auth();
 
         // Get hook
@@ -5204,7 +5453,7 @@ impl RefundContract {
         // Mark as inactive
         let mut updated_hook = hook.clone();
         updated_hook.active = false;
-        
+
         env.storage()
             .instance()
             .set(&SystemKey::NotificationHook(hook_id), &updated_hook);
@@ -5220,12 +5469,9 @@ impl RefundContract {
     }
 
     /// Get all hooks registered for a specific event type
-    pub fn get_hooks_for_event(
-        env: Env,
-        event_type: RefundEventType,
-    ) -> Vec<NotificationHook> {
+    pub fn get_hooks_for_event(env: Env, event_type: RefundEventType) -> Vec<NotificationHook> {
         let mut hooks: Vec<NotificationHook> = Vec::new(&env);
-        
+
         let count: u32 = env
             .storage()
             .instance()
@@ -5254,12 +5500,9 @@ impl RefundContract {
     }
 
     /// Get all hooks for a subscriber
-    pub fn get_subscriber_hooks(
-        env: Env,
-        subscriber: Address,
-    ) -> Vec<NotificationHook> {
+    pub fn get_subscriber_hooks(env: Env, subscriber: Address) -> Vec<NotificationHook> {
         let mut hooks: Vec<NotificationHook> = Vec::new(&env);
-        
+
         let count: u32 = env
             .storage()
             .instance()
@@ -5286,11 +5529,7 @@ impl RefundContract {
     }
 
     /// Internal function to invoke hooks for a specific event
-    fn invoke_hooks(
-        env: &Env,
-        event_type: RefundEventType,
-        refund_id: u64,
-    ) {
+    fn invoke_hooks(env: &Env, event_type: RefundEventType, refund_id: u64) {
         let count: u32 = env
             .storage()
             .instance()
@@ -5366,12 +5605,14 @@ impl RefundContract {
                 .instance()
                 .get(&EligibilityKey::MerchantCustomerCount(merchant.clone()))
                 .unwrap_or(0);
-            env.storage()
-                .instance()
-                .set(&EligibilityKey::MerchantCustomerIndex(merchant.clone(), count), &customer);
-            env.storage()
-                .instance()
-                .set(&EligibilityKey::MerchantCustomerCount(merchant.clone()), &(count + 1));
+            env.storage().instance().set(
+                &EligibilityKey::MerchantCustomerIndex(merchant.clone(), count),
+                &customer,
+            );
+            env.storage().instance().set(
+                &EligibilityKey::MerchantCustomerCount(merchant.clone()),
+                &(count + 1),
+            );
         }
 
         (EligibilitySet {
@@ -5402,9 +5643,10 @@ impl RefundContract {
     ) -> EligibilityRule {
         env.storage()
             .instance()
-            .get::<EligibilityKey, RefundEligibilityEntry>(
-                &EligibilityKey::Entry(merchant.clone(), customer.clone()),
-            )
+            .get::<EligibilityKey, RefundEligibilityEntry>(&EligibilityKey::Entry(
+                merchant.clone(),
+                customer.clone(),
+            ))
             .map(|e| e.rule)
             .unwrap_or(EligibilityRule::Allow)
     }
@@ -5454,22 +5696,23 @@ impl RefundContract {
                 if pos != last {
                     // Swap with last
                     let last_key = EligibilityKey::MerchantCustomerIndex(merchant.clone(), last);
-                    let last_addr: Address = env
-                        .storage()
-                        .instance()
-                        .get(&last_key)
-                        .unwrap();
-                    env.storage()
-                        .instance()
-                        .set(&EligibilityKey::MerchantCustomerIndex(merchant.clone(), pos), &last_addr);
+                    let last_addr: Address = env.storage().instance().get(&last_key).unwrap();
+                    env.storage().instance().set(
+                        &EligibilityKey::MerchantCustomerIndex(merchant.clone(), pos),
+                        &last_addr,
+                    );
                 }
                 // Remove the last slot
                 env.storage()
                     .instance()
-                    .remove(&EligibilityKey::MerchantCustomerIndex(merchant.clone(), last));
-                env.storage()
-                    .instance()
-                    .set(&EligibilityKey::MerchantCustomerCount(merchant.clone()), &last);
+                    .remove(&EligibilityKey::MerchantCustomerIndex(
+                        merchant.clone(),
+                        last,
+                    ));
+                env.storage().instance().set(
+                    &EligibilityKey::MerchantCustomerCount(merchant.clone()),
+                    &last,
+                );
             }
         }
 
@@ -5491,19 +5734,16 @@ impl RefundContract {
             .unwrap_or(0);
 
         for i in 0..count {
-            if let Some(customer) = env
-                .storage()
-                .instance()
-                .get::<EligibilityKey, Address>(
-                    &EligibilityKey::MerchantCustomerIndex(merchant.clone(), i),
-                )
-            {
+            if let Some(customer) = env.storage().instance().get::<EligibilityKey, Address>(
+                &EligibilityKey::MerchantCustomerIndex(merchant.clone(), i),
+            ) {
                 if let Some(entry) = env
                     .storage()
                     .instance()
-                    .get::<EligibilityKey, RefundEligibilityEntry>(
-                        &EligibilityKey::Entry(merchant.clone(), customer),
-                    )
+                    .get::<EligibilityKey, RefundEligibilityEntry>(&EligibilityKey::Entry(
+                        merchant.clone(),
+                        customer,
+                    ))
                 {
                     results.push_back(entry);
                 }
@@ -5518,7 +5758,7 @@ impl RefundContract {
         merchant: &Address,
         status: RefundStatus,
         limit: u64,
-        offset: u64
+        offset: u64,
     ) -> Vec<Refund> {
         let mut results: Vec<Refund> = Vec::new(env);
         if limit == 0 {
@@ -5531,13 +5771,16 @@ impl RefundContract {
         let mut index = 0u64;
 
         while index < total && collected < limit {
-            if
-                let Some(refund_id) = env
+            if let Some(refund_id) = env
+                .storage()
+                .instance()
+                .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
+            {
+                if let Some(refund) = env
                     .storage()
                     .instance()
-                    .get::<_, u64>(&DataKey::MerchantRefunds(merchant.clone(), index))
-            {
-                if let Some(refund) = env.storage().instance().get::<_, Refund>(&DataKey::Refund(refund_id)) {
+                    .get::<_, Refund>(&DataKey::Refund(refund_id))
+                {
                     if refund.status == status {
                         if matched >= offset {
                             results.push_back(refund);
@@ -5590,7 +5833,9 @@ impl RefundContract {
                 Self::remove_from_status_index(&env, RefundStatus::Requested, refund_id)?;
                 refund.status = RefundStatus::Rejected;
                 refund.rejected_at = Some(env.ledger().timestamp());
-                env.storage().instance().set(&DataKey::Refund(refund_id), &refund);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Refund(refund_id), &refund);
                 Self::add_to_status_index(&env, RefundStatus::Rejected, refund_id);
                 env.storage().instance().set(
                     &SystemKey::RefundRejectedAt(refund_id),
@@ -5662,9 +5907,9 @@ impl RefundContract {
         let cat_idx = category.to_index();
         env.storage()
             .instance()
-            .get::<RefundExtKey, CategoryRefundWindow>(
-                &RefundExtKey::CategoryWindow(merchant, cat_idx),
-            )
+            .get::<RefundExtKey, CategoryRefundWindow>(&RefundExtKey::CategoryWindow(
+                merchant, cat_idx,
+            ))
             .map(|w| w.window_seconds)
     }
 
@@ -5691,7 +5936,13 @@ impl RefundContract {
 
     pub fn get_effective_window(env: Env, merchant: Address, payment_id: u64) -> u64 {
         let default_window: u64 = Self::get_refund_policy(&env, merchant.clone())
-            .map(|p| if p.default_window_seconds > 0 { p.default_window_seconds } else { 30 * 24 * 60 * 60 })
+            .map(|p| {
+                if p.default_window_seconds > 0 {
+                    p.default_window_seconds
+                } else {
+                    30 * 24 * 60 * 60
+                }
+            })
             .unwrap_or(30 * 24 * 60 * 60);
 
         let cat_idx_opt: Option<u32> = env
@@ -5703,9 +5954,9 @@ impl RefundContract {
             if let Some(window) = env
                 .storage()
                 .instance()
-                .get::<RefundExtKey, CategoryRefundWindow>(
-                    &RefundExtKey::CategoryWindow(merchant, cat_idx),
-                )
+                .get::<RefundExtKey, CategoryRefundWindow>(&RefundExtKey::CategoryWindow(
+                    merchant, cat_idx,
+                ))
                 .map(|w| w.window_seconds)
             {
                 return window;
@@ -5849,11 +6100,7 @@ impl RefundContract {
 
     // ── Issue #199: Refund request TTL with automatic expiry ──────────────────
 
-    pub fn set_refund_ttl_config(
-        env: Env,
-        admin: Address,
-        ttl_seconds: u64,
-    ) -> Result<(), Error> {
+    pub fn set_refund_ttl_config(env: Env, admin: Address, ttl_seconds: u64) -> Result<(), Error> {
         admin.require_auth();
         let stored_admin: Address = env
             .storage()
@@ -5984,9 +6231,10 @@ impl RefundContract {
             submitted_at: env.ledger().timestamp(),
         };
 
-        env.storage()
-            .instance()
-            .set(&EvidenceKey::Evidence(refund_id, submitter.clone()), &evidence);
+        env.storage().instance().set(
+            &EvidenceKey::Evidence(refund_id, submitter.clone()),
+            &evidence,
+        );
         env.storage()
             .instance()
             .set(&EvidenceKey::EvidenceIndex(refund_id, count), &submitter);
@@ -6036,11 +6284,7 @@ impl RefundContract {
 
     // ── Issue #191: Multi-token refund support ─────────────────────────────
 
-    pub fn register_refund_token(
-        env: Env,
-        admin: Address,
-        token: Address,
-    ) -> Result<(), Error> {
+    pub fn register_refund_token(env: Env, admin: Address, token: Address) -> Result<(), Error> {
         admin.require_auth();
         let stored_admin: Address = env
             .storage()
@@ -6084,11 +6328,7 @@ impl RefundContract {
         Ok(())
     }
 
-    pub fn deregister_refund_token(
-        env: Env,
-        admin: Address,
-        token: Address,
-    ) -> Result<(), Error> {
+    pub fn deregister_refund_token(env: Env, admin: Address, token: Address) -> Result<(), Error> {
         admin.require_auth();
         let stored_admin: Address = env
             .storage()
@@ -6196,12 +6436,14 @@ impl RefundContract {
             .instance()
             .get(&VoucherKey::CustomerVoucherCount(refund.customer.clone()))
             .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&VoucherKey::CustomerVoucher(refund.customer.clone(), customer_count), &voucher_id);
-        env.storage()
-            .instance()
-            .set(&VoucherKey::CustomerVoucherCount(refund.customer.clone()), &(customer_count + 1));
+        env.storage().instance().set(
+            &VoucherKey::CustomerVoucher(refund.customer.clone(), customer_count),
+            &voucher_id,
+        );
+        env.storage().instance().set(
+            &VoucherKey::CustomerVoucherCount(refund.customer.clone()),
+            &(customer_count + 1),
+        );
 
         Ok(voucher_id)
     }
@@ -6347,7 +6589,11 @@ impl RefundContract {
             .get(&ArbitrationKey::ArbitrationTierConfig)
             .ok_or(Error::CaseNotTimedOut)?;
 
-        if env.ledger().timestamp() < case.created_at.saturating_add(config.escalation_timeout_seconds) {
+        if env.ledger().timestamp()
+            < case
+                .created_at
+                .saturating_add(config.escalation_timeout_seconds)
+        {
             return Err(Error::CaseNotTimedOut);
         }
 
@@ -6433,7 +6679,11 @@ impl RefundContract {
         refund_amount: i128,
     ) -> Result<(), Error> {
         // If no cap is set, no restriction applies
-        let cap: PaymentRefundCap = match env.storage().instance().get(&DataKey::PaymentRefundCap(payment_id)) {
+        let cap: PaymentRefundCap = match env
+            .storage()
+            .instance()
+            .get(&DataKey::PaymentRefundCap(payment_id))
+        {
             Some(c) => c,
             None => return Ok(()),
         };
@@ -6458,11 +6708,7 @@ impl RefundContract {
         Ok(())
     }
 
-    fn update_payment_refund_usage(
-        env: &Env,
-        payment_id: u64,
-        refund_amount: i128,
-    ) {
+    fn update_payment_refund_usage(env: &Env, payment_id: u64, refund_amount: i128) {
         let (current_count, current_amount): (u32, i128) = env
             .storage()
             .instance()
@@ -6472,16 +6718,16 @@ impl RefundContract {
         let new_count = current_count.saturating_add(1u32);
         let new_amount = current_amount.saturating_add(refund_amount);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::PaymentRefundUsage(payment_id), &(new_count, new_amount));
+        env.storage().instance().set(
+            &DataKey::PaymentRefundUsage(payment_id),
+            &(new_count, new_amount),
+        );
     }
-
 }
 
 mod test;
-mod test_process;
 mod test_policy;
+mod test_process;
 mod test_rate_limit;
 
 #[cfg(test)]
@@ -6514,9 +6760,9 @@ mod test_auto_refund;
 #[cfg(test)]
 mod test_inheritance;
 
+mod test_customer_history;
 #[cfg(test)]
 mod test_notification_hooks;
-mod test_customer_history;
 
 #[cfg(test)]
 mod test_arbitration_timeout;

--- a/contracts/refund/src/test.rs
+++ b/contracts/refund/src/test.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{ testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String };
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String,
+};
 
 #[test]
 fn test_request_refund_with_valid_data() {
@@ -27,7 +29,7 @@ fn test_request_refund_with_valid_data() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     assert_eq!(refund_id, 1u64);
@@ -59,7 +61,7 @@ fn test_refund_id_increments_correctly() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     let refund_id2 = client.request_refund(
@@ -71,7 +73,7 @@ fn test_refund_id_increments_correctly() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     assert_eq!(refund_id1, 1u64);
@@ -101,7 +103,7 @@ fn test_get_refund_by_id() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -148,7 +150,7 @@ fn test_request_multiple_refunds_and_retrieve_each() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     let refund_id2 = client.request_refund(
@@ -160,7 +162,7 @@ fn test_request_multiple_refunds_and_retrieve_each() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     let refund_id3 = client.request_refund(
@@ -172,7 +174,7 @@ fn test_request_multiple_refunds_and_retrieve_each() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     let refund1 = client.get_refund(&refund_id1);
@@ -310,7 +312,7 @@ fn test_refund_requested_event_is_emitted() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     // Check that the event was emitted
@@ -345,7 +347,7 @@ fn test_refund_stored_with_requested_status() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -375,7 +377,7 @@ fn test_request_refund_without_reason() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -406,7 +408,7 @@ fn test_request_refund_with_reason() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -440,7 +442,7 @@ fn test_approve_requested_refund_successfully() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -475,7 +477,7 @@ fn test_reject_requested_refund_successfully() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -539,7 +541,7 @@ fn test_approve_already_approved_refund_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -573,7 +575,7 @@ fn test_reject_already_rejected_refund_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -607,7 +609,7 @@ fn test_approve_rejected_refund_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -641,7 +643,7 @@ fn test_reject_approved_refund_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -673,7 +675,7 @@ fn test_refund_approved_event_is_emitted() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.approve_refund(&admin, &refund_id);
@@ -708,7 +710,7 @@ fn test_refund_rejected_event_is_emitted() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -742,7 +744,7 @@ fn test_approve_correct_refund_among_multiple() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let refund_id2 = client.request_refund(
         &merchant,
@@ -753,7 +755,7 @@ fn test_approve_correct_refund_among_multiple() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let refund_id3 = client.request_refund(
         &merchant,
@@ -764,7 +766,7 @@ fn test_approve_correct_refund_among_multiple() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     client.approve_refund(&admin, &refund_id2);
@@ -804,7 +806,7 @@ fn test_reject_refund_with_empty_reason() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -839,7 +841,7 @@ fn test_reject_refund_with_detailed_reason() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     client.reject_refund(&admin, &refund_id, &rejection_reason);
@@ -872,7 +874,7 @@ fn test_request_partial_refund_half_payment() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     let refund = client.get_refund(&refund_id);
@@ -905,7 +907,7 @@ fn test_multiple_partial_refunds_for_same_payment() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id1);
     client.process_refund(&admin, &refund_id1);
@@ -919,7 +921,7 @@ fn test_multiple_partial_refunds_for_same_payment() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let refund2 = client.get_refund(&refund_id2);
     assert_eq!(refund2.status, RefundStatus::Requested);
@@ -953,7 +955,7 @@ fn test_request_refund_exceeding_original_payment_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 }
 
@@ -982,7 +984,7 @@ fn test_cumulative_refunds_exceeding_payment_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id1);
     client.process_refund(&admin, &refund_id1);
@@ -996,7 +998,7 @@ fn test_cumulative_refunds_exceeding_payment_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 }
 
@@ -1024,7 +1026,7 @@ fn test_status_queries_and_counts() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let r2 = client.request_refund(
         &merchant,
@@ -1035,7 +1037,7 @@ fn test_status_queries_and_counts() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let r3 = client.request_refund(
         &merchant,
@@ -1046,23 +1048,47 @@ fn test_status_queries_and_counts() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Requested), 3u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Approved), 0u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Rejected), 0u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Processed), 0u64);
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Requested),
+        3u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Approved),
+        0u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Rejected),
+        0u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Processed),
+        0u64
+    );
 
     client.approve_refund(&admin, &r1);
     client.reject_refund(&admin, &r2, &String::from_str(&env, "No"));
     client.approve_refund(&admin, &r3);
     client.process_refund(&admin, &r3);
 
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Requested), 0u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Approved), 1u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Rejected), 1u64);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Processed), 1u64);
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Requested),
+        0u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Approved),
+        1u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Rejected),
+        1u64
+    );
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Processed),
+        1u64
+    );
 
     let requested = client.get_refunds_by_status(&RefundStatus::Requested, &10u64, &0u64);
     assert_eq!(requested.len(), 0);
@@ -1096,11 +1122,14 @@ fn test_pagination_for_status_queries() {
     let reason = String::from_str(&env, "Pagination");
 
     env.mock_all_auths();
-    client.set_fraud_config(&admin, &FraudConfig {
-        max_refund_rate_bps: 10000,
-        min_transactions_for_check: 100,
-        enabled: false,
-    });
+    client.set_fraud_config(
+        &admin,
+        &FraudConfig {
+            max_refund_rate_bps: 10000,
+            min_transactions_for_check: 100,
+            enabled: false,
+        },
+    );
     let r1 = client.request_refund(
         &merchant,
         &payment_id,
@@ -1110,7 +1139,7 @@ fn test_pagination_for_status_queries() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let r2 = client.request_refund(
         &merchant,
@@ -1121,7 +1150,7 @@ fn test_pagination_for_status_queries() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let r3 = client.request_refund(
         &merchant,
@@ -1132,7 +1161,7 @@ fn test_pagination_for_status_queries() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     let r4 = client.request_refund(
         &merchant,
@@ -1143,7 +1172,7 @@ fn test_pagination_for_status_queries() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     let page = client.get_refunds_by_status(&RefundStatus::Requested, &2u64, &1u64);
@@ -1181,11 +1210,14 @@ fn test_request_refund_persists_each_reason_code() {
     ];
 
     env.mock_all_auths();
-    client.set_fraud_config(&admin, &FraudConfig {
-        max_refund_rate_bps: 10000,
-        min_transactions_for_check: 100,
-        enabled: false,
-    });
+    client.set_fraud_config(
+        &admin,
+        &FraudConfig {
+            max_refund_rate_bps: 10000,
+            min_transactions_for_check: 100,
+            enabled: false,
+        },
+    );
     for (idx, code) in reason_codes.iter().enumerate() {
         let payment_id = idx as u64 + 1;
         let refund_id = client.request_refund(
@@ -1218,11 +1250,14 @@ fn test_reason_code_analytics_sorted_by_frequency() {
     let reason = String::from_str(&env, "analytics");
 
     env.mock_all_auths();
-    client.set_fraud_config(&admin, &FraudConfig {
-        max_refund_rate_bps: 10000,
-        min_transactions_for_check: 100,
-        enabled: false,
-    });
+    client.set_fraud_config(
+        &admin,
+        &FraudConfig {
+            max_refund_rate_bps: 10000,
+            min_transactions_for_check: 100,
+            enabled: false,
+        },
+    );
     client.request_refund(
         &merchant,
         &1u64,
@@ -1330,11 +1365,14 @@ fn test_get_refunds_by_reason_code_with_pagination() {
     let reason = String::from_str(&env, "pagination");
 
     env.mock_all_auths();
-    client.set_fraud_config(&admin, &FraudConfig {
-        max_refund_rate_bps: 10000,
-        min_transactions_for_check: 100,
-        enabled: false,
-    });
+    client.set_fraud_config(
+        &admin,
+        &FraudConfig {
+            max_refund_rate_bps: 10000,
+            min_transactions_for_check: 100,
+            enabled: false,
+        },
+    );
     let r1 = client.request_refund(
         &merchant,
         &11u64,
@@ -1396,10 +1434,12 @@ fn test_get_refunds_by_reason_code_with_pagination() {
     assert_eq!(page.get(0).unwrap().id, r3);
     assert_eq!(page.get(1).unwrap().id, r5);
 
-    let out_of_range = client.get_refunds_by_reason_code(&RefundReasonCode::NonDelivery, &2u64, &3u64);
+    let out_of_range =
+        client.get_refunds_by_reason_code(&RefundReasonCode::NonDelivery, &2u64, &3u64);
     assert_eq!(out_of_range.len(), 0);
 
-    let zero_limit = client.get_refunds_by_reason_code(&RefundReasonCode::NonDelivery, &0u64, &0u64);
+    let zero_limit =
+        client.get_refunds_by_reason_code(&RefundReasonCode::NonDelivery, &0u64, &0u64);
     assert_eq!(zero_limit.len(), 0);
 
     let first = client.get_refunds_by_reason_code(&RefundReasonCode::NonDelivery, &1u64, &0u64);
@@ -1432,7 +1472,7 @@ fn test_refund_for_zero_amount_payment_should_fail() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 }
 
@@ -1460,7 +1500,7 @@ fn test_full_refund_is_allowed() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
 
     let refund = client.get_refund(&refund_id);
@@ -1476,7 +1516,10 @@ fn test_status_query_with_no_refunds() {
 
     let refunds = client.get_refunds_by_status(&RefundStatus::Approved, &10u64, &0u64);
     assert_eq!(refunds.len(), 0);
-    assert_eq!(client.get_refund_count_by_status(&RefundStatus::Approved), 0u64);
+    assert_eq!(
+        client.get_refund_count_by_status(&RefundStatus::Approved),
+        0u64
+    );
 }
 
 #[test]
@@ -1503,7 +1546,7 @@ fn test_can_refund_payment_helper() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id);
     client.process_refund(&admin, &refund_id);
@@ -1537,7 +1580,7 @@ fn test_can_refund_payment_helper_rejects_overflow() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.approve_refund(&admin, &refund_id);
     client.process_refund(&admin, &refund_id);
@@ -1577,7 +1620,7 @@ fn test_arbitration_quorum() {
         &token,
         &String::from_str(&env, "reason"),
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1629,7 +1672,7 @@ fn test_arbitration_deadline_enforcement() {
         &token,
         &String::from_str(&env, "reason"),
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1684,7 +1727,7 @@ fn test_arbitration_success_fee_distribution() {
         &token,
         &String::from_str(&env, "reason"),
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1752,7 +1795,7 @@ fn test_arbitration_arbitrator_cannot_vote() {
         &token,
         &String::from_str(&env, "reason"),
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1813,7 +1856,7 @@ fn test_arbitration_outcome_execution_approved() {
         &token,
         &String::from_str(&env, "reason"),
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -1890,7 +1933,7 @@ fn test_arbitration_outcome_execution_rejected() {
         &token,
         &String::from_str(&env, "reason"),
         &RefundReasonCode::Other,
-        &0_u64
+        &0_u64,
     );
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
@@ -2009,7 +2052,11 @@ fn test_file_appeal_after_window_expires_should_fail() {
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "rejected"));
 
     env.ledger().set_timestamp(1_000 + 72 * 60 * 60 + 1);
-    client.file_appeal(&customer, &refund_id, &String::from_str(&env, "late challenge"));
+    client.file_appeal(
+        &customer,
+        &refund_id,
+        &String::from_str(&env, "late challenge"),
+    );
 }
 
 #[test]

--- a/contracts/refund/src/test_arbitration_fees.rs
+++ b/contracts/refund/src/test_arbitration_fees.rs
@@ -1,12 +1,12 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{
-    testutils::Address as _,
-    token, Address, Env, String,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
 
-fn create_token_contract<'a>(env: &Env, admin: &Address) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
+fn create_token_contract<'a>(
+    env: &Env,
+    admin: &Address,
+) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
     let contract = env.register_stellar_asset_contract_v2(admin.clone());
     let contract_address = contract.address();
     (
@@ -15,7 +15,17 @@ fn create_token_contract<'a>(env: &Env, admin: &Address) -> (token::Client<'a>, 
     )
 }
 
-fn setup_test_env() -> (Env, Address, Address, Address, Address, Address, Address, Address, token::Client<'static>) {
+fn setup_test_env() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+    token::Client<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -40,7 +50,17 @@ fn setup_test_env() -> (Env, Address, Address, Address, Address, Address, Addres
     client.register_arbitrator(&admin, &arbitrator2);
     client.register_arbitrator(&admin, &arbitrator3);
 
-    (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, treasury, token_client)
+    (
+        env,
+        admin,
+        merchant,
+        customer,
+        arbitrator1,
+        arbitrator2,
+        arbitrator3,
+        treasury,
+        token_client,
+    )
 }
 
 #[test]
@@ -109,8 +129,18 @@ fn test_set_arbitration_fee_config_unauthorized() {
 
 #[test]
 fn test_fee_distribution_equal_split() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, treasury, token_client) = setup_test_env();
-    
+    let (
+        env,
+        admin,
+        merchant,
+        customer,
+        arbitrator1,
+        arbitrator2,
+        arbitrator3,
+        treasury,
+        token_client,
+    ) = setup_test_env();
+
     // Set fee configuration: 50/50 split
     let config = ArbitrationFeeConfig {
         arbitrator_share_bps: 5000, // 50%
@@ -119,16 +149,16 @@ fn test_fee_distribution_equal_split() {
         fee_token: token_client.address.clone(),
         fee_per_case: 1000,
     };
-    
+
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
-    
+
     // Register arbitrators
     client.register_arbitrator(&admin, &arbitrator1);
     client.register_arbitrator(&admin, &arbitrator2);
     client.register_arbitrator(&admin, &arbitrator3);
-    
+
     client.set_arbitration_fee_config(&admin, &config);
 
     // Create a refund request
@@ -145,18 +175,18 @@ fn test_fee_distribution_equal_split() {
     );
 
     // Reject it first so we can escalate
-    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "Rejected for testing"));
+    client.reject_refund(
+        &admin,
+        &refund_id,
+        &String::from_str(&env, "Rejected for testing"),
+    );
 
     // Escalate to arbitration with fee pool of 1000
     let fee_pool = 1000i128;
     token_client.transfer(&merchant, &contract_id, &fee_pool);
-    
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Cast votes - all three arbitrators vote for refund (majority)
     let hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -194,7 +224,17 @@ fn test_fee_distribution_equal_split() {
 
 #[test]
 fn test_fee_distribution_majority_only() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, treasury, token_client) = setup_test_env();
+    let (
+        env,
+        admin,
+        merchant,
+        customer,
+        arbitrator1,
+        arbitrator2,
+        arbitrator3,
+        treasury,
+        token_client,
+    ) = setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -228,18 +268,18 @@ fn test_fee_distribution_majority_only() {
     );
 
     // Reject it first so we can escalate
-    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "Rejected for testing"));
+    client.reject_refund(
+        &admin,
+        &refund_id,
+        &String::from_str(&env, "Rejected for testing"),
+    );
 
     // Escalate to arbitration
     let fee_pool = 1000i128;
     token_client.transfer(&merchant, &contract_id, &fee_pool);
-    
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Cast votes - 2 for refund (majority), 1 against (minority)
     let hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -266,7 +306,7 @@ fn test_fee_distribution_majority_only() {
     // 800 / 2 = 400 each
     assert_eq!(arb1_final - arb1_initial, 400);
     assert_eq!(arb2_final - arb2_initial, 400);
-    
+
     // Minority voter (arb3) should get nothing
     assert_eq!(arb3_final - arb3_initial, 0);
 
@@ -276,7 +316,17 @@ fn test_fee_distribution_majority_only() {
 
 #[test]
 fn test_withdraw_treasury_fees() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, treasury, token_client) = setup_test_env();
+    let (
+        env,
+        admin,
+        merchant,
+        customer,
+        arbitrator1,
+        arbitrator2,
+        arbitrator3,
+        treasury,
+        token_client,
+    ) = setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -310,17 +360,17 @@ fn test_withdraw_treasury_fees() {
     );
 
     // Reject it first so we can escalate
-    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "Rejected for testing"));
+    client.reject_refund(
+        &admin,
+        &refund_id,
+        &String::from_str(&env, "Rejected for testing"),
+    );
 
     let fee_pool = 1000i128;
     token_client.transfer(&merchant, &contract_id, &fee_pool);
-    
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     let hash = BytesN::from_array(&env, &[0u8; 32]);
     client.cast_arbitration_vote(&arbitrator1, &case_id, &true, &hash);
@@ -367,7 +417,8 @@ fn test_withdraw_treasury_fees_unauthorized() {
 
 #[test]
 fn test_fee_distribution_without_config() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, _, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, _, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -393,18 +444,18 @@ fn test_fee_distribution_without_config() {
     );
 
     // Reject it first so we can escalate
-    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "Rejected for testing"));
+    client.reject_refund(
+        &admin,
+        &refund_id,
+        &String::from_str(&env, "Rejected for testing"),
+    );
 
     // Escalate to arbitration
     let fee_pool = 1000i128;
     token_client.transfer(&merchant, &contract_id, &fee_pool);
-    
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Cast votes
     let hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -436,7 +487,17 @@ fn test_fee_distribution_without_config() {
 
 #[test]
 fn test_fee_distribution_100_percent_treasury() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, treasury, token_client) = setup_test_env();
+    let (
+        env,
+        admin,
+        merchant,
+        customer,
+        arbitrator1,
+        arbitrator2,
+        arbitrator3,
+        treasury,
+        token_client,
+    ) = setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -448,8 +509,8 @@ fn test_fee_distribution_100_percent_treasury() {
 
     // Set fee configuration: 0% arbitrators, 100% treasury
     let config = ArbitrationFeeConfig {
-        arbitrator_share_bps: 0,     // 0%
-        treasury_share_bps: 10000,   // 100%
+        arbitrator_share_bps: 0,   // 0%
+        treasury_share_bps: 10000, // 100%
         treasury_address: treasury.clone(),
         fee_token: token_client.address.clone(),
         fee_per_case: 1000,
@@ -470,18 +531,18 @@ fn test_fee_distribution_100_percent_treasury() {
     );
 
     // Reject it first so we can escalate
-    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "Rejected for testing"));
+    client.reject_refund(
+        &admin,
+        &refund_id,
+        &String::from_str(&env, "Rejected for testing"),
+    );
 
     // Escalate to arbitration
     let fee_pool = 1000i128;
     token_client.transfer(&merchant, &contract_id, &fee_pool);
-    
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Cast votes
     let hash = BytesN::from_array(&env, &[0u8; 32]);

--- a/contracts/refund/src/test_arbitration_stake.rs
+++ b/contracts/refund/src/test_arbitration_stake.rs
@@ -1,12 +1,12 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{
-    testutils::Address as _,
-    token, Address, Env, String,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
 
-fn create_token_contract<'a>(env: &Env, admin: &Address) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
+fn create_token_contract<'a>(
+    env: &Env,
+    admin: &Address,
+) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
     let contract = env.register_stellar_asset_contract_v2(admin.clone());
     let contract_address = contract.address();
     (
@@ -142,12 +142,8 @@ fn test_stake_deposit_on_escalation() {
     // Escalate to arbitration (should require stake)
     let fee_pool = 1000i128;
 
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // With mock_all_auths, balances don't actually change
     // Just verify stake record was created
@@ -211,12 +207,8 @@ fn test_stake_returned_on_win() {
     // Escalate to arbitration
     let fee_pool = 1000i128;
 
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Vote against refund (merchant wins)
     let hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -296,12 +288,8 @@ fn test_stake_forfeited_on_loss() {
     // Escalate to arbitration
     let fee_pool = 1000i128;
 
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Vote for refund (merchant loses)
     let hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -362,12 +350,8 @@ fn test_escalation_without_stake_config() {
     // Escalate to arbitration (should work without stake)
     let fee_pool = 1000i128;
 
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Verify no stake was recorded
     let stake = client.get_arbitration_stake(&case_id);
@@ -425,12 +409,8 @@ fn test_escalation_with_disabled_stake() {
     // Escalate to arbitration (should work without stake since disabled)
     let fee_pool = 1000i128;
 
-    let case_id = client.escalate_to_arbitration(
-        &merchant,
-        &refund_id,
-        &token_client.address,
-        &fee_pool,
-    );
+    let case_id =
+        client.escalate_to_arbitration(&merchant, &refund_id, &token_client.address, &fee_pool);
 
     // Verify no stake was recorded
     let stake = client.get_arbitration_stake(&case_id);

--- a/contracts/refund/src/test_arbitration_timeout.rs
+++ b/contracts/refund/src/test_arbitration_timeout.rs
@@ -53,7 +53,18 @@ fn setup() -> (
     client.register_arbitrator(&admin, &arb2);
     client.register_arbitrator(&admin, &arb3);
 
-    (env, client, contract_id, admin, merchant, customer, arb1, arb2, arb3, token_client)
+    (
+        env,
+        client,
+        contract_id,
+        admin,
+        merchant,
+        customer,
+        arb1,
+        arb2,
+        arb3,
+        token_client,
+    )
 }
 
 fn create_open_case(
@@ -93,8 +104,15 @@ fn test_trigger_arbitration_timeout_success() {
     // Set a short timeout of 100 seconds
     client.set_arbitration_timeout(&admin, &100u64);
 
-    let (refund_id, case_id) =
-        create_open_case(&env, &client, &contract_id, &admin, &merchant, &customer, &token_client);
+    let (refund_id, case_id) = create_open_case(
+        &env,
+        &client,
+        &contract_id,
+        &admin,
+        &merchant,
+        &customer,
+        &token_client,
+    );
 
     // Advance time past timeout
     env.ledger().with_mut(|l| l.timestamp += 200);
@@ -120,8 +138,15 @@ fn test_trigger_arbitration_timeout_too_early() {
     // Set a long timeout of 1000 seconds
     client.set_arbitration_timeout(&admin, &1000u64);
 
-    let (_refund_id, case_id) =
-        create_open_case(&env, &client, &contract_id, &admin, &merchant, &customer, &token_client);
+    let (_refund_id, case_id) = create_open_case(
+        &env,
+        &client,
+        &contract_id,
+        &admin,
+        &merchant,
+        &customer,
+        &token_client,
+    );
 
     // Do NOT advance time — still before timeout_at
     let _ = env.ledger().timestamp(); // ensure time hasn't advanced
@@ -138,8 +163,15 @@ fn test_trigger_arbitration_timeout_blocked_by_quorum() {
 
     client.set_arbitration_timeout(&admin, &100u64);
 
-    let (_refund_id, case_id) =
-        create_open_case(&env, &client, &contract_id, &admin, &merchant, &customer, &token_client);
+    let (_refund_id, case_id) = create_open_case(
+        &env,
+        &client,
+        &contract_id,
+        &admin,
+        &merchant,
+        &customer,
+        &token_client,
+    );
 
     // Cast 3 votes to reach quorum
     let hash = BytesN::from_array(&env, &[0u8; 32]);

--- a/contracts/refund/src/test_arbitrator_reputation.rs
+++ b/contracts/refund/src/test_arbitrator_reputation.rs
@@ -6,7 +6,10 @@ use soroban_sdk::{
     token, Address, BytesN, Env, String,
 };
 
-fn create_token_contract<'a>(env: &Env, admin: &Address) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
+fn create_token_contract<'a>(
+    env: &Env,
+    admin: &Address,
+) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
     let contract = env.register_stellar_asset_contract_v2(admin.clone());
     let contract_address = contract.address();
     (
@@ -15,7 +18,16 @@ fn create_token_contract<'a>(env: &Env, admin: &Address) -> (token::Client<'a>, 
     )
 }
 
-fn setup_test_env() -> (Env, Address, Address, Address, Address, Address, Address, token::Client<'static>) {
+fn setup_test_env() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+    token::Client<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -39,7 +51,16 @@ fn setup_test_env() -> (Env, Address, Address, Address, Address, Address, Addres
     client.register_arbitrator(&admin, &arbitrator2);
     client.register_arbitrator(&admin, &arbitrator3);
 
-    (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client)
+    (
+        env,
+        admin,
+        merchant,
+        customer,
+        arbitrator1,
+        arbitrator2,
+        arbitrator3,
+        token_client,
+    )
 }
 
 fn create_and_escalate_refund(
@@ -71,15 +92,15 @@ fn create_and_escalate_refund(
     );
 
     // Reject refund
-    client.reject_refund(admin, &refund_id, &String::from_str(env, "Rejected for testing"));
+    client.reject_refund(
+        admin,
+        &refund_id,
+        &String::from_str(env, "Rejected for testing"),
+    );
 
     // Escalate to arbitration
-    let case_id = client.escalate_to_arbitration(
-        customer,
-        &refund_id,
-        &token_client.address,
-        &3000,
-    );
+    let case_id =
+        client.escalate_to_arbitration(customer, &refund_id, &token_client.address, &3000);
 
     case_id
 }
@@ -95,7 +116,7 @@ fn test_register_arbitrator_initializes_reputation() {
 
     let reputation = client.get_arbitrator_reputation(&arbitrator1);
     assert!(reputation.is_some());
-    
+
     let rep = reputation.unwrap();
     assert_eq!(rep.arbitrator, arbitrator1);
     assert_eq!(rep.total_cases, 0);
@@ -107,7 +128,8 @@ fn test_register_arbitrator_initializes_reputation() {
 
 #[test]
 fn test_score_increases_on_majority_vote() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -116,7 +138,8 @@ fn test_score_increases_on_majority_vote() {
     client.register_arbitrator(&admin, &arbitrator2);
     client.register_arbitrator(&admin, &arbitrator3);
 
-    let case_id = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
 
     // All three arbitrators vote for refund (majority)
     let reasoning_hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -142,7 +165,8 @@ fn test_score_increases_on_majority_vote() {
 
 #[test]
 fn test_score_decreases_on_minority_vote() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -151,7 +175,8 @@ fn test_score_decreases_on_minority_vote() {
     client.register_arbitrator(&admin, &arbitrator2);
     client.register_arbitrator(&admin, &arbitrator3);
 
-    let case_id = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
 
     // Two arbitrators vote for refund, one against (minority)
     let reasoning_hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -169,14 +194,15 @@ fn test_score_decreases_on_minority_vote() {
 
     assert_eq!(rep1.score, 110); // Majority: 100 + 10
     assert_eq!(rep2.score, 110); // Majority: 100 + 10
-    assert_eq!(rep3.score, 95);  // Minority: 100 - 5
+    assert_eq!(rep3.score, 95); // Minority: 100 - 5
     assert_eq!(rep3.majority_votes, 0);
     assert_eq!(rep3.minority_votes, 1);
 }
 
 #[test]
 fn test_avg_resolution_time_updated() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -185,7 +211,8 @@ fn test_avg_resolution_time_updated() {
     client.register_arbitrator(&admin, &arbitrator2);
     client.register_arbitrator(&admin, &arbitrator3);
 
-    let case_id = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
 
     // Advance time by 1000 seconds
     env.ledger().with_mut(|li| {
@@ -209,7 +236,8 @@ fn test_avg_resolution_time_updated() {
 
 #[test]
 fn test_multiple_cases_update_average_resolution_time() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -219,7 +247,8 @@ fn test_multiple_cases_update_average_resolution_time() {
     client.register_arbitrator(&admin, &arbitrator3);
 
     // First case - 1000 seconds
-    let case_id1 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id1 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     env.ledger().with_mut(|li| {
         li.timestamp += 1000;
     });
@@ -233,7 +262,8 @@ fn test_multiple_cases_update_average_resolution_time() {
     let first_avg = rep_after_first.avg_resolution_time;
 
     // Second case - 2000 seconds
-    let case_id2 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id2 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     env.ledger().with_mut(|li| {
         li.timestamp += 2000;
     });
@@ -252,7 +282,8 @@ fn test_multiple_cases_update_average_resolution_time() {
 
 #[test]
 fn test_get_top_arbitrators_sorted_by_score() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -263,7 +294,8 @@ fn test_get_top_arbitrators_sorted_by_score() {
 
     // Create multiple cases to differentiate scores
     // Case 1: arbitrator1 and arbitrator2 in majority, arbitrator3 in minority
-    let case_id1 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id1 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     let reasoning_hash = BytesN::from_array(&env, &[0u8; 32]);
     client.cast_arbitration_vote(&arbitrator1, &case_id1, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id1, &true, &reasoning_hash);
@@ -271,7 +303,8 @@ fn test_get_top_arbitrators_sorted_by_score() {
     client.close_arbitration_case(&case_id1);
 
     // Case 2: arbitrator1 in majority, arbitrator2 and arbitrator3 in minority
-    let case_id2 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id2 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     client.cast_arbitration_vote(&arbitrator1, &case_id2, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id2, &false, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator3, &case_id2, &true, &reasoning_hash);
@@ -279,13 +312,13 @@ fn test_get_top_arbitrators_sorted_by_score() {
 
     // Get top arbitrators
     let top_arbitrators = client.get_top_arbitrators(&3);
-    
+
     assert_eq!(top_arbitrators.len(), 3);
-    
+
     // arbitrator1 should be first (2 majority votes: 100 + 10 + 10 = 120)
     assert_eq!(top_arbitrators.get(0).unwrap().arbitrator, arbitrator1);
     assert_eq!(top_arbitrators.get(0).unwrap().score, 120);
-    
+
     // arbitrator2 and arbitrator3 should have lower scores
     // arbitrator2: 1 majority, 1 minority = 100 + 10 - 5 = 105
     // arbitrator3: 1 majority, 1 minority = 100 + 10 - 5 = 105
@@ -297,7 +330,8 @@ fn test_get_top_arbitrators_sorted_by_score() {
 
 #[test]
 fn test_get_top_arbitrators_with_limit() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -308,13 +342,14 @@ fn test_get_top_arbitrators_with_limit() {
 
     // Get top 2 arbitrators
     let top_arbitrators = client.get_top_arbitrators(&2);
-    
+
     assert_eq!(top_arbitrators.len(), 2);
 }
 
 #[test]
 fn test_deregister_low_performing_arbitrators() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -325,16 +360,18 @@ fn test_deregister_low_performing_arbitrators() {
 
     // Create cases to lower arbitrator3's score
     let reasoning_hash = BytesN::from_array(&env, &[0u8; 32]);
-    
+
     // Case 1: arbitrator3 in minority
-    let case_id1 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id1 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     client.cast_arbitration_vote(&arbitrator1, &case_id1, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id1, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator3, &case_id1, &false, &reasoning_hash);
     client.close_arbitration_case(&case_id1);
 
     // Case 2: arbitrator3 in minority again
-    let case_id2 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id2 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     client.cast_arbitration_vote(&arbitrator1, &case_id2, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id2, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator3, &case_id2, &false, &reasoning_hash);
@@ -361,7 +398,8 @@ fn test_deregister_low_performing_arbitrators() {
 
 #[test]
 fn test_deregister_multiple_low_performers() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -374,23 +412,26 @@ fn test_deregister_multiple_low_performers() {
     // arbitrator1 and arbitrator2 vote FOR refund (majority)
     // arbitrator3 votes AGAINST refund (minority)
     let reasoning_hash = BytesN::from_array(&env, &[0u8; 32]);
-    
+
     // Case 1
-    let case_id1 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id1 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     client.cast_arbitration_vote(&arbitrator1, &case_id1, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id1, &false, &reasoning_hash); // minority
     client.cast_arbitration_vote(&arbitrator3, &case_id1, &true, &reasoning_hash);
     client.close_arbitration_case(&case_id1);
 
     // Case 2
-    let case_id2 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id2 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     client.cast_arbitration_vote(&arbitrator1, &case_id2, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id2, &false, &reasoning_hash); // minority
     client.cast_arbitration_vote(&arbitrator3, &case_id2, &true, &reasoning_hash);
     client.close_arbitration_case(&case_id2);
 
     // Case 3
-    let case_id3 = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id3 =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     client.cast_arbitration_vote(&arbitrator1, &case_id3, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id3, &false, &reasoning_hash); // minority
     client.cast_arbitration_vote(&arbitrator3, &case_id3, &true, &reasoning_hash);
@@ -400,14 +441,14 @@ fn test_deregister_multiple_low_performers() {
     let rep1 = client.get_arbitrator_reputation(&arbitrator1).unwrap();
     let rep2 = client.get_arbitrator_reputation(&arbitrator2).unwrap();
     let rep3 = client.get_arbitrator_reputation(&arbitrator3).unwrap();
-    
+
     // arbitrator1: 3 majority votes = 100 + 10 + 10 + 10 = 130
     assert_eq!(rep1.score, 130);
     // arbitrator2: 3 minority votes = 100 - 5 - 5 - 5 = 85
     assert_eq!(rep2.score, 85);
     // arbitrator3: 3 majority votes = 100 + 10 + 10 + 10 = 130
     assert_eq!(rep3.score, 130);
-    
+
     // Deregister arbitrators with score below 90
     let removed_count = client.deregister_low_performers(&admin, &90);
     assert_eq!(removed_count, 1); // Only arbitrator2 should be removed
@@ -451,7 +492,8 @@ fn test_deregister_with_negative_threshold() {
 
 #[test]
 fn test_last_active_timestamp_updated() {
-    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) = setup_test_env();
+    let (env, admin, merchant, customer, arbitrator1, arbitrator2, arbitrator3, token_client) =
+        setup_test_env();
     let contract_id = env.register(RefundContract, ());
     let client = RefundContractClient::new(&env, &contract_id);
     client.initialize(&admin);
@@ -469,7 +511,8 @@ fn test_last_active_timestamp_updated() {
     });
 
     // Create and close a case
-    let case_id = create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
+    let case_id =
+        create_and_escalate_refund(&env, &client, &merchant, &customer, &admin, &token_client);
     let reasoning_hash = BytesN::from_array(&env, &[0u8; 32]);
     client.cast_arbitration_vote(&arbitrator1, &case_id, &true, &reasoning_hash);
     client.cast_arbitration_vote(&arbitrator2, &case_id, &true, &reasoning_hash);

--- a/contracts/refund/src/test_auto_refund.rs
+++ b/contracts/refund/src/test_auto_refund.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{contract, contractimpl, testutils::Address as _, testutils::Ledger, Address, Bytes, BytesN, Env, String};
+use soroban_sdk::{
+    contract, contractimpl, testutils::Address as _, testutils::Ledger, Address, Bytes, BytesN,
+    Env, String,
+};
 
 fn setup(env: &Env) -> (RefundContractClient, Address) {
     let contract_id = env.register(RefundContract, ());
@@ -59,7 +62,12 @@ impl MockStateContract {
     }
 }
 
-fn sample_payment(env: &Env, merchant: &Address, customer: &Address, token: &Address) -> ExternalPayment {
+fn sample_payment(
+    env: &Env,
+    merchant: &Address,
+    customer: &Address,
+    token: &Address,
+) -> ExternalPayment {
     ExternalPayment {
         id: 7,
         customer: customer.clone(),
@@ -84,13 +92,16 @@ fn test_evaluate_auto_refund_triggers_on_timeout() {
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
     let token = Address::generate(&env);
-    let payment_contract = install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
+    let payment_contract =
+        install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
     client.set_payment_contract_address(&admin, &payment_contract);
 
     let trigger_id = client.register_auto_refund_trigger(
         &merchant,
         &7u64,
-        &AutoRefundCondition::FulfillmentTimeout(FulfillmentTimeoutCondition { fulfillment_deadline: 9_000 }),
+        &AutoRefundCondition::FulfillmentTimeout(FulfillmentTimeoutCondition {
+            fulfillment_deadline: 9_000,
+        }),
         &2_500u32,
     );
 
@@ -112,13 +123,16 @@ fn test_evaluate_auto_refund_holds_before_timeout() {
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
     let token = Address::generate(&env);
-    let payment_contract = install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
+    let payment_contract =
+        install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
     client.set_payment_contract_address(&admin, &payment_contract);
 
     let trigger_id = client.register_auto_refund_trigger(
         &merchant,
         &7u64,
-        &AutoRefundCondition::FulfillmentTimeout(FulfillmentTimeoutCondition { fulfillment_deadline: 9_000 }),
+        &AutoRefundCondition::FulfillmentTimeout(FulfillmentTimeoutCondition {
+            fulfillment_deadline: 9_000,
+        }),
         &2_500u32,
     );
 
@@ -137,7 +151,8 @@ fn test_evaluate_auto_refund_triggers_on_contract_state_match() {
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
     let token = Address::generate(&env);
-    let payment_contract = install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
+    let payment_contract =
+        install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
     client.set_payment_contract_address(&admin, &payment_contract);
 
     let state_contract_id = env.register(MockStateContract, ());
@@ -172,13 +187,16 @@ fn test_evaluate_auto_refund_cannot_retrigger_after_success() {
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
     let token = Address::generate(&env);
-    let payment_contract = install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
+    let payment_contract =
+        install_mock_payment_contract(&env, sample_payment(&env, &merchant, &customer, &token));
     client.set_payment_contract_address(&admin, &payment_contract);
 
     let trigger_id = client.register_auto_refund_trigger(
         &merchant,
         &7u64,
-        &AutoRefundCondition::FulfillmentTimeout(FulfillmentTimeoutCondition { fulfillment_deadline: 9_000 }),
+        &AutoRefundCondition::FulfillmentTimeout(FulfillmentTimeoutCondition {
+            fulfillment_deadline: 9_000,
+        }),
         &2_500u32,
     );
 

--- a/contracts/refund/src/test_batch.rs
+++ b/contracts/refund/src/test_batch.rs
@@ -12,7 +12,12 @@ fn setup(env: &Env) -> (RefundContractClient, Address) {
     (client, admin)
 }
 
-fn make_refund(client: &RefundContractClient, env: &Env, merchant: &Address, payment_id: u64) -> u64 {
+fn make_refund(
+    client: &RefundContractClient,
+    env: &Env,
+    merchant: &Address,
+    payment_id: u64,
+) -> u64 {
     let customer = Address::generate(env);
     let token = Address::generate(env);
     client.request_refund(
@@ -137,5 +142,8 @@ fn test_oversized_batch_rejected() {
     let results = client.approve_refund_batch(&admin, &ids);
     assert_eq!(results.len(), 1);
     assert!(!results.get(0).unwrap().success);
-    assert_eq!(results.get(0).unwrap().error_code, Error::BatchRefundTooLarge as u32);
+    assert_eq!(
+        results.get(0).unwrap().error_code,
+        Error::BatchRefundTooLarge as u32
+    );
 }

--- a/contracts/refund/src/test_circuit_breaker.rs
+++ b/contracts/refund/src/test_circuit_breaker.rs
@@ -24,7 +24,14 @@ fn default_config(enabled: bool) -> CircuitBreakerConfig {
     }
 }
 
-fn request(client: &RefundContractClient, merchant: &Address, customer: &Address, token: &Address, amount: i128, payment_amount: i128) -> u64 {
+fn request(
+    client: &RefundContractClient,
+    merchant: &Address,
+    customer: &Address,
+    token: &Address,
+    amount: i128,
+    payment_amount: i128,
+) -> u64 {
     let reason = soroban_sdk::String::from_str(&client.env, "test");
     client.request_refund(
         merchant,
@@ -50,8 +57,15 @@ fn test_circuit_breaker_trips_when_rate_exceeded() {
 
     // 10% threshold: 1000/10000 = 10%. request 1100/10000 = 11% -> should trip
     let result = client.try_request_refund(
-        &merchant, &1u64, &customer, &1100_i128, &10000_i128, &token,
-        &String::from_str(&env, "test"), &RefundReasonCode::Other, &0u64,
+        &merchant,
+        &1u64,
+        &customer,
+        &1100_i128,
+        &10000_i128,
+        &token,
+        &String::from_str(&env, "test"),
+        &RefundReasonCode::Other,
+        &0u64,
     );
     assert_eq!(result, Err(Ok(Error::CircuitBreakerTripped)));
 
@@ -71,14 +85,28 @@ fn test_tripped_breaker_blocks_new_requests() {
 
     // Trip the breaker
     let _ = client.try_request_refund(
-        &merchant, &1u64, &customer, &1100_i128, &10000_i128, &token,
-        &String::from_str(&env, "reason"), &RefundReasonCode::Other, &0u64,
+        &merchant,
+        &1u64,
+        &customer,
+        &1100_i128,
+        &10000_i128,
+        &token,
+        &String::from_str(&env, "reason"),
+        &RefundReasonCode::Other,
+        &0u64,
     );
 
     // Now a small refund should also be blocked
     let result = client.try_request_refund(
-        &merchant, &2u64, &customer, &10_i128, &10000_i128, &token,
-        &String::from_str(&env, "reason"), &RefundReasonCode::Other, &0u64,
+        &merchant,
+        &2u64,
+        &customer,
+        &10_i128,
+        &10000_i128,
+        &token,
+        &String::from_str(&env, "reason"),
+        &RefundReasonCode::Other,
+        &0u64,
     );
     assert_eq!(result, Err(Ok(Error::CircuitBreakerTripped)));
 }
@@ -94,8 +122,15 @@ fn test_auto_reset_after_cooldown() {
 
     // Trip the breaker
     let _ = client.try_request_refund(
-        &merchant, &1u64, &customer, &1100_i128, &10000_i128, &token,
-        &String::from_str(&env, "reason"), &RefundReasonCode::Other, &0u64,
+        &merchant,
+        &1u64,
+        &customer,
+        &1100_i128,
+        &10000_i128,
+        &token,
+        &String::from_str(&env, "reason"),
+        &RefundReasonCode::Other,
+        &0u64,
     );
 
     // Advance past cooldown (600s from timestamp 1000)
@@ -103,8 +138,15 @@ fn test_auto_reset_after_cooldown() {
 
     // A small refund should succeed now (new window, low rate)
     let result = client.try_request_refund(
-        &merchant, &2u64, &customer, &10_i128, &10000_i128, &token,
-        &String::from_str(&env, "reason"), &RefundReasonCode::Other, &0u64,
+        &merchant,
+        &2u64,
+        &customer,
+        &10_i128,
+        &10000_i128,
+        &token,
+        &String::from_str(&env, "reason"),
+        &RefundReasonCode::Other,
+        &0u64,
     );
     assert!(result.is_ok());
 
@@ -123,8 +165,15 @@ fn test_manual_reset_by_admin() {
 
     // Trip the breaker
     let _ = client.try_request_refund(
-        &merchant, &1u64, &customer, &1100_i128, &10000_i128, &token,
-        &String::from_str(&env, "reason"), &RefundReasonCode::Other, &0u64,
+        &merchant,
+        &1u64,
+        &customer,
+        &1100_i128,
+        &10000_i128,
+        &token,
+        &String::from_str(&env, "reason"),
+        &RefundReasonCode::Other,
+        &0u64,
     );
 
     assert!(client.get_circuit_breaker_state().tripped);
@@ -146,8 +195,15 @@ fn test_disabled_breaker_does_not_block() {
 
     // High refund rate, but breaker disabled — should not block
     let result = client.try_request_refund(
-        &merchant, &1u64, &customer, &9000_i128, &10000_i128, &token,
-        &String::from_str(&env, "reason"), &RefundReasonCode::Other, &0u64,
+        &merchant,
+        &1u64,
+        &customer,
+        &9000_i128,
+        &10000_i128,
+        &token,
+        &String::from_str(&env, "reason"),
+        &RefundReasonCode::Other,
+        &0u64,
     );
     assert!(result.is_ok());
 

--- a/contracts/refund/src/test_cross_contract.rs
+++ b/contracts/refund/src/test_cross_contract.rs
@@ -45,7 +45,10 @@ fn test_set_get_payment_contract_address() {
 
     assert!(client.get_payment_contract_address().is_none());
     client.set_payment_contract_address(&admin, &payment_contract);
-    assert_eq!(client.get_payment_contract_address().unwrap(), payment_contract);
+    assert_eq!(
+        client.get_payment_contract_address().unwrap(),
+        payment_contract
+    );
 }
 
 // verify_payment_ownership returns false when no contract set

--- a/contracts/refund/src/test_customer_history.rs
+++ b/contracts/refund/src/test_customer_history.rs
@@ -3,7 +3,10 @@
 use crate::{
     CustomerRefundSummary, RefundContract, RefundContractClient, RefundReasonCode, RefundStatus,
 };
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
 
 fn setup_test_env<'a>() -> (Env, RefundContractClient<'a>, Address, Address, Address) {
     let env = Env::default();
@@ -41,10 +44,10 @@ fn test_lifecycle_timestamps_on_request() {
     );
 
     let refund = client.get_refund(&refund_id);
-    
+
     // Verify requested_at is set
     assert_eq!(refund.requested_at, 50);
-    
+
     // Verify other timestamps are None
     assert_eq!(refund.approved_at, None);
     assert_eq!(refund.rejected_at, None);
@@ -74,11 +77,11 @@ fn test_lifecycle_timestamps_on_approve() {
     client.approve_refund(&admin, &refund_id);
 
     let refund = client.get_refund(&refund_id);
-    
+
     // Verify approved_at is set
     assert!(refund.approved_at.is_some());
     assert_eq!(refund.approved_at.unwrap(), 100);
-    
+
     // Verify other timestamps
     assert!(refund.requested_at < refund.approved_at.unwrap());
     assert_eq!(refund.rejected_at, None);
@@ -108,11 +111,11 @@ fn test_lifecycle_timestamps_on_reject() {
     client.reject_refund(&admin, &refund_id, &String::from_str(&env, "Invalid"));
 
     let refund = client.get_refund(&refund_id);
-    
+
     // Verify rejected_at is set
     assert!(refund.rejected_at.is_some());
     assert_eq!(refund.rejected_at.unwrap(), 100);
-    
+
     // Verify other timestamps
     assert!(refund.requested_at < refund.rejected_at.unwrap());
     assert_eq!(refund.approved_at, None);
@@ -145,13 +148,13 @@ fn test_lifecycle_timestamps_on_process() {
     client.process_refund(&admin, &refund_id);
 
     let refund = client.get_refund(&refund_id);
-    
+
     // Verify all timestamps are set correctly
     assert!(refund.requested_at == 0);
     assert_eq!(refund.approved_at, Some(100));
     assert_eq!(refund.processed_at, Some(200));
     assert_eq!(refund.rejected_at, None);
-    
+
     // Verify chronological order
     assert!(refund.requested_at < refund.approved_at.unwrap());
     assert!(refund.approved_at.unwrap() < refund.processed_at.unwrap());
@@ -234,12 +237,12 @@ fn test_get_customer_refund_history_newest_first() {
 
     let history = client.get_customer_refund_history(&customer, &10, &0);
     assert_eq!(history.len(), 3);
-    
+
     // Verify newest first ordering
     assert_eq!(history.get(0).unwrap().id, refund_id3);
     assert_eq!(history.get(1).unwrap().id, refund_id2);
     assert_eq!(history.get(2).unwrap().id, refund_id1);
-    
+
     // Verify timestamps are in descending order
     assert!(history.get(0).unwrap().requested_at > history.get(1).unwrap().requested_at);
     assert!(history.get(1).unwrap().requested_at > history.get(2).unwrap().requested_at);
@@ -426,11 +429,11 @@ fn test_get_customer_refund_summary_with_data() {
     client.reject_refund(&admin, &refund_id3, &String::from_str(&env, "Invalid"));
 
     let summary = client.get_customer_refund_summary(&customer);
-    
+
     assert_eq!(summary.total_requested, 3);
     assert_eq!(summary.total_approved, 2); // Only processed ones count as approved
     assert_eq!(summary.total_amount_refunded, 3000); // 1000 + 2000
-    
+
     // Average processing time: ((200-100) + (500-300)) / 2 = (100 + 200) / 2 = 150
     assert_eq!(summary.avg_processing_time, 150);
 }
@@ -466,7 +469,7 @@ fn test_get_customer_refund_summary_only_requested() {
     );
 
     let summary = client.get_customer_refund_summary(&customer);
-    
+
     assert_eq!(summary.total_requested, 2);
     assert_eq!(summary.total_approved, 0);
     assert_eq!(summary.total_amount_refunded, 0);
@@ -477,7 +480,7 @@ fn test_get_customer_refund_summary_only_requested() {
 fn test_customer_refund_history_multiple_customers() {
     let (env, client, _admin, merchant, _customer) = setup_test_env();
     let token = Address::generate(&env);
-    
+
     let customer1 = Address::generate(&env);
     let customer2 = Address::generate(&env);
 

--- a/contracts/refund/src/test_inheritance.rs
+++ b/contracts/refund/src/test_inheritance.rs
@@ -22,7 +22,13 @@ fn test_single_level_inheritance() {
     env.mock_all_auths();
 
     // Parent sets their own policy
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 14, max_refund_bps: 7500 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 14,
+            max_refund_bps: 7500,
+        }],
+    );
     client.set_refund_policy(&parent_merchant, &tiers);
     client.set_requires_admin_approval(&parent_merchant, &false);
     client.set_auto_approve_below(&parent_merchant, &500i128);
@@ -63,7 +69,13 @@ fn test_multi_level_inheritance() {
     client.set_merchant_parent(&admin, &merchant_c, &merchant_b);
 
     // Only A has explicit policy
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&merchant_a, &tiers);
     client.set_requires_admin_approval(&merchant_a, &true);
     client.set_auto_approve_below(&merchant_a, &0i128);
@@ -95,13 +107,25 @@ fn test_child_override_priority() {
     client.set_merchant_parent(&admin, &child_merchant, &parent_merchant);
 
     // Parent policy
-    let parent_tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let parent_tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&parent_merchant, &parent_tiers);
     client.set_requires_admin_approval(&parent_merchant, &true);
     client.set_auto_approve_below(&parent_merchant, &0i128);
 
     // Child sets their OWN policy (override)
-    let child_tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 7, max_refund_bps: 5000 }]);
+    let child_tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 7,
+            max_refund_bps: 5000,
+        }],
+    );
     client.set_refund_policy(&child_merchant, &child_tiers);
     client.set_requires_admin_approval(&child_merchant, &false);
     client.set_auto_approve_below(&child_merchant, &100i128);
@@ -229,7 +253,13 @@ fn test_inactive_policy_handling() {
     client.set_merchant_parent(&admin, &child_merchant, &parent_merchant);
 
     // Parent sets their policy
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&parent_merchant, &tiers);
     client.set_requires_admin_approval(&parent_merchant, &true);
     client.set_auto_approve_below(&parent_merchant, &0i128);
@@ -266,7 +296,13 @@ fn test_inheritance_disabled() {
     client.set_merchant_parent(&admin, &child_merchant, &parent_merchant);
 
     // Parent has policy
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&parent_merchant, &tiers);
     client.set_requires_admin_approval(&parent_merchant, &true);
     client.set_auto_approve_below(&parent_merchant, &0i128);
@@ -451,7 +487,13 @@ fn test_parent_updates_existing_policy() {
     env.mock_all_auths();
 
     // Child sets policy first (no parent yet)
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 7, max_refund_bps: 5000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 7,
+            max_refund_bps: 5000,
+        }],
+    );
     client.set_refund_policy(&child, &tiers);
     client.set_requires_admin_approval(&child, &false);
     client.set_auto_approve_below(&child, &100i128);

--- a/contracts/refund/src/test_merchant_eligibility.rs
+++ b/contracts/refund/src/test_merchant_eligibility.rs
@@ -291,14 +291,38 @@ fn test_block_then_allow_then_block_again() {
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
 
-    client.set_refund_eligibility(&merchant, &customer, &EligibilityRule::Block, &zero_hash(&env));
-    assert_eq!(client.check_refund_eligibility(&merchant, &customer), EligibilityRule::Block);
+    client.set_refund_eligibility(
+        &merchant,
+        &customer,
+        &EligibilityRule::Block,
+        &zero_hash(&env),
+    );
+    assert_eq!(
+        client.check_refund_eligibility(&merchant, &customer),
+        EligibilityRule::Block
+    );
 
-    client.set_refund_eligibility(&merchant, &customer, &EligibilityRule::Allow, &zero_hash(&env));
-    assert_eq!(client.check_refund_eligibility(&merchant, &customer), EligibilityRule::Allow);
+    client.set_refund_eligibility(
+        &merchant,
+        &customer,
+        &EligibilityRule::Allow,
+        &zero_hash(&env),
+    );
+    assert_eq!(
+        client.check_refund_eligibility(&merchant, &customer),
+        EligibilityRule::Allow
+    );
 
-    client.set_refund_eligibility(&merchant, &customer, &EligibilityRule::Block, &zero_hash(&env));
-    assert_eq!(client.check_refund_eligibility(&merchant, &customer), EligibilityRule::Block);
+    client.set_refund_eligibility(
+        &merchant,
+        &customer,
+        &EligibilityRule::Block,
+        &zero_hash(&env),
+    );
+    assert_eq!(
+        client.check_refund_eligibility(&merchant, &customer),
+        EligibilityRule::Block
+    );
 }
 
 // ── remove_refund_eligibility ─────────────────────────────────────────────────
@@ -385,9 +409,24 @@ fn test_get_eligibility_list_returns_all_entries() {
     let customer_b = Address::generate(&env);
     let customer_c = Address::generate(&env);
 
-    client.set_refund_eligibility(&merchant, &customer_a, &EligibilityRule::Block, &reason_hash(&env, 1));
-    client.set_refund_eligibility(&merchant, &customer_b, &EligibilityRule::Allow, &reason_hash(&env, 2));
-    client.set_refund_eligibility(&merchant, &customer_c, &EligibilityRule::Block, &reason_hash(&env, 3));
+    client.set_refund_eligibility(
+        &merchant,
+        &customer_a,
+        &EligibilityRule::Block,
+        &reason_hash(&env, 1),
+    );
+    client.set_refund_eligibility(
+        &merchant,
+        &customer_b,
+        &EligibilityRule::Allow,
+        &reason_hash(&env, 2),
+    );
+    client.set_refund_eligibility(
+        &merchant,
+        &customer_c,
+        &EligibilityRule::Block,
+        &reason_hash(&env, 3),
+    );
 
     let list = client.get_merchant_eligibility_list(&merchant);
     assert_eq!(list.len(), 3);
@@ -409,7 +448,12 @@ fn test_get_eligibility_list_is_merchant_scoped() {
     let merchant_b = Address::generate(&env);
     let customer = Address::generate(&env);
 
-    client.set_refund_eligibility(&merchant_a, &customer, &EligibilityRule::Block, &zero_hash(&env));
+    client.set_refund_eligibility(
+        &merchant_a,
+        &customer,
+        &EligibilityRule::Block,
+        &zero_hash(&env),
+    );
 
     let list_a = client.get_merchant_eligibility_list(&merchant_a);
     let list_b = client.get_merchant_eligibility_list(&merchant_b);
@@ -425,8 +469,18 @@ fn test_get_eligibility_list_reflects_correct_rules() {
     let customer_a = Address::generate(&env);
     let customer_b = Address::generate(&env);
 
-    client.set_refund_eligibility(&merchant, &customer_a, &EligibilityRule::Block, &reason_hash(&env, 5));
-    client.set_refund_eligibility(&merchant, &customer_b, &EligibilityRule::Allow, &reason_hash(&env, 6));
+    client.set_refund_eligibility(
+        &merchant,
+        &customer_a,
+        &EligibilityRule::Block,
+        &reason_hash(&env, 5),
+    );
+    client.set_refund_eligibility(
+        &merchant,
+        &customer_b,
+        &EligibilityRule::Allow,
+        &reason_hash(&env, 6),
+    );
 
     let list = client.get_merchant_eligibility_list(&merchant);
     assert_eq!(list.len(), 2);
@@ -452,8 +506,18 @@ fn test_get_eligibility_list_shrinks_after_removal() {
     let customer_a = Address::generate(&env);
     let customer_b = Address::generate(&env);
 
-    client.set_refund_eligibility(&merchant, &customer_a, &EligibilityRule::Block, &zero_hash(&env));
-    client.set_refund_eligibility(&merchant, &customer_b, &EligibilityRule::Block, &zero_hash(&env));
+    client.set_refund_eligibility(
+        &merchant,
+        &customer_a,
+        &EligibilityRule::Block,
+        &zero_hash(&env),
+    );
+    client.set_refund_eligibility(
+        &merchant,
+        &customer_b,
+        &EligibilityRule::Block,
+        &zero_hash(&env),
+    );
 
     assert_eq!(client.get_merchant_eligibility_list(&merchant).len(), 2);
 
@@ -471,9 +535,19 @@ fn test_update_existing_entry_does_not_duplicate_in_list() {
     let merchant = Address::generate(&env);
     let customer = Address::generate(&env);
 
-    client.set_refund_eligibility(&merchant, &customer, &EligibilityRule::Block, &zero_hash(&env));
+    client.set_refund_eligibility(
+        &merchant,
+        &customer,
+        &EligibilityRule::Block,
+        &zero_hash(&env),
+    );
     // Update the same customer — should not add a second entry
-    client.set_refund_eligibility(&merchant, &customer, &EligibilityRule::Allow, &zero_hash(&env));
+    client.set_refund_eligibility(
+        &merchant,
+        &customer,
+        &EligibilityRule::Allow,
+        &zero_hash(&env),
+    );
 
     let list = client.get_merchant_eligibility_list(&merchant);
     assert_eq!(list.len(), 1);

--- a/contracts/refund/src/test_notification_hooks.rs
+++ b/contracts/refund/src/test_notification_hooks.rs
@@ -264,7 +264,11 @@ fn test_hook_invocation_on_refund_rejected() {
         &env.ledger().timestamp(),
     );
 
-    client.reject_refund(&admin, &refund_id, &String::from_str(&env, "Invalid request"));
+    client.reject_refund(
+        &admin,
+        &refund_id,
+        &String::from_str(&env, "Invalid request"),
+    );
     // If hook invocation failed, the test would panic
 }
 

--- a/contracts/refund/src/test_payment_refund_cap.rs
+++ b/contracts/refund/src/test_payment_refund_cap.rs
@@ -297,7 +297,7 @@ fn test_no_cap_allows_unlimited() {
     client.initialize(&admin);
 
     // No cap is set for this payment, so unlimited refunds should be allowed
-    
+
     // Request multiple refunds without a cap
     for i in 0..5 {
         let res = client.try_request_refund(

--- a/contracts/refund/src/test_policy.rs
+++ b/contracts/refund/src/test_policy.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{ testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String };
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, String,
+};
 
 #[test]
 fn test_set_refund_policy_successfully() {
@@ -15,7 +17,13 @@ fn test_set_refund_policy_successfully() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 14, max_refund_bps: 5000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 14,
+            max_refund_bps: 5000,
+        }],
+    );
     let requires_admin_approval = false;
     let auto_approve_below = 1000i128;
 
@@ -29,7 +37,10 @@ fn test_set_refund_policy_successfully() {
     assert_eq!(policy.merchant, merchant);
     assert_eq!(policy.tiers.get(0).unwrap().days_from_purchase, 14);
     assert_eq!(policy.tiers.get(0).unwrap().max_refund_bps, 5000);
-    assert_eq!(client.get_requires_admin_approval(&merchant), requires_admin_approval);
+    assert_eq!(
+        client.get_requires_admin_approval(&merchant),
+        requires_admin_approval
+    );
     assert_eq!(client.get_auto_approve_below(&merchant), auto_approve_below);
     assert!(policy.active);
 }
@@ -103,7 +114,13 @@ fn test_apply_template_to_merchant_overwrites_policy_and_preserves_history() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    let tiers1 = Vec::from_array(&env, [RefundTier { days_from_purchase: 7, max_refund_bps: 5000 }]);
+    let tiers1 = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 7,
+            max_refund_bps: 5000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers1);
 
     let tiers: Vec<(u32, i128)> = Vec::new(&env);
@@ -162,7 +179,13 @@ fn test_set_refund_policy_with_invalid_percentage_should_fail() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 15000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 15000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
 }
 
@@ -179,7 +202,13 @@ fn test_deactivate_refund_policy_successfully() {
 
     env.mock_all_auths();
     // First set a policy
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
 
     // Then deactivate it
@@ -230,7 +259,7 @@ fn test_admin_override_policy_successfully() {
         &token,
         &String::from_str(&env, "Test"),
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     // Then admin overrides policy
@@ -268,7 +297,7 @@ fn test_admin_override_policy_by_non_admin_should_fail() {
         &token,
         &String::from_str(&env, "Test"),
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     // Try to override with unauthorized user
@@ -292,7 +321,13 @@ fn test_refund_window_expired_should_fail() {
 
     env.mock_all_auths();
     // Set a policy with 1 day refund window
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 1, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 1,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
 
     // Simulate payment created 2 days ago
@@ -308,7 +343,7 @@ fn test_refund_window_expired_should_fail() {
         &token,
         &String::from_str(&env, "Too late"),
         &RefundReasonCode::Other,
-        &payment_created_at
+        &payment_created_at,
     );
 
     assert_eq!(result, Err(Ok(Error::RefundWindowExpired)));
@@ -329,7 +364,13 @@ fn test_refund_percentage_exceeds_policy_should_fail() {
 
     env.mock_all_auths();
     // Set a policy with 50% max refund
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 5000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 5000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
 
     // Try to request 75% refund
@@ -342,7 +383,7 @@ fn test_refund_percentage_exceeds_policy_should_fail() {
         &token,
         &String::from_str(&env, "Too much"),
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     assert_eq!(result, Err(Ok(Error::RefundExceedsPolicy)));
@@ -363,7 +404,13 @@ fn test_auto_approve_below_threshold() {
 
     env.mock_all_auths();
     // Set policy with auto-approve for amounts <= 500
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
     client.set_requires_admin_approval(&merchant, &false);
     client.set_auto_approve_below(&merchant, &500i128);
@@ -378,7 +425,7 @@ fn test_auto_approve_below_threshold() {
         &token,
         &String::from_str(&env, "Small refund"),
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     // Check that AutoApproved event was emitted (before next contract call clears events)
@@ -404,7 +451,13 @@ fn test_refund_with_inactive_policy_should_fail() {
 
     env.mock_all_auths();
     // Set a policy
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
 
     // Deactivate it
@@ -420,7 +473,7 @@ fn test_refund_with_inactive_policy_should_fail() {
         &token,
         &String::from_str(&env, "Inactive policy"),
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     assert_eq!(result, Err(Ok(Error::PolicyInactive)));
@@ -452,7 +505,7 @@ fn test_refund_without_merchant_policy_uses_default() {
         &token,
         &String::from_str(&env, "Default policy"),
         &RefundReasonCode::Other,
-        &env.ledger().timestamp()
+        &env.ledger().timestamp(),
     );
 
     let refund = client.get_refund(&refund_id);
@@ -471,7 +524,13 @@ fn test_refund_policy_set_event_emitted() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 7, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 7,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
 
     // Check that RefundPolicySet event was emitted
@@ -492,7 +551,13 @@ fn test_refund_policy_deactivated_event_emitted() {
 
     env.mock_all_auths();
     // Set and then deactivate policy
-    let tiers = Vec::from_array(&env, [RefundTier { days_from_purchase: 30, max_refund_bps: 10000 }]);
+    let tiers = Vec::from_array(
+        &env,
+        [RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
     client.set_refund_policy(&merchant, &tiers);
 
     client.deactivate_refund_policy(&merchant);

--- a/contracts/refund/src/test_process.rs
+++ b/contracts/refund/src/test_process.rs
@@ -1,9 +1,6 @@
 #![cfg(test)]
 use super::{RefundContract, RefundContractClient, RefundReasonCode, RefundStatus};
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env, String,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 #[test]
 fn test_initialize() {
@@ -44,18 +41,17 @@ fn test_approve_refund() {
     let reason = String::from_str(&env, "reason");
 
     env.mock_all_auths();
-    let refund_id =
-        client.request_refund(
-            &merchant,
-            &payment_id,
-            &customer,
-            &amount,
-            &1000,
-            &token,
-            &reason,
-            &RefundReasonCode::Other,
-            &0_u64,
-        );
+    let refund_id = client.request_refund(
+        &merchant,
+        &payment_id,
+        &customer,
+        &amount,
+        &1000,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0_u64,
+    );
 
     // Approve
     client.approve_refund(&admin, &refund_id);

--- a/contracts/refund/src/test_rate_limit.rs
+++ b/contracts/refund/src/test_rate_limit.rs
@@ -32,7 +32,7 @@ fn test_global_refund_rate_limit() {
             &token,
             &reason,
             &RefundReasonCode::Other,
-            &0
+            &0,
         );
     }
 
@@ -46,7 +46,7 @@ fn test_global_refund_rate_limit() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0
+        &0,
     );
 
     assert!(res.is_err());
@@ -69,7 +69,7 @@ fn test_customer_override_refund_rate_limit() {
 
     // Set global limit: 1 request per 24 hours
     client.set_global_refund_rate_limit(&admin, &1, &86400);
-    
+
     // Set customer override: 5 requests per 24 hours
     client.set_customer_rate_limit(&admin, &customer, &5, &86400);
 
@@ -84,10 +84,10 @@ fn test_customer_override_refund_rate_limit() {
             &token,
             &reason,
             &RefundReasonCode::Other,
-            &0
+            &0,
         );
     }
-    
+
     let status = client.get_customer_rate_limit_status(&customer);
     assert_eq!(status.request_count, 3);
 }
@@ -120,7 +120,7 @@ fn test_rate_limit_window_reset() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0
+        &0,
     );
 
     // 2nd request fails
@@ -133,7 +133,7 @@ fn test_rate_limit_window_reset() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0
+        &0,
     );
     assert!(res.is_err());
 
@@ -150,6 +150,6 @@ fn test_rate_limit_window_reset() {
         &token,
         &reason,
         &RefundReasonCode::Other,
-        &0
+        &0,
     );
 }


### PR DESCRIPTION
## Summary

- **escrow**: Remove unconditional `return Err(Error::Unauthorized)` in `resolve_dispute()` that made dispute resolution permanently inaccessible to everyone, including the admin
- **payment**: Replace single-hop forward config check with a bounded DFS (max depth 10) to detect multi-hop forwarding cycles (e.g. A→B→C→A) before persisting a new config
- **payment tests**: Update `test_set_payment_forward_loop_detection` to validate an actual 3-hop cycle instead of the old over-restrictive "no chaining" behavior

## Changes

### `contracts/escrow/src/lib.rs`
`resolve_dispute()` contained a `return Err(Error::Unauthorized)` inside the multisig admin check block that fired unconditionally after the `NotAnAdmin` guard — meaning even a valid admin could never reach `internal_resolve_dispute`. Removed the dead-code return so valid admins fall through to resolution.

### `contracts/payment/src/lib.rs`
`set_payment_forward_config()` only checked whether `forward_to` had any existing config (one-hop), which blocked valid non-cyclic chains (A→B→C) and failed to catch cycles formed via config updates. Replaced with a bounded DFS that walks the stored chain up to 10 hops and returns `ForwardLoop` only when the walk reaches the calling merchant.

### `contracts/payment/src/test_payment_forward.rs`
Updated the loop detection test to build a real 3-hop cycle (`B→C→A`) before attempting `A→B`, confirming `ForwardLoop` is returned. The previous test was asserting against non-cycle chain rejection, which no longer applies.

closes #268 
closes #269 

## Test plan

- [ ] `cargo test -p payments` — all 298 tests pass, including `test_set_payment_forward_loop_detection`
- [ ] Verify self-referential forward (A→A) is rejected by the DFS
- [ ] Verify a valid 2-hop non-cyclic chain (A→B→C) is now permitted
- [ ] Verify admin can successfully call `resolve_dispute()` on a disputed escrow
