### PR TITLE
fix: enforce customer spend limits across all payment paths (#282)

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -2002,6 +2002,9 @@ impl PaymentContract {
             return Err(Error::PaymentNotYetDue);
         }
 
+        // Check customer spend limit (#282)
+        PaymentContract::check_and_update_spend_limit(&env, &scheduled.customer, scheduled.amount)?;
+
         Self::settle_or_accumulate(
             &env,
             scheduled.merchant.clone(),
@@ -4216,6 +4219,11 @@ impl PaymentContract {
                 return Err(Error::RetryTooEarly);
             }
 
+            // Check customer spend limit (#282)
+            if let Err(_) = PaymentContract::check_and_update_spend_limit(&env, &sub.customer, sub.amount) {
+                return Err(Error::SpendLimitExceeded);
+            }
+
             let token_client = token::Client::new(&env, &sub.token);
             let contract_address = env.current_contract_address();
             let transfer_ok = token_client
@@ -4318,6 +4326,11 @@ impl PaymentContract {
                 .instance()
                 .set(&DataKey::Subscription(subscription_id), &sub);
             return Ok(());
+        }
+
+        // Check customer spend limit (#282)
+        if let Err(_) = PaymentContract::check_and_update_spend_limit(&env, &sub.customer, sub.amount) {
+            return Err(Error::SpendLimitExceeded);
         }
 
         // Attempt token transfer
@@ -6525,6 +6538,30 @@ impl PaymentContract {
                 continue;
             }
 
+            // Check merchant rate limits
+            if let Err(e) =
+                PaymentContract::check_merchant_rate_limit(&env, &entry.merchant, entry.amount)
+            {
+                results.push_back(BatchResult {
+                    payment_id: 0,
+                    success: false,
+                    error_code: Some(e as u32),
+                });
+                continue;
+            }
+
+            // Check customer spend limit
+            if let Err(e) =
+                PaymentContract::check_and_update_spend_limit(&env, &entry.customer, entry.amount)
+            {
+                results.push_back(BatchResult {
+                    payment_id: 0,
+                    success: false,
+                    error_code: Some(e as u32),
+                });
+                continue;
+            }
+
             // Create payment record
             let counter: u64 = env
                 .storage()
@@ -8439,6 +8476,9 @@ impl PaymentContract {
         if total_bps != 10000 {
             return Err(Error::InvalidSplitShares);
         }
+
+        // Check customer spend limit (#282)
+        PaymentContract::check_and_update_spend_limit(&env, &customer, amount)?;
 
         let counter: u64 = env
             .storage()


### PR DESCRIPTION
# Fix Customer Spend Limits Enforcement

## Summary
Fixes issue #282 where customer spend limits were only enforced in the standard payment creation path but not in batch payments, split payments, scheduled payments, or recurring payments. The spend limit check now prevents multiple payments that each fall below the limit cap from bypassing the enforcement.

## Changes
- **execute_scheduled_payment**: Added spend limit validation before executing scheduled payments
- **execute_recurring_payment**: Added spend limit validation for both normal execution and dunning retry paths
- **create_payment_batch_optimized**: Added spend limit check to batch payment creation + missing merchant rate limit check
- **create_split_payment**: Added spend limit validation before creating split payments

The `spent_this_period` accumulator is now incremented for all payment paths, preventing customers from circumventing limits with multiple sub-limit payments.

## Testing
- All 7 existing spend limit tests pass
- Full test suite (210+ tests) passes
- Verified no regressions in other payment paths

Closes #282
