### PR TITLE
fix: validate expiry_timestamp is in the future on escrow creation

### DIFF
--- a/contracts/escrow/src/expiry_test.rs
+++ b/contracts/escrow/src/expiry_test.rs
@@ -100,3 +100,61 @@ fn test_create_escrow_expiry_before_release_fails() {
     );
     assert!(result.is_err());
 }
+
+#[test]
+fn test_create_escrow_expiry_in_past_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(5000);
+    // expiry_timestamp(4999) is in the past relative to ledger time(5000)
+    let result = client.try_create_escrow(
+        &customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &4999_u64, &true,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_escrow_expiry_equal_to_current_time_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(5000);
+    // expiry_timestamp(5000) == ledger time(5000), must be strictly after
+    let result = client.try_create_escrow(
+        &customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &5000_u64, &true,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_escrow_expiry_within_hold_period_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+    // min_hold_period=500 → expiry must be > 1000+500=1500; 1400 fails
+    let result = client.try_create_escrow(
+        &customer, &merchant, &500_i128, &token, &500_u64, &500_u64, &1400_u64, &true,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_escrow_expiry_after_hold_period_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+    // min_hold_period=500 → expiry must be > 1000+500=1500; 1600 succeeds
+    // release_timestamp=500, expiry=1600 (> release and > current+hold_period)
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &500_i128, &token, &500_u64, &500_u64, &1600_u64, &true,
+    );
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.expiry_timestamp, 1600);
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2042,9 +2042,18 @@ impl EscrowContract {
             }
         }
 
+        let current_timestamp = env.ledger().timestamp();
+
         // Validate expiry: if set (non-zero), must be strictly after release_timestamp
         if expiry_timestamp != 0 && expiry_timestamp <= release_timestamp {
             return Err(Error::ExpiryBeforeRelease);
+        }
+
+        // Validate expiry: must be strictly in the future and after the hold period elapses
+        if expiry_timestamp != 0
+            && expiry_timestamp <= current_timestamp.saturating_add(min_hold_period)
+        {
+            return Err(Error::EscrowAlreadyExpired);
         }
 
         let counter: u64 = env
@@ -2053,8 +2062,6 @@ impl EscrowContract {
             .get(&DataKey::EscrowCounter)
             .unwrap_or(0);
         let escrow_id = counter + 1;
-
-        let current_timestamp = env.ledger().timestamp();
 
         let fee_config = Self::get_escrow_fee_config(env.clone());
         let fee_bps = if fee_config.enabled {
@@ -8330,8 +8337,8 @@ mod hierarchy_test;
 // #[cfg(test)]
 // mod pause_history_test;
 //
-// #[cfg(test)]
-// mod expiry_test;
+#[cfg(test)]
+mod expiry_test;
 //
 // #[cfg(test)]
 // mod multisig_threshold_test;


### PR DESCRIPTION


Summary
create_escrow() previously only validated that expiry_timestamp > release_timestamp, allowing past or zero-valued expiry timestamps to be set at creation time
An attacker could pass expiry_timestamp = 0 or any past value and immediately trigger expiry-based release/cancellation logic, bypassing the intended hold period
Added a second guard in internal_create_escrow: if expiry_timestamp is non-zero, it must be strictly greater than env.ledger().timestamp() + min_hold_period (using saturating_add to prevent overflow)
Returns the existing EscrowAlreadyExpired error (code 86) on violation
Enabled the expiry_test module and added 4 new test cases covering: past timestamp, equal-to-current timestamp, expiry within hold period, and valid expiry after hold period
Test plan
 cargo test -p escrow -- expiry — all 9 expiry tests pass
 cargo build -p escrow — contract compiles cleanly with no new warnings
 Manually verify: creating an escrow with expiry_timestamp = 0 (unset) still works as before — the guard is skipped for zero values

Closes #280