### PR TITLE
fix(escrow): reject zero amount creation

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2031,6 +2031,10 @@ impl EscrowContract {
         expiry_timestamp: u64,
         auto_refund_on_expiry: bool,
     ) -> Result<u64, Error> {
+        if amount <= 0 {
+            return Err(Error::InvalidStatus);
+        }
+
         // Block new escrow creation during migration
         if let Some(status) = env
             .storage()
@@ -2182,6 +2186,10 @@ impl EscrowContract {
         release_timestamp: u64,
     ) -> Result<u64, Error> {
         customer.require_auth();
+
+        if total_amount <= 0 {
+            return Err(Error::InvalidStatus);
+        }
 
         // Minimum 2, maximum 10 participants
         if participants.len() < 2 || participants.len() > 10 {
@@ -2534,6 +2542,11 @@ impl EscrowContract {
         }
         if tokens.len() > 10 {
             return Err(Error::InvalidStatus);
+        }
+        for entry in tokens.iter() {
+            if entry.amount <= 0 {
+                return Err(Error::InvalidStatus);
+            }
         }
 
         // Reject duplicate token addresses

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -378,6 +378,29 @@ fn test_create_escrow() {
     assert_eq!(escrow.min_hold_period, min_hold_period);
 }
 
+
+#[test]
+fn test_create_escrow_zero_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let result = client.try_create_escrow(
+        &customer,
+        &merchant,
+        &0_i128,
+        &token,
+        &1000_u64,
+        &0_u64,
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidStatus)));
+}
 #[test]
 fn test_get_escrow() {
     let env = Env::default();
@@ -2015,6 +2038,47 @@ fn test_release_vested_amount_before_cliff_returns_cliff_error() {
     assert_eq!(result, Err(Ok(Error::CliffPeriodNotPassed)));
 }
 
+
+#[test]
+fn test_create_multi_party_escrow_zero_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+
+    let mut participants = Vec::new(&env);
+    participants.push_back(Participant {
+        address: p1,
+        role: ParticipantRole::Merchant,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
+    });
+    participants.push_back(Participant {
+        address: p2,
+        role: ParticipantRole::ServiceProvider,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
+    });
+
+    let result = client.try_create_multi_party_escrow(
+        &customer,
+        &participants,
+        &0_i128,
+        &token,
+        &1000_u64,
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidStatus)));
+}
 #[test]
 #[should_panic]
 fn test_create_multi_party_escrow_invalid_shares() {
@@ -2933,6 +2997,29 @@ fn test_create_multi_token_escrow_empty_list() {
     assert_eq!(result, Err(Ok(Error::EmptyTokenList)));
 }
 
+
+#[test]
+fn test_create_multi_token_escrow_zero_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let token_a = setup_token(&env);
+    let token_a_admin = token::StellarAssetClient::new(&env, &token_a);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    token_a_admin.mint(&customer, &1000);
+
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(TokenEntry {
+        token: token_a,
+        amount: 0,
+    });
+
+    let result = client.try_create_multi_token_escrow(&customer, &merchant, &tokens, &1000_u64);
+    assert_eq!(result, Err(Ok(Error::InvalidStatus)));
+}
 #[test]
 fn test_create_multi_token_escrow_duplicate_token() {
     let env = Env::default();


### PR DESCRIPTION

## Summary
- Rejects `amount <= 0` in the shared single-escrow creation path before state is written.
- Rejects `total_amount <= 0` in `create_multi_party_escrow` before participant normalization or transfer.
- Rejects any `TokenEntry.amount <= 0` in `create_multi_token_escrow` before duplicate checks or transfers.
- Adds regression coverage for zero-value single, multi-party, and multi-token escrow creation.

## Validation
- Static review of `contracts/escrow/src/lib.rs` and `contracts/escrow/src/test.rs`.
- GitHub compare confirms two intended files changed.
- Local contract tests were not run on this Windows host because Soroban/Rust test execution has previously been blocked by missing MSVC linker support here.