### PR TITLE
fix: reject zero interval_seconds in create_subscription

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -356,6 +356,7 @@ pub enum Error {
     InvalidForwardBps = 111,
     // Arithmetic safety
     BillingOverflow = 124,
+    InvalidInterval = 125,
 }
 
 // Manual trait implementations replacing #[contracterror] (105 variants exceed the 50-variant XDR spec limit)
@@ -377,7 +378,7 @@ impl TryFrom<soroban_sdk::Error> for Error {
     fn try_from(error: soroban_sdk::Error) -> Result<Self, soroban_sdk::Error> {
         if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) {
             let code = error.get_code();
-            if matches!(code, 1..=21 | 23..=48 | 50..=56 | 58..=80 | 85..=91 | 95..=96 | 100..=102 | 106..=111 | 114..=124)
+            if matches!(code, 1..=21 | 23..=48 | 50..=56 | 58..=80 | 85..=91 | 95..=96 | 100..=102 | 106..=111 | 114..=125)
             {
                 // SAFETY: Error is #[repr(u32)] and all valid discriminants are covered by the matches! guard above
                 Ok(unsafe { core::mem::transmute::<u32, Error>(code) })
@@ -4079,6 +4080,9 @@ impl PaymentContract {
         }
         if metadata.len() > MAX_METADATA_SIZE {
             return Err(Error::MetadataTooLarge);
+        }
+        if interval == 0 {
+            return Err(Error::InvalidInterval);
         }
 
         let counter: u64 = env

--- a/contracts/payment/src/test_trial.rs
+++ b/contracts/payment/src/test_trial.rs
@@ -45,6 +45,31 @@ fn test_zero_trial_default_behavior() {
     assert!(!sub.trial_data.converted);
 }
 
+// interval = 0 must be rejected, otherwise proration in resume_subscription
+// would divide by zero.
+#[test]
+fn test_create_subscription_rejects_zero_interval() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let result = client.try_create_subscription(
+        &customer,
+        &merchant,
+        &1000i128,
+        &token,
+        &Currency::USDC,
+        &0u64, // interval
+        &0u64, // duration
+        &3u64,
+        &String::from_str(&env, ""),
+        &0u64,
+    );
+    assert_eq!(result.unwrap_err().unwrap(), Error::InvalidInterval);
+}
+
 // During trial: execute_recurring_payment returns Ok without charging
 #[test]
 fn test_execute_during_trial_skips_charge() {


### PR DESCRIPTION
closes #299
A zero interval is meaningless (infinite billing frequency) and causes resume_subscription's proration formula to divide by sub.interval, panicking when a zero-interval subscription is paused and resumed. Validate interval > 0 at creation time so it can never reach storage.