### PR TITLE
Feat/multi party escrow

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -51,6 +51,8 @@ pub enum DisputeKey {
 #[contracttype]
 pub enum DataKey {
     Config(ConfigKey), Escrow(EscrowKey), Participant(ParticipantKey), Dispute(DisputeKey),
+    VoteWeight(u64, Address),
+    ReleaseThresholdBps(u64),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1389,11 +1391,16 @@ pub struct MultiPartyDisputeResolved {
     pub resolved_at: u64,
 }
 
-fn sum_approved_weight(participants: &Vec<Participant>) -> u32 {
+fn sum_approved_weight(env: &Env, escrow_id: u64, participants: &Vec<Participant>) -> u32 {
     let mut total: u32 = 0;
     for p in participants.iter() {
         if p.approved {
-            total += p.weight_bps;
+            let weight: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::VoteWeight(escrow_id, p.address.clone()))
+                .unwrap_or(p.weight_bps);
+            total += weight;
         }
     }
     total
@@ -2286,6 +2293,15 @@ impl EscrowContract {
             .instance()
             .set(&DataKey::Escrow(EscrowKey::MultiPartyCounter), &escrow_id);
 
+        for p in escrow.participants.iter() {
+            env.storage()
+                .instance()
+                .set(&DataKey::VoteWeight(escrow_id, p.address.clone()), &p.share_bps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ReleaseThresholdBps(escrow_id), &10000u32);
+
         MultiPartyEscrowCreated {
             escrow_id,
             participant_count: escrow.participants.len(),
@@ -2322,7 +2338,12 @@ impl EscrowContract {
         let mut found_voter = false;
         for p in escrow.participants.iter() {
             if p.address == caller {
-                if p.weight_bps == 0 {
+                let weight = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::VoteWeight(escrow_id, caller.clone()))
+                    .unwrap_or(p.weight_bps);
+                if weight == 0 {
                     return Err(Error::Basic(BasicError::Unauthorized));
                 }
                 if p.approved {
@@ -2333,7 +2354,7 @@ impl EscrowContract {
                     address: p.address.clone(),
                     role: p.role.clone(),
                     share_bps: p.share_bps,
-                    weight_bps: p.weight_bps,
+                    weight_bps: weight,
                     approved: true,
                     approved_at: Some(now),
                 });
@@ -2381,8 +2402,13 @@ impl EscrowContract {
         }
 
         // Check if cumulative approved weight meets the threshold
-        let approved_weight = sum_approved_weight(&escrow.participants);
-        if approved_weight < escrow.threshold_bps {
+        let approved_weight = sum_approved_weight(&env, escrow_id, &escrow.participants);
+        let threshold = env
+            .storage()
+            .instance()
+            .get(&DataKey::ReleaseThresholdBps(escrow_id))
+            .unwrap_or(escrow.threshold_bps);
+        if approved_weight < threshold {
             return Err(Error::Action(ActionError::ApprovalsThresholdNotMet));
         }
 
@@ -2436,8 +2462,13 @@ impl EscrowContract {
             .instance()
             .get(&DataKey::Escrow(EscrowKey::MultiParty(escrow_id)))
             .ok_or(Error::Escrow(EscrowError::NotFound))?;
-        let approved = sum_approved_weight(&escrow.participants);
-        Ok((approved, escrow.threshold_bps))
+        let approved = sum_approved_weight(&env, escrow_id, &escrow.participants);
+        let threshold = env
+            .storage()
+            .instance()
+            .get(&DataKey::ReleaseThresholdBps(escrow_id))
+            .unwrap_or(escrow.threshold_bps);
+        Ok((approved, threshold))
     }
 
     /// Admin updates a participant's voting weight. Blocked once any participant has approved.
@@ -2505,6 +2536,10 @@ impl EscrowContract {
             .instance()
             .set(&DataKey::Escrow(EscrowKey::MultiParty(escrow_id)), &escrow);
 
+        env.storage()
+            .instance()
+            .set(&DataKey::VoteWeight(escrow_id, participant.clone()), &weight_bps);
+
         WeightUpdated {
             escrow_id,
             participant,
@@ -2546,6 +2581,10 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::Escrow(EscrowKey::MultiParty(escrow_id)), &escrow);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ReleaseThresholdBps(escrow_id), &threshold_bps);
 
         ThresholdUpdated {
             escrow_id,
@@ -8363,6 +8402,9 @@ mod swap_test;
 
 #[cfg(test)]
 mod hierarchy_test;
+
+#[cfg(test)]
+mod multi_party_weight_test;
 
 // mod test;
 

--- a/contracts/escrow/src/multi_party_weight_test.rs
+++ b/contracts/escrow/src/multi_party_weight_test.rs
@@ -1,0 +1,169 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, token, Address, Env, Vec};
+
+#[test]
+fn test_multi_party_escrow_weight_governance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let token_client = token::StellarAssetClient::new(&env, &token_id);
+    let token_user_client = token::Client::new(&env, &token_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let customer = Address::generate(&env);
+    token_client.mint(&customer, &10000);
+
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+    let p3 = Address::generate(&env);
+
+    let mut participants = Vec::new(&env);
+    // p1 has 60% share (6000 bps)
+    participants.push_back(Participant {
+        address: p1.clone(),
+        role: ParticipantRole::Merchant,
+        share_bps: 6000,
+        weight_bps: 1000, // weight_bps is ignored now, initialized based on share_bps (6000)
+        approved: false,
+        approved_at: None,
+    });
+    // p2 has 30% share (3000 bps)
+    participants.push_back(Participant {
+        address: p2.clone(),
+        role: ParticipantRole::ServiceProvider,
+        share_bps: 3000,
+        weight_bps: 1000, // will be initialized to 3000
+        approved: false,
+        approved_at: None,
+    });
+    // p3 has 10% share (1000 bps)
+    participants.push_back(Participant {
+        address: p3.clone(),
+        role: ParticipantRole::Arbitrator,
+        share_bps: 1000,
+        weight_bps: 8000, // will be initialized to 1000
+        approved: false,
+        approved_at: None,
+    });
+
+    let release_timestamp = 1000_u64;
+    env.ledger().set_timestamp(500);
+
+    let escrow_id = client.create_multi_party_escrow(
+        &customer,
+        &participants,
+        &10000,
+        &token_id,
+        &release_timestamp,
+    );
+
+    // Verify default threshold is 10000 bps
+    let (approved_wt, threshold_bps) = client.get_approval_weight(&escrow_id);
+    assert_eq!(approved_wt, 0);
+    assert_eq!(threshold_bps, 10000);
+
+    // p1 approves (60% weight, i.e. 6000 bps)
+    client.approve_release(&p1, &escrow_id);
+    let (approved_wt, _) = client.get_approval_weight(&escrow_id);
+    assert_eq!(approved_wt, 6000);
+
+    // Trying to release at 60% (6000 < 10000) should fail
+    env.ledger().set_timestamp(1001);
+    let release_res = client.try_release_multi_party_escrow(&escrow_id);
+    assert_eq!(release_res, Err(Ok(Error::Action(ActionError::ApprovalsThresholdNotMet))));
+
+    // Update threshold to 60% (6000 bps)
+    client.update_approval_threshold_bps(&admin, &escrow_id, &6000);
+    let (_, threshold_bps) = client.get_approval_weight(&escrow_id);
+    assert_eq!(threshold_bps, 6000);
+
+    // Now it should release successfully since approved weight (6000) >= threshold (6000)
+    let release_res2 = client.try_release_multi_party_escrow(&escrow_id);
+    assert!(release_res2.is_ok());
+
+    let escrow = client.get_multi_party_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+    assert_eq!(token_user_client.balance(&p1), 6000);
+    assert_eq!(token_user_client.balance(&p2), 3000);
+    assert_eq!(token_user_client.balance(&p3), 1000);
+}
+
+#[test]
+fn test_multi_party_escrow_set_participant_weight() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let token_client = token::StellarAssetClient::new(&env, &token_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let customer = Address::generate(&env);
+    token_client.mint(&customer, &10000);
+
+    let p1 = Address::generate(&env);
+    let p2 = Address::generate(&env);
+
+    let mut participants = Vec::new(&env);
+    participants.push_back(Participant {
+        address: p1.clone(),
+        role: ParticipantRole::Merchant,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
+    });
+    participants.push_back(Participant {
+        address: p2.clone(),
+        role: ParticipantRole::ServiceProvider,
+        share_bps: 5000,
+        weight_bps: 5000,
+        approved: false,
+        approved_at: None,
+    });
+
+    let release_timestamp = 1000_u64;
+    let escrow_id = client.create_multi_party_escrow(
+        &customer,
+        &participants,
+        &10000,
+        &token_id,
+        &release_timestamp,
+    );
+
+    // Initial weight of p1 = 5000, p2 = 5000.
+    // We update p1's weight to 5000, which keeps the total at 10000.
+    client.set_participant_weight(&admin, &escrow_id, &p1, &5000);
+
+    // Set threshold to 5000 bps
+    client.update_approval_threshold_bps(&admin, &escrow_id, &5000);
+
+    // p1 approves (has 5000 weight)
+    client.approve_release(&p1, &escrow_id);
+    let (approved_wt, threshold_bps) = client.get_approval_weight(&escrow_id);
+    assert_eq!(approved_wt, 5000);
+    assert_eq!(threshold_bps, 5000);
+
+    // Advance time and release
+    env.ledger().set_timestamp(1001);
+    let release_res = client.try_release_multi_party_escrow(&escrow_id);
+    assert!(release_res.is_ok());
+}


### PR DESCRIPTION
### Summary of Accomplishments

1. **Contract Logic Update ([lib.rs](file:///c:/Users/USER/Desktop/facilpay-contracts/contracts/escrow/src/lib.rs))**:
   - Added `DataKey::VoteWeight` and `DataKey::ReleaseThresholdBps` enums to manage and persist individual participant voting weights and release threshold requirements.
   - Initialized vote weights based on each participant's economic share (`share_bps`) on creation.
   - Updated the approval checking, releasing, threshold updating, and weight modifying methods to resolve and operate against the new persistent storage keys.

2. **Unit Testing ([multi_party_weight_test.rs](file:///c:/Users/USER/Desktop/facilpay-contracts/contracts/escrow/src/multi_party_weight_test.rs))**:
   - Added comprehensive tests verifying that voting weights are proportional to shares, threshold updates work, and release validation accurately prevents early release until the total weight threshold is met.
   - Ran `cargo test -p escrow` showing all **36 tests passed**.

3. **Commits**:
   - Split changes into two separate commits:
     - **Commit 1**: Contract logic and storage adjustments in `lib.rs`.
     - **Commit 2**: Test suite implementation in `multi_party_weight_test.rs`.

Please refer to the [walkthrough.md](file:///C:/Users/USER/.gemini/antigravity-ide/brain/a7fddeee-129e-4025-bf2f-c163141464e5/walkthrough.md) for full details!

Closes #352 