### PR TITLE
fix(payment): enforce sender-as-recipient guard and min split amount

### DIFF
--- a/contracts/escrow/src/bulk_evidence_test.rs
+++ b/contracts/escrow/src/bulk_evidence_test.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use crate::*;
-use soroban_sdk::{testutils::{Address as _, Ledger as _}, token, Address, Bytes, Env, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, Address, Bytes, Env, Vec,
+};
 
 fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address) {
     env.mock_all_auths();
@@ -27,8 +30,7 @@ fn make_disputed_escrow(
     token: &Address,
 ) -> u64 {
     let escrow_id = client.create_escrow(
-        customer, merchant, &500i128, token,
-        &9999u64, &0u64, &0u64, &false,
+        customer, merchant, &500i128, token, &9999u64, &0u64, &0u64, &false,
     );
     client.dispute_escrow(customer, &escrow_id);
     escrow_id
@@ -131,8 +133,7 @@ fn test_batch_on_non_disputed_escrow_rejected() {
 
     // Create escrow but do NOT dispute it — status stays Locked.
     let escrow_id = client.create_escrow(
-        &customer, &merchant, &500i128, &token,
-        &9999u64, &0u64, &0u64, &false,
+        &customer, &merchant, &500i128, &token, &9999u64, &0u64, &0u64, &false,
     );
 
     let mut items: Vec<Bytes> = Vec::new(&env);
@@ -178,7 +179,11 @@ fn test_oversized_batch_leaves_no_partial_state() {
 
     // No page should have been written — the page is empty.
     let page = client.get_evidence_page(&escrow_id, &0u32);
-    assert_eq!(page.len(), 0u32, "no partial state should be stored on failure");
+    assert_eq!(
+        page.len(),
+        0u32,
+        "no partial state should be stored on failure"
+    );
 }
 
 #[test]
@@ -213,7 +218,10 @@ fn test_merchant_can_submit_batch() {
     items.push_back(Bytes::from_array(&env, &[0xbbu8; 32]));
 
     let result = client.try_submit_evidence_batch(&merchant, &escrow_id, &items);
-    assert!(result.is_ok(), "merchant should be allowed to submit evidence");
+    assert!(
+        result.is_ok(),
+        "merchant should be allowed to submit evidence"
+    );
 
     let page = client.get_evidence_page(&escrow_id, &0u32);
     assert_eq!(page.len(), 2u32);
@@ -311,5 +319,8 @@ fn test_batch_rejected_after_evidence_deadline() {
     items.push_back(Bytes::from_array(&env, &[0xffu8; 32]));
 
     let result = client.try_submit_evidence_batch(&customer, &escrow_id, &items);
-    assert_eq!(result, Err(Ok(Error::Action(ActionError::EvidenceDeadlinePassed))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Action(ActionError::EvidenceDeadlinePassed)))
+    );
 }

--- a/contracts/escrow/src/expiry_test.rs
+++ b/contracts/escrow/src/expiry_test.rs
@@ -29,8 +29,9 @@ fn test_expire_escrow_success() {
 
     env.ledger().set_timestamp(1000);
     // release_timestamp=2000, expiry_timestamp=3000
-    let escrow_id =
-        client.create_escrow(&customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true);
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true,
+    );
 
     assert!(!client.is_escrow_expired(&escrow_id));
 
@@ -50,8 +51,9 @@ fn test_expire_escrow_premature_fails() {
     let (client, _admin, customer, merchant, token) = setup(&env);
 
     env.ledger().set_timestamp(1000);
-    let escrow_id =
-        client.create_escrow(&customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true);
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true,
+    );
 
     // Still before expiry
     env.ledger().set_timestamp(2500);
@@ -66,8 +68,9 @@ fn test_expire_disputed_escrow_fails() {
     let (client, _admin, customer, merchant, token) = setup(&env);
 
     env.ledger().set_timestamp(1000);
-    let escrow_id =
-        client.create_escrow(&customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true);
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &500_i128, &token, &2000_u64, &0_u64, &3000_u64, &true,
+    );
 
     client.dispute_escrow(&customer, &escrow_id);
 

--- a/contracts/escrow/src/hierarchy_test.rs
+++ b/contracts/escrow/src/hierarchy_test.rs
@@ -28,7 +28,10 @@ fn test_two_level_hierarchy_success() {
 
     // Verify parent release is blocked since child is unresolved (Locked)
     let release_res = client.try_release_escrow(&admin, &parent_id, &false);
-    assert_eq!(release_res, Err(Ok(Error::Escrow(EscrowError::ChildrenNotResolved))));
+    assert_eq!(
+        release_res,
+        Err(Ok(Error::Escrow(EscrowError::ChildrenNotResolved)))
+    );
 
     // Advance ledger timestamp so child can be released without early release check
     env.ledger().set_timestamp(2000);
@@ -76,7 +79,10 @@ fn test_depth_limit_enforced() {
     // Creating under level 3 (would be level 4) should fail with MaxHierarchyDepth
     let lvl4_res =
         client.try_create_child_escrow(&admin, &lvl3_id, &50_i128, &token, &customer, &merchant);
-    assert_eq!(lvl4_res, Err(Ok(Error::Escrow(EscrowError::MaxHierarchyDepth))));
+    assert_eq!(
+        lvl4_res,
+        Err(Ok(Error::Escrow(EscrowError::MaxHierarchyDepth)))
+    );
 }
 
 #[test]
@@ -156,5 +162,8 @@ fn test_create_child_escrow_validation() {
     // Non-existent parent fails with ParentEscrowNotFound
     let res2 =
         client.try_create_child_escrow(&admin, &999_u64, &100_i128, &token, &customer, &merchant);
-    assert_eq!(res2, Err(Ok(Error::Escrow(EscrowError::ParentEscrowNotFound))));
+    assert_eq!(
+        res2,
+        Err(Ok(Error::Escrow(EscrowError::ParentEscrowNotFound)))
+    );
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3,95 +3,186 @@
 #![no_std]
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, panic_with_error, token,
-    Address, Bytes, BytesN, Env, FromVal, IntoVal, String, TryFromVal, Val, Symbol, Vec,
+    Address, Bytes, BytesN, Env, FromVal, IntoVal, String, Symbol, TryFromVal, Val, Vec,
 };
 
 #[derive(Clone)]
 #[contracttype]
 pub enum ConfigKey {
-    AdminMultiSig, AdminProposal(String), AdminProposalCounter, AdminSuccessionPlan,
-    AdminClawbackRequest(u64), AdminClawbackCounter, AdminEscrowClawback(u64),
-    ReputationConfig, ReputationDecayConfig, TenureConfig, GlobalExpiryConfig,
-    EscalationConfig, WatchdogConfig, BatchLimit, PauseStateKey, PauseHistoryEntry(u64),
-    PauseHistoryCount, ActivePauseIndex(String), EscrowFeeConfig, StaleThresholdConfig,
-    DisputeConfig, InsurancePool, InsuranceConfig, TimeLockConfig, AdminClawbackEscrow(u64),
+    AdminMultiSig,
+    AdminProposal(String),
+    AdminProposalCounter,
+    AdminSuccessionPlan,
+    AdminClawbackRequest(u64),
+    AdminClawbackCounter,
+    AdminEscrowClawback(u64),
+    ReputationConfig,
+    ReputationDecayConfig,
+    TenureConfig,
+    GlobalExpiryConfig,
+    EscalationConfig,
+    WatchdogConfig,
+    BatchLimit,
+    PauseStateKey,
+    PauseHistoryEntry(u64),
+    PauseHistoryCount,
+    ActivePauseIndex(String),
+    EscrowFeeConfig,
+    StaleThresholdConfig,
+    DisputeConfig,
+    InsurancePool,
+    InsuranceConfig,
+    TimeLockConfig,
+    AdminClawbackEscrow(u64),
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum EscrowKey {
-    Data(u64), Counter, MultiParty(u64), MultiPartyCounter, CustomerList(Address, u64),
-    MerchantList(Address, u64), CustomerCount(Address), MerchantCount(Address),
-    Evidence(u64, u64), EvidenceCount(u64), EvidencePage(u64, u32), EvidencePageCount(u64),
-    EvidenceCommitment(u64), VestingSchedule(u64), VestingAccelerationConfig(u64),
-    Conditional(u64), OracleCondition(u64), MultiToken(u64), MultiTokenCounter, Hierarchy(u64),
-    Template(u64), TemplateCounter, SubAccount(u64, u64), SubAccountCounter(u64),
+    Data(u64),
+    Counter,
+    MultiParty(u64),
+    MultiPartyCounter,
+    CustomerList(Address, u64),
+    MerchantList(Address, u64),
+    CustomerCount(Address),
+    MerchantCount(Address),
+    Evidence(u64, u64),
+    EvidenceCount(u64),
+    EvidencePage(u64, u32),
+    EvidencePageCount(u64),
+    EvidenceCommitment(u64),
+    VestingSchedule(u64),
+    VestingAccelerationConfig(u64),
+    Conditional(u64),
+    OracleCondition(u64),
+    MultiToken(u64),
+    MultiTokenCounter,
+    Hierarchy(u64),
+    Template(u64),
+    TemplateCounter,
+    SubAccount(u64, u64),
+    SubAccountCounter(u64),
     EscrowHierarchy(u64),
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum ParticipantKey {
-    ReputationScore(Address), TenureBonusApplied(u64, Address),
-    CustomerAnalytics(Address), MerchantAnalytics(Address), AccumulatedFees(Address),
-    BeneficiaryTransferHistory(u64, u64), BeneficiaryTransferCount(u64),
+    ReputationScore(Address),
+    TenureBonusApplied(u64, Address),
+    CustomerAnalytics(Address),
+    MerchantAnalytics(Address),
+    AccumulatedFees(Address),
+    BeneficiaryTransferHistory(u64, u64),
+    BeneficiaryTransferCount(u64),
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum DisputeKey {
-    Action(u64), Counter, Collateral(u64), Appeal(u64), AppealCounter, Round(u64),
-    AppealsByEscrow(u64, u64), InsuranceClaim(u64), InsuranceClaimCounter,
-    MultiPartyDispute(u64), EscrowAnalytics, EscrowMigrationStatus, EscrowMigrated(u64),
-    EscrowRenewalConfig, EscrowRenewal(u64), EscrowRenewalCount(u64),
-    EscrowSwapConfig(u64), Observer(u64, u64), ObserverCount(u64),
+    Action(u64),
+    Counter,
+    Collateral(u64),
+    Appeal(u64),
+    AppealCounter,
+    Round(u64),
+    AppealsByEscrow(u64, u64),
+    InsuranceClaim(u64),
+    InsuranceClaimCounter,
+    MultiPartyDispute(u64),
+    EscrowAnalytics,
+    EscrowMigrationStatus,
+    EscrowMigrated(u64),
+    EscrowRenewalConfig,
+    EscrowRenewal(u64),
+    EscrowRenewalCount(u64),
+    EscrowSwapConfig(u64),
+    Observer(u64, u64),
+    ObserverCount(u64),
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
-    Config(ConfigKey), Escrow(EscrowKey), Participant(ParticipantKey), Dispute(DisputeKey),
+    Config(ConfigKey),
+    Escrow(EscrowKey),
+    Participant(ParticipantKey),
+    Dispute(DisputeKey),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 #[contracterror]
 pub enum BasicError {
-    Unauthorized = 100, NotAnAdmin = 101, AlreadyApproved = 102, ContractPaused = 103,
-    DuplicateApproval = 104, MultiSigNotInitialized = 105, MigrationNotStarted = 106,
-    AlreadyMigrated = 107, ParticipantNotFound = 108, InvalidMerkleProof = 109,
-    RootAlreadyCommitted = 110, InvalidBps = 111,
+    Unauthorized = 100,
+    NotAnAdmin = 101,
+    AlreadyApproved = 102,
+    ContractPaused = 103,
+    DuplicateApproval = 104,
+    MultiSigNotInitialized = 105,
+    MigrationNotStarted = 106,
+    AlreadyMigrated = 107,
+    ParticipantNotFound = 108,
+    InvalidMerkleProof = 109,
+    RootAlreadyCommitted = 110,
+    InvalidBps = 111,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 #[contracterror]
 pub enum EscrowError {
-    NotFound = 200, InvalidStatus = 201, AlreadyProcessed = 202,
-    ReleaseNotYetAvailable = 203, TimeoutNotReached = 204, ReleaseOnHoldPeriod = 205,
-    InvalidVestingSchedule = 206, CliffPeriodNotPassed = 207, MilestoneAlreadyReleased = 208,
-    EscrowNotExpired = 209, EscrowAlreadyExpired = 210, ExpiryBeforeRelease = 211,
-    TemplateNotFound = 212, TemplateInactive = 213, SubAccountNotFound = 214,
-    SubAccountAlreadyReleased = 215, SubAccountFundingExceedsEscrow = 216,
-    ConditionalEscrowNotFound = 217, ParentEscrowNotFound = 218, ChildrenNotResolved = 219,
-    MaxHierarchyDepth = 220, BatchTooLarge = 221
+    NotFound = 200,
+    InvalidStatus = 201,
+    AlreadyProcessed = 202,
+    ReleaseNotYetAvailable = 203,
+    TimeoutNotReached = 204,
+    ReleaseOnHoldPeriod = 205,
+    InvalidVestingSchedule = 206,
+    CliffPeriodNotPassed = 207,
+    MilestoneAlreadyReleased = 208,
+    EscrowNotExpired = 209,
+    EscrowAlreadyExpired = 210,
+    ExpiryBeforeRelease = 211,
+    TemplateNotFound = 212,
+    TemplateInactive = 213,
+    SubAccountNotFound = 214,
+    SubAccountAlreadyReleased = 215,
+    SubAccountFundingExceedsEscrow = 216,
+    ConditionalEscrowNotFound = 217,
+    ParentEscrowNotFound = 218,
+    ChildrenNotResolved = 219,
+    MaxHierarchyDepth = 220,
+    BatchTooLarge = 221,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 #[contracterror]
 pub enum ActionError {
-    NotReady = 300, NotDisputed = 301, ObserverAlreadyAdded = 302, ObserverNotFound = 303,
-    AccelerationLimitExceeded = 304, TransferNotAllowed = 305, SameBeneficiary = 306,
-    ConditionAlreadyEvaluated = 307, StaleThresholdNotConfigured = 308,
-    SwapConfigNotFound = 309, SwapOutputBelowMinimum = 310, SwapAlreadyExecuted = 311,
-    BatchReleaseSizeLimitExceeded = 312, EvidenceDeadlinePassed = 313,
+    NotReady = 300,
+    NotDisputed = 301,
+    ObserverAlreadyAdded = 302,
+    ObserverNotFound = 303,
+    AccelerationLimitExceeded = 304,
+    TransferNotAllowed = 305,
+    SameBeneficiary = 306,
+    ConditionAlreadyEvaluated = 307,
+    StaleThresholdNotConfigured = 308,
+    SwapConfigNotFound = 309,
+    SwapOutputBelowMinimum = 310,
+    SwapAlreadyExecuted = 311,
+    BatchReleaseSizeLimitExceeded = 312,
+    EvidenceDeadlinePassed = 313,
     ApprovalsThresholdNotMet = 314,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Error {
-    Basic(BasicError), Escrow(EscrowError), Action(ActionError),
+    Basic(BasicError),
+    Escrow(EscrowError),
+    Action(ActionError),
 }
 
 impl Error {
@@ -121,9 +212,15 @@ impl TryFrom<soroban_sdk::Error> for Error {
     fn try_from(error: soroban_sdk::Error) -> Result<Self, Self::Error> {
         if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) {
             let code = error.get_code();
-            if code >= 300 && code <= 314 { return Ok(Error::Action(unsafe { core::mem::transmute(code) })); }
-            if code >= 200 && code <= 221 { return Ok(Error::Escrow(unsafe { core::mem::transmute(code) })); }
-            if code >= 100 && code <= 111 { return Ok(Error::Basic(unsafe { core::mem::transmute(code) })); }
+            if code >= 300 && code <= 314 {
+                return Ok(Error::Action(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 200 && code <= 221 {
+                return Ok(Error::Escrow(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 100 && code <= 111 {
+                return Ok(Error::Basic(unsafe { core::mem::transmute(code) }));
+            }
         }
         Err(error)
     }
@@ -138,13 +235,11 @@ impl FromVal<Env, Error> for Val {
 impl TryFromVal<Env, Val> for Error {
     type Error = soroban_sdk::ConversionError;
     fn try_from_val(env: &Env, val: &Val) -> Result<Self, Self::Error> {
-        let error: soroban_sdk::Error = soroban_sdk::Error::try_from_val(env, val).map_err(|_| soroban_sdk::ConversionError)?;
+        let error: soroban_sdk::Error =
+            soroban_sdk::Error::try_from_val(env, val).map_err(|_| soroban_sdk::ConversionError)?;
         Error::try_from(error).map_err(|_| soroban_sdk::ConversionError)
     }
 }
-
-
-
 
 /// Secondary storage keys (keeps `DataKey` within Soroban's 50-variant limit).
 
@@ -178,7 +273,7 @@ pub struct EscalationConfig {
 #[derive(Clone)]
 #[contracttype]
 pub struct EscrowFeeConfig {
-    pub fee_bps: i128, 
+    pub fee_bps: i128,
     pub fee_recipient: Address,
     pub enabled: bool,
 }
@@ -1405,7 +1500,11 @@ pub struct EscrowContract;
 #[contractimpl]
 impl EscrowContract {
     pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&DataKey::Config(ConfigKey::AdminMultiSig)) {
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::Config(ConfigKey::AdminMultiSig))
+        {
             panic!("already initialized");
         }
         let config = MultiSigConfig {
@@ -1454,7 +1553,9 @@ impl EscrowContract {
     pub fn get_accumulated_escrow_fees(env: Env, token: Address) -> i128 {
         env.storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(token)))
+            .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(
+                token,
+            )))
             .unwrap_or(0)
     }
 
@@ -1473,16 +1574,19 @@ impl EscrowContract {
         let amount: i128 = env
             .storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(token.clone())))
+            .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(
+                token.clone(),
+            )))
             .unwrap_or(0);
         if amount == 0 {
             return Ok(0);
         }
 
         Self::transfer_if_token_contract(&env, &token, &to, amount)?;
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::AccumulatedFees(token.clone())), &0i128);
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::AccumulatedFees(token.clone())),
+            &0i128,
+        );
 
         EscrowFeesWithdrawn {
             amount,
@@ -1549,9 +1653,10 @@ impl EscrowContract {
             expires_at: now + config.proposal_ttl,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         ActionProposed {
             proposal_id: proposal_id.clone(),
@@ -1579,7 +1684,9 @@ impl EscrowContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())))
+            .get(&DataKey::Config(ConfigKey::AdminProposal(
+                proposal_id.clone(),
+            )))
             .ok_or(Error::Basic(BasicError::Unauthorized))?;
 
         if proposal.executed || proposal.rejected {
@@ -1597,9 +1704,10 @@ impl EscrowContract {
         proposal.approvals.push_back(approver.clone());
         proposal.approval_count += 1;
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         ActionApproved {
             proposal_id,
@@ -1621,7 +1729,9 @@ impl EscrowContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())))
+            .get(&DataKey::Config(ConfigKey::AdminProposal(
+                proposal_id.clone(),
+            )))
             .ok_or(Error::Basic(BasicError::Unauthorized))?;
 
         if proposal.executed || proposal.rejected {
@@ -1637,9 +1747,10 @@ impl EscrowContract {
         }
 
         proposal.executed = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         EscrowContract::dispatch_action(&env, &proposal)?;
 
@@ -1664,7 +1775,9 @@ impl EscrowContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())))
+            .get(&DataKey::Config(ConfigKey::AdminProposal(
+                proposal_id.clone(),
+            )))
             .ok_or(Error::Basic(BasicError::Unauthorized))?;
 
         if proposal.executed || proposal.rejected {
@@ -1672,9 +1785,10 @@ impl EscrowContract {
         }
 
         proposal.rejected = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         ActionRejected {
             proposal_id,
@@ -1871,14 +1985,18 @@ impl EscrowContract {
             return Err(Error::Escrow(EscrowError::AlreadyProcessed));
         }
 
-        env.storage().instance().remove(&DataKey::Config(ConfigKey::AdminSuccessionPlan));
+        env.storage()
+            .instance()
+            .remove(&DataKey::Config(ConfigKey::AdminSuccessionPlan));
         SuccessionRevoked { revoked_by: admin }.publish(&env);
 
         Ok(())
     }
 
     pub fn get_succession_plan(env: Env) -> Option<SuccessionPlan> {
-        env.storage().instance().get(&DataKey::Config(ConfigKey::AdminSuccessionPlan))
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::AdminSuccessionPlan))
     }
 
     pub fn initiate_clawback(
@@ -1899,7 +2017,11 @@ impl EscrowContract {
             panic!("delay_seconds must be at least 86400");
         }
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -1908,10 +2030,12 @@ impl EscrowContract {
             .instance()
             .get::<DataKey, u64>(&DataKey::Config(ConfigKey::AdminClawbackEscrow(escrow_id)))
         {
-            if let Some(request) = env
-                .storage()
-                .instance()
-                .get::<DataKey, ClawbackRequest>(&DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)))
+            if let Some(request) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, ClawbackRequest>(&DataKey::Config(
+                        ConfigKey::AdminClawbackRequest(request_id),
+                    ))
             {
                 if !request.executed && !request.cancelled {
                     return Err(Error::Escrow(EscrowError::AlreadyProcessed));
@@ -1940,12 +2064,14 @@ impl EscrowContract {
             cancelled: false,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminClawbackRequest(counter)), &request);
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminClawbackEscrow(escrow_id)), &counter);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminClawbackRequest(counter)),
+            &request,
+        );
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminClawbackEscrow(escrow_id)),
+            &counter,
+        );
 
         Ok(counter)
     }
@@ -1961,7 +2087,9 @@ impl EscrowContract {
         let mut request: ClawbackRequest = env
             .storage()
             .instance()
-            .get(&DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)))
+            .get(&DataKey::Config(ConfigKey::AdminClawbackRequest(
+                request_id,
+            )))
             .ok_or(Error::Basic(BasicError::Unauthorized))?;
 
         if request.executed {
@@ -1984,14 +2112,16 @@ impl EscrowContract {
 
         let mut updated_escrow = escrow;
         updated_escrow.status = EscrowStatus::Resolved;
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Data(request.escrow_id)), &updated_escrow);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Data(request.escrow_id)),
+            &updated_escrow,
+        );
 
         request.executed = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)), &request);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)),
+            &request,
+        );
 
         Ok(())
     }
@@ -2007,7 +2137,9 @@ impl EscrowContract {
         let mut request: ClawbackRequest = env
             .storage()
             .instance()
-            .get(&DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)))
+            .get(&DataKey::Config(ConfigKey::AdminClawbackRequest(
+                request_id,
+            )))
             .ok_or(Error::Basic(BasicError::Unauthorized))?;
 
         if request.executed {
@@ -2018,9 +2150,10 @@ impl EscrowContract {
         }
 
         request.cancelled = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)), &request);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)),
+            &request,
+        );
 
         Ok(())
     }
@@ -2028,7 +2161,9 @@ impl EscrowContract {
     pub fn get_clawback_request(env: Env, request_id: u64) -> Option<ClawbackRequest> {
         env.storage()
             .instance()
-            .get(&DataKey::Config(ConfigKey::AdminClawbackRequest(request_id)))
+            .get(&DataKey::Config(ConfigKey::AdminClawbackRequest(
+                request_id,
+            )))
     }
 
     pub fn create_escrow(
@@ -2726,7 +2861,11 @@ impl EscrowContract {
     fn can_release_escrow(env: Env, escrow_id: u64, early_release: bool) -> Result<(), Error> {
         let current_time: u64 = env.ledger().timestamp();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -2744,10 +2883,12 @@ impl EscrowContract {
             .get(&DataKey::Escrow(EscrowKey::SubAccountCounter(escrow_id)))
             .unwrap_or(0);
         for sub_id in 1..=sub_count {
-            if let Some(sub) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)))
+            if let Some(sub) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(
+                        escrow_id, sub_id,
+                    )))
             {
                 if !sub.released {
                     return Err(Error::Escrow(EscrowError::InvalidStatus));
@@ -2811,12 +2952,15 @@ impl EscrowContract {
                 let mut acc: i128 = env
                     .storage()
                     .instance()
-                    .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(escrow.token.clone())))
+                    .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(
+                        escrow.token.clone(),
+                    )))
                     .unwrap_or(0);
                 acc += fee_amount;
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Participant(ParticipantKey::AccumulatedFees(escrow.token.clone())), &acc);
+                env.storage().instance().set(
+                    &DataKey::Participant(ParticipantKey::AccumulatedFees(escrow.token.clone())),
+                    &acc,
+                );
             }
 
             EscrowFeeCollected {
@@ -2898,7 +3042,11 @@ impl EscrowContract {
     pub fn refund_escrow(env: Env, caller: Address, escrow_id: u64) -> Result<(), Error> {
         caller.require_auth();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -2940,7 +3088,11 @@ impl EscrowContract {
         caller.require_auth();
 
         // Check if escrow exists
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -2968,9 +3120,10 @@ impl EscrowContract {
                 token: config.collateral_token.clone(),
                 deposited_at: env.ledger().timestamp(),
             };
-            env.storage()
-                .instance()
-                .set(&DataKey::Dispute(DisputeKey::Collateral(escrow_id)), &collateral);
+            env.storage().instance().set(
+                &DataKey::Dispute(DisputeKey::Collateral(escrow_id)),
+                &collateral,
+            );
 
             CollateralDeposited {
                 escrow_id,
@@ -3049,7 +3202,11 @@ impl EscrowContract {
         ipfs_hash: String,
     ) -> Result<(), Error> {
         caller.require_auth();
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let escrow = EscrowContract::get_escrow(&env, escrow_id);
@@ -3085,7 +3242,11 @@ impl EscrowContract {
         merkle_root: BytesN<32>,
     ) -> Result<(), Error> {
         caller.require_auth();
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let escrow = EscrowContract::get_escrow(&env, escrow_id);
@@ -3108,9 +3269,10 @@ impl EscrowContract {
             committed_at: env.ledger().timestamp(),
             committed_by: caller,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::EvidenceCommitment(escrow_id)), &commitment);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::EvidenceCommitment(escrow_id)),
+            &commitment,
+        );
         Ok(())
     }
 
@@ -3130,7 +3292,11 @@ impl EscrowContract {
         leaf_index: u32,
     ) -> Result<(), Error> {
         caller.require_auth();
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let escrow_check = EscrowContract::get_escrow(&env, escrow_id);
@@ -3141,10 +3307,12 @@ impl EscrowContract {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
 
-        let commitment_opt = env
-            .storage()
-            .instance()
-            .get::<DataKey, EvidenceCommitment>(&DataKey::Escrow(EscrowKey::EvidenceCommitment(escrow_id)));
+        let commitment_opt =
+            env.storage()
+                .instance()
+                .get::<DataKey, EvidenceCommitment>(&DataKey::Escrow(
+                    EscrowKey::EvidenceCommitment(escrow_id),
+                ));
 
         if commitment_opt.is_none() {
             let ipfs_hash = EscrowContract::evidence_bytes_to_label_string(&env, evidence);
@@ -3168,12 +3336,18 @@ impl EscrowContract {
     }
 
     pub fn get_evidence_commitment(env: Env, escrow_id: u64) -> Result<EvidenceCommitment, Error> {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         env.storage()
             .instance()
-            .get::<DataKey, EvidenceCommitment>(&DataKey::Escrow(EscrowKey::EvidenceCommitment(escrow_id)))
+            .get::<DataKey, EvidenceCommitment>(&DataKey::Escrow(EscrowKey::EvidenceCommitment(
+                escrow_id,
+            )))
             .ok_or(Error::Basic(BasicError::RootAlreadyCommitted))
     }
 
@@ -3238,12 +3412,14 @@ impl EscrowContract {
             ipfs_hash: ipfs_hash.clone(),
             submitted_at: env.ledger().timestamp(),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Evidence(escrow_id, count)), &evidence);
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::EvidenceCount(escrow_id)), &(count + 1));
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Evidence(escrow_id, count)),
+            &evidence,
+        );
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::EvidenceCount(escrow_id)),
+            &(count + 1),
+        );
         let mut escrow = EscrowContract::get_escrow(env, escrow_id);
         escrow.last_activity_at = env.ledger().timestamp();
         env.storage()
@@ -3294,7 +3470,11 @@ impl EscrowContract {
     ) -> Result<u32, Error> {
         caller.require_auth();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -3341,9 +3521,10 @@ impl EscrowContract {
             });
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::EvidencePage(escrow_id, page_num)), &page);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::EvidencePage(escrow_id, page_num)),
+            &page,
+        );
         env.storage().instance().set(
             &DataKey::Escrow(EscrowKey::EvidencePageCount(escrow_id)),
             &(page_num + 1),
@@ -3361,7 +3542,11 @@ impl EscrowContract {
 
     pub fn escalate_dispute(env: Env, caller: Address, escrow_id: u64) -> Result<(), Error> {
         caller.require_auth();
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let mut escrow = EscrowContract::get_escrow(&env, escrow_id);
@@ -3387,7 +3572,11 @@ impl EscrowContract {
     }
 
     pub fn auto_resolve_dispute(env: Env, escrow_id: u64) -> Result<(), Error> {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let mut escrow = EscrowContract::get_escrow(&env, escrow_id);
@@ -3450,7 +3639,10 @@ impl EscrowContract {
     }
 
     pub fn check_escalation_timeout(env: Env, escrow_id: u64) -> bool {
-        let escrow: Option<Escrow> = env.storage().instance().get(&DataKey::Escrow(EscrowKey::Data(escrow_id)));
+        let escrow: Option<Escrow> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Escrow(EscrowKey::Data(escrow_id)));
         let escrow = match escrow {
             Some(e) => e,
             None => return false,
@@ -3464,7 +3656,11 @@ impl EscrowContract {
     }
 
     pub fn trigger_timeout_resolution(env: Env, escrow_id: u64) -> Result<(), Error> {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -3474,7 +3670,9 @@ impl EscrowContract {
             return Err(Error::Action(ActionError::NotDisputed));
         }
 
-        let escalated_at = escrow.escalated_at.ok_or(Error::Escrow(EscrowError::InvalidStatus))?;
+        let escalated_at = escrow
+            .escalated_at
+            .ok_or(Error::Escrow(EscrowError::InvalidStatus))?;
 
         let now = env.ledger().timestamp();
         if now.saturating_sub(escalated_at) < escrow.escalation_timeout {
@@ -3569,7 +3767,11 @@ impl EscrowContract {
         release_to_merchant: bool,
     ) -> Result<(), Error> {
         // Check if escrow exists
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -3726,7 +3928,11 @@ impl EscrowContract {
         appellant.require_auth();
 
         // Check if escrow exists and is in Resolved or Released status from initial dispute
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -3791,9 +3997,10 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::Dispute(DisputeKey::Appeal(appeal_id)), &appeal);
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::AppealCounter), &(appeals_count + 1));
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::AppealCounter),
+            &(appeals_count + 1),
+        );
 
         // Update dispute round to Appeal
         env.storage().instance().set(
@@ -3854,7 +4061,11 @@ impl EscrowContract {
         let escrow_id = appeal.escrow_id;
 
         // Get the escrow
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -3995,7 +4206,10 @@ impl EscrowContract {
             if let Some(escrow_id) = env
                 .storage()
                 .instance()
-                .get::<DataKey, u64>(&DataKey::Escrow(EscrowKey::CustomerList(customer.clone(), i)))
+                .get::<DataKey, u64>(&DataKey::Escrow(EscrowKey::CustomerList(
+                    customer.clone(),
+                    i,
+                )))
             {
                 if let Some(escrow) = env
                     .storage()
@@ -4037,7 +4251,10 @@ impl EscrowContract {
             if let Some(escrow_id) = env
                 .storage()
                 .instance()
-                .get::<DataKey, u64>(&DataKey::Escrow(EscrowKey::MerchantList(merchant.clone(), i)))
+                .get::<DataKey, u64>(&DataKey::Escrow(EscrowKey::MerchantList(
+                    merchant.clone(),
+                    i,
+                )))
             {
                 if let Some(escrow) = env
                     .storage()
@@ -4127,7 +4344,11 @@ impl EscrowContract {
     ) -> Result<(), Error> {
         granter.require_auth();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -4155,10 +4376,12 @@ impl EscrowContract {
 
         let mut i = 0u64;
         while i < count {
-            if let Some(existing) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(escrow_id, i)))
+            if let Some(existing) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(
+                        escrow_id, i,
+                    )))
             {
                 if existing.observer == observer && existing.expires_at > now {
                     return Err(Error::Action(ActionError::ObserverAlreadyAdded));
@@ -4175,12 +4398,14 @@ impl EscrowContract {
             expires_at: now.saturating_add(duration_seconds),
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::Observer(escrow_id, count)), &obs);
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::ObserverCount(escrow_id)), &(count + 1));
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::Observer(escrow_id, count)),
+            &obs,
+        );
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::ObserverCount(escrow_id)),
+            &(count + 1),
+        );
 
         Ok(())
     }
@@ -4194,7 +4419,11 @@ impl EscrowContract {
     ) -> Result<(), Error> {
         granter.require_auth();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -4221,19 +4450,19 @@ impl EscrowContract {
 
         let mut i = 0u64;
         while i < count {
-            if let Some(existing) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(escrow_id, i)))
+            if let Some(existing) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(
+                        escrow_id, i,
+                    )))
             {
                 if existing.observer == observer {
                     let last_index = count.saturating_sub(1);
                     if i != last_index {
-                        if let Some(last) =
-                            env.storage().instance().get::<DataKey, EscrowObserver>(
-                                &DataKey::Dispute(DisputeKey::Observer(escrow_id, last_index)),
-                            )
-                        {
+                        if let Some(last) = env.storage().instance().get::<DataKey, EscrowObserver>(
+                            &DataKey::Dispute(DisputeKey::Observer(escrow_id, last_index)),
+                        ) {
                             env.storage()
                                 .instance()
                                 .set(&DataKey::Dispute(DisputeKey::Observer(escrow_id, i)), &last);
@@ -4241,10 +4470,13 @@ impl EscrowContract {
                     }
                     env.storage()
                         .instance()
-                        .remove(&DataKey::Dispute(DisputeKey::Observer(escrow_id, last_index)));
-                    env.storage()
-                        .instance()
-                        .set(&DataKey::Dispute(DisputeKey::ObserverCount(escrow_id)), &last_index);
+                        .remove(&DataKey::Dispute(DisputeKey::Observer(
+                            escrow_id, last_index,
+                        )));
+                    env.storage().instance().set(
+                        &DataKey::Dispute(DisputeKey::ObserverCount(escrow_id)),
+                        &last_index,
+                    );
                     return Ok(());
                 }
             }
@@ -4264,10 +4496,12 @@ impl EscrowContract {
         let mut items: Vec<EscrowObserver> = Vec::new(&env);
         let mut i = 0u64;
         while i < total {
-            if let Some(o) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(escrow_id, i)))
+            if let Some(o) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(
+                        escrow_id, i,
+                    )))
             {
                 items.push_back(o);
             }
@@ -4287,10 +4521,12 @@ impl EscrowContract {
             .unwrap_or(0);
         let mut i = 0u64;
         while i < total {
-            if let Some(o) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(escrow_id, i)))
+            if let Some(o) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowObserver>(&DataKey::Dispute(DisputeKey::Observer(
+                        escrow_id, i,
+                    )))
             {
                 if o.observer == observer {
                     return o.expires_at > now;
@@ -4344,7 +4580,9 @@ impl EscrowContract {
     fn get_or_default_reputation(env: &Env, address: &Address) -> ReputationScore {
         env.storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::ReputationScore(address.clone())))
+            .get(&DataKey::Participant(ParticipantKey::ReputationScore(
+                address.clone(),
+            )))
             .unwrap_or(ReputationScore {
                 address: address.clone(),
                 total_transactions: 0,
@@ -4379,9 +4617,10 @@ impl EscrowContract {
         rep.score = (rep.score + config.completion_reward).min(10000);
         rep.total_transactions = rep.total_transactions.saturating_add(1);
         rep.last_updated = env.ledger().timestamp();
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::ReputationScore(address.clone())), &rep);
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::ReputationScore(address.clone())),
+            &rep,
+        );
         ReputationUpdated {
             address: address.clone(),
             old_score,
@@ -4402,9 +4641,10 @@ impl EscrowContract {
         winner_rep.score = (winner_rep.score + config.win_reward).min(10000);
         winner_rep.disputes_won = winner_rep.disputes_won.saturating_add(1);
         winner_rep.last_updated = now;
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::ReputationScore(winner.clone())), &winner_rep);
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::ReputationScore(winner.clone())),
+            &winner_rep,
+        );
         ReputationUpdated {
             address: winner.clone(),
             old_score: old_winner_score,
@@ -4418,9 +4658,10 @@ impl EscrowContract {
         loser_rep.score = (loser_rep.score - config.loss_penalty).max(0);
         loser_rep.disputes_lost = loser_rep.disputes_lost.saturating_add(1);
         loser_rep.last_updated = now;
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::ReputationScore(loser.clone())), &loser_rep);
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::ReputationScore(loser.clone())),
+            &loser_rep,
+        );
         ReputationUpdated {
             address: loser.clone(),
             old_score: old_loser_score,
@@ -4452,7 +4693,9 @@ impl EscrowContract {
 
     /// Returns the tenure reputation configuration, or `None` if unset.
     pub fn get_tenure_config(env: Env) -> Option<TenureReputationConfig> {
-        env.storage().instance().get(&DataKey::Config(ConfigKey::TenureConfig))
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::TenureConfig))
     }
 
     /// Computes the duration-weighted tenure bonus for an escrow:
@@ -4484,9 +4727,13 @@ impl EscrowContract {
     /// `base_score` plus the duration-weighted bonus to the participant's
     /// reputation. Disputed escrows are ineligible and receive nothing.
     pub fn apply_tenure_bonus(env: Env, escrow_id: u64, participant: Address) -> Result<(), Error> {
-        let config = Self::get_tenure_config(env.clone()).ok_or(Error::Escrow(EscrowError::NotFound))?;
+        let config =
+            Self::get_tenure_config(env.clone()).ok_or(Error::Escrow(EscrowError::NotFound))?;
 
-        let marker = DataKey::Participant(ParticipantKey::TenureBonusApplied(escrow_id, participant.clone()));
+        let marker = DataKey::Participant(ParticipantKey::TenureBonusApplied(
+            escrow_id,
+            participant.clone(),
+        ));
         if env.storage().instance().has(&marker) {
             return Err(Error::Escrow(EscrowError::AlreadyProcessed));
         }
@@ -4506,9 +4753,10 @@ impl EscrowContract {
             let old_score = rep.score;
             rep.score = (rep.score + increase).min(10000);
             rep.last_updated = env.ledger().timestamp();
-            env.storage()
-                .instance()
-                .set(&DataKey::Participant(ParticipantKey::ReputationScore(participant.clone())), &rep);
+            env.storage().instance().set(
+                &DataKey::Participant(ParticipantKey::ReputationScore(participant.clone())),
+                &rep,
+            );
             ReputationUpdated {
                 address: participant.clone(),
                 old_score,
@@ -4685,9 +4933,10 @@ impl EscrowContract {
             milestones: indexed_milestones,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)), &vesting_schedule);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)),
+            &vesting_schedule,
+        );
 
         // Index by customer
         let customer_count: u64 = env
@@ -4747,14 +4996,16 @@ impl EscrowContract {
     }
 
     fn get_base_vested_amount(env: &Env, escrow_id: u64) -> i128 {
-        let vesting_schedule = match env
-            .storage()
-            .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
-        {
-            Some(schedule) => schedule,
-            None => return 0,
-        };
+        let vesting_schedule =
+            match env
+                .storage()
+                .instance()
+                .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                    escrow_id,
+                ))) {
+                Some(schedule) => schedule,
+                None => return 0,
+            };
 
         let current_timestamp = env.ledger().timestamp();
 
@@ -4794,14 +5045,16 @@ impl EscrowContract {
     }
 
     pub fn get_vested_amount(env: Env, escrow_id: u64) -> i128 {
-        let vesting_schedule = match env
-            .storage()
-            .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
-        {
-            Some(schedule) => schedule,
-            None => return 0,
-        };
+        let vesting_schedule =
+            match env
+                .storage()
+                .instance()
+                .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                    escrow_id,
+                ))) {
+                Some(schedule) => schedule,
+                None => return 0,
+            };
 
         let base_vested = Self::get_base_vested_amount(&env, escrow_id);
         let accelerated_amount = Self::calculate_accelerated_amount(env.clone(), escrow_id);
@@ -4831,14 +5084,16 @@ impl EscrowContract {
             return Err(Error::Escrow(EscrowError::InvalidVestingSchedule));
         }
 
-        if milestone_bps > max_acceleration_bps{
+        if milestone_bps > max_acceleration_bps {
             return Err(Error::Escrow(EscrowError::InvalidVestingSchedule));
         }
 
         if env
             .storage()
             .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(schedule_id)))
+            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                schedule_id,
+            )))
             .is_none()
         {
             return Err(Error::Escrow(EscrowError::NotFound));
@@ -4873,9 +5128,9 @@ impl EscrowContract {
         let mut acceleration_config = env
             .storage()
             .instance()
-            .get::<DataKey, VestingAccelerationConfig>(&DataKey::Escrow(EscrowKey::VestingAccelerationConfig(
-                schedule_id,
-            )))
+            .get::<DataKey, VestingAccelerationConfig>(&DataKey::Escrow(
+                EscrowKey::VestingAccelerationConfig(schedule_id),
+            ))
             .ok_or(Error::Escrow(EscrowError::NotFound))?;
 
         if acceleration_config.total_accelerated_bps >= acceleration_config.max_acceleration_bps {
@@ -4904,25 +5159,29 @@ impl EscrowContract {
     ) -> Option<VestingAccelerationConfig> {
         env.storage()
             .instance()
-            .get(&DataKey::Escrow(EscrowKey::VestingAccelerationConfig(schedule_id)))
+            .get(&DataKey::Escrow(EscrowKey::VestingAccelerationConfig(
+                schedule_id,
+            )))
     }
 
     pub fn calculate_accelerated_amount(env: Env, schedule_id: u64) -> i128 {
-        let vesting_schedule = match env
-            .storage()
-            .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(schedule_id)))
-        {
-            Some(schedule) => schedule,
-            None => return 0,
-        };
+        let vesting_schedule =
+            match env
+                .storage()
+                .instance()
+                .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                    schedule_id,
+                ))) {
+                Some(schedule) => schedule,
+                None => return 0,
+            };
 
         let acceleration_config = match env
             .storage()
             .instance()
-            .get::<DataKey, VestingAccelerationConfig>(&DataKey::Escrow(EscrowKey::VestingAccelerationConfig(
-                schedule_id,
-            ))) {
+            .get::<DataKey, VestingAccelerationConfig>(&DataKey::Escrow(
+                EscrowKey::VestingAccelerationConfig(schedule_id),
+            )) {
             Some(config) => config,
             None => return 0,
         };
@@ -4941,7 +5200,9 @@ impl EscrowContract {
         let vesting_schedule = env
             .storage()
             .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
+            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                escrow_id,
+            )))
             .ok_or(Error::Escrow(EscrowError::NotFound))?;
 
         let now = env.ledger().timestamp();
@@ -4969,14 +5230,16 @@ impl EscrowContract {
     /// # Returns
     /// The amount that can be released
     pub fn get_releasable_amount(env: Env, escrow_id: u64) -> i128 {
-        let vesting_schedule = match env
-            .storage()
-            .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
-        {
-            Some(schedule) => schedule,
-            None => return 0,
-        };
+        let vesting_schedule =
+            match env
+                .storage()
+                .instance()
+                .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                    escrow_id,
+                ))) {
+                Some(schedule) => schedule,
+                None => return 0,
+            };
 
         let vested_amount = EscrowContract::get_vested_amount(env, escrow_id);
         vested_amount.saturating_sub(vesting_schedule.released_amount)
@@ -5001,14 +5264,20 @@ impl EscrowContract {
         admin.require_auth();
 
         // Check if escrow exists
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
         let mut vesting_schedule = env
             .storage()
             .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
+            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                escrow_id,
+            )))
             .ok_or(Error::Escrow(EscrowError::NotFound))?;
 
         let current_timestamp = env.ledger().timestamp();
@@ -5057,9 +5326,10 @@ impl EscrowContract {
         }
 
         // Update storage
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)), &vesting_schedule);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)),
+            &vesting_schedule,
+        );
 
         VestedAmountReleased {
             escrow_id,
@@ -5094,7 +5364,9 @@ impl EscrowContract {
         let mut vesting_schedule = env
             .storage()
             .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
+            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                escrow_id,
+            )))
             .ok_or(Error::Escrow(EscrowError::NotFound))?;
 
         let mut found = false;
@@ -5119,9 +5391,10 @@ impl EscrowContract {
         }
 
         vesting_schedule.milestones = milestones;
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)), &vesting_schedule);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)),
+            &vesting_schedule,
+        );
 
         MilestoneApproved {
             escrow_id,
@@ -5145,7 +5418,9 @@ impl EscrowContract {
         let mut vesting_schedule = env
             .storage()
             .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
+            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                escrow_id,
+            )))
             .ok_or(Error::Escrow(EscrowError::NotFound))?;
 
         let escrow: Escrow = env
@@ -5189,9 +5464,10 @@ impl EscrowContract {
             .released_amount
             .saturating_add(release_amount);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)), &vesting_schedule);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)),
+            &vesting_schedule,
+        );
 
         // Transfer to merchant
         EscrowContract::transfer_if_token_contract(
@@ -5213,14 +5489,16 @@ impl EscrowContract {
 
     /// Returns all milestones that have not yet been released.
     pub fn get_pending_milestones(env: Env, escrow_id: u64) -> Vec<VestingMilestone> {
-        let vesting_schedule = match env
-            .storage()
-            .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
-        {
-            Some(s) => s,
-            None => return Vec::new(&env),
-        };
+        let vesting_schedule =
+            match env
+                .storage()
+                .instance()
+                .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                    escrow_id,
+                ))) {
+                Some(s) => s,
+                None => return Vec::new(&env),
+            };
 
         let mut pending = Vec::new(&env);
         for m in vesting_schedule.milestones.iter() {
@@ -5255,7 +5533,9 @@ impl EscrowContract {
         let mut vesting_schedule = env
             .storage()
             .instance()
-            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)))
+            .get::<DataKey, VestingSchedule>(&DataKey::Escrow(EscrowKey::VestingSchedule(
+                escrow_id,
+            )))
             .ok_or(Error::Escrow(EscrowError::NotFound))?;
 
         // Sum existing milestone amounts
@@ -5282,9 +5562,10 @@ impl EscrowContract {
         }
 
         vesting_schedule.milestones.push_back(new_milestone);
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)), &vesting_schedule);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::VestingSchedule(escrow_id)),
+            &vesting_schedule,
+        );
 
         Ok(())
     }
@@ -5346,7 +5627,11 @@ impl EscrowContract {
                 let escrow_id = EscrowContract::read_u64_from_bytes(&proposal.data, 0);
                 let early_release = proposal.data.get(8).unwrap_or(0) != 0;
 
-                if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+                if !env
+                    .storage()
+                    .instance()
+                    .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+                {
                     return Err(Error::Escrow(EscrowError::NotFound));
                 }
 
@@ -5365,10 +5650,18 @@ impl EscrowContract {
                         }
                         escrow.status = EscrowStatus::Released;
                     }
-                    EscrowStatus::Released => return Err(Error::Escrow(EscrowError::AlreadyProcessed)),
-                    EscrowStatus::Disputed => return Err(Error::Escrow(EscrowError::InvalidStatus)),
-                    EscrowStatus::Resolved => return Err(Error::Escrow(EscrowError::AlreadyProcessed)),
-                    EscrowStatus::Cancelled => return Err(Error::Escrow(EscrowError::AlreadyProcessed)),
+                    EscrowStatus::Released => {
+                        return Err(Error::Escrow(EscrowError::AlreadyProcessed))
+                    }
+                    EscrowStatus::Disputed => {
+                        return Err(Error::Escrow(EscrowError::InvalidStatus))
+                    }
+                    EscrowStatus::Resolved => {
+                        return Err(Error::Escrow(EscrowError::AlreadyProcessed))
+                    }
+                    EscrowStatus::Cancelled => {
+                        return Err(Error::Escrow(EscrowError::AlreadyProcessed))
+                    }
                 }
 
                 env.storage()
@@ -5391,12 +5684,17 @@ impl EscrowContract {
                         let mut acc: i128 = env
                             .storage()
                             .instance()
-                            .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(escrow.token.clone())))
+                            .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(
+                                escrow.token.clone(),
+                            )))
                             .unwrap_or(0);
                         acc += fee_amount;
-                        env.storage()
-                            .instance()
-                            .set(&DataKey::Participant(ParticipantKey::AccumulatedFees(escrow.token.clone())), &acc);
+                        env.storage().instance().set(
+                            &DataKey::Participant(ParticipantKey::AccumulatedFees(
+                                escrow.token.clone(),
+                            )),
+                            &acc,
+                        );
                     }
 
                     EscrowFeeCollected {
@@ -5459,7 +5757,11 @@ impl EscrowContract {
                 let escrow_id = EscrowContract::read_u64_from_bytes(&proposal.data, 0);
                 let release_to_merchant = proposal.data.get(8).unwrap_or(0) != 0;
 
-                if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+                if !env
+                    .storage()
+                    .instance()
+                    .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+                {
                     return Err(Error::Escrow(EscrowError::NotFound));
                 }
 
@@ -5812,14 +6114,18 @@ impl EscrowContract {
     pub fn get_merchant_analytics(env: Env, merchant: Address) -> EscrowAnalytics {
         env.storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::MerchantAnalytics(merchant)))
+            .get(&DataKey::Participant(ParticipantKey::MerchantAnalytics(
+                merchant,
+            )))
             .unwrap_or(EscrowAnalytics::default_value())
     }
 
     pub fn get_customer_analytics(env: Env, customer: Address) -> EscrowAnalytics {
         env.storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::CustomerAnalytics(customer)))
+            .get(&DataKey::Participant(ParticipantKey::CustomerAnalytics(
+                customer,
+            )))
             .unwrap_or(EscrowAnalytics::default_value())
     }
 
@@ -5858,7 +6164,9 @@ impl EscrowContract {
         if env
             .storage()
             .instance()
-            .has(&DataKey::Config(ConfigKey::ActivePauseIndex(global_key.clone())))
+            .has(&DataKey::Config(ConfigKey::ActivePauseIndex(
+                global_key.clone(),
+            )))
         {
             return Ok(());
         }
@@ -5898,15 +6206,18 @@ impl EscrowContract {
             unpaused_at: None,
             reason: reason.clone(),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::PauseHistoryEntry(history_count)), &entry);
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::PauseHistoryCount), &(history_count + 1));
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::ActivePauseIndex(global_key)), &history_count);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::PauseHistoryEntry(history_count)),
+            &entry,
+        );
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::PauseHistoryCount),
+            &(history_count + 1),
+        );
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::ActivePauseIndex(global_key)),
+            &history_count,
+        );
         (ContractPausedEvent {
             paused_by: admin,
             reason,
@@ -5941,18 +6252,23 @@ impl EscrowContract {
         if let Some(active_idx) = env
             .storage()
             .instance()
-            .get::<DataKey, u64>(&DataKey::Config(ConfigKey::ActivePauseIndex(global_key.clone())))
+            .get::<DataKey, u64>(&DataKey::Config(ConfigKey::ActivePauseIndex(
+                global_key.clone(),
+            )))
         {
-            if let Some(mut entry) = env
-                .storage()
-                .instance()
-                .get::<DataKey, PauseHistory>(&DataKey::Config(ConfigKey::PauseHistoryEntry(active_idx)))
+            if let Some(mut entry) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, PauseHistory>(&DataKey::Config(ConfigKey::PauseHistoryEntry(
+                        active_idx,
+                    )))
             {
                 entry.unpaused_by = Some(admin.clone());
                 entry.unpaused_at = Some(now);
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Config(ConfigKey::PauseHistoryEntry(active_idx)), &entry);
+                env.storage().instance().set(
+                    &DataKey::Config(ConfigKey::PauseHistoryEntry(active_idx)),
+                    &entry,
+                );
             }
             env.storage()
                 .instance()
@@ -5987,7 +6303,9 @@ impl EscrowContract {
         if env
             .storage()
             .instance()
-            .has(&DataKey::Config(ConfigKey::ActivePauseIndex(function_name.clone())))
+            .has(&DataKey::Config(ConfigKey::ActivePauseIndex(
+                function_name.clone(),
+            )))
         {
             return Ok(());
         }
@@ -6028,12 +6346,14 @@ impl EscrowContract {
             unpaused_at: None,
             reason: reason.clone(),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::PauseHistoryEntry(history_count)), &entry);
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::PauseHistoryCount), &(history_count + 1));
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::PauseHistoryEntry(history_count)),
+            &entry,
+        );
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::PauseHistoryCount),
+            &(history_count + 1),
+        );
         env.storage().instance().set(
             &DataKey::Config(ConfigKey::ActivePauseIndex(function_name.clone())),
             &history_count,
@@ -6077,22 +6397,29 @@ impl EscrowContract {
         if let Some(active_idx) = env
             .storage()
             .instance()
-            .get::<DataKey, u64>(&DataKey::Config(ConfigKey::ActivePauseIndex(function_name.clone())))
+            .get::<DataKey, u64>(&DataKey::Config(ConfigKey::ActivePauseIndex(
+                function_name.clone(),
+            )))
         {
-            if let Some(mut entry) = env
-                .storage()
-                .instance()
-                .get::<DataKey, PauseHistory>(&DataKey::Config(ConfigKey::PauseHistoryEntry(active_idx)))
+            if let Some(mut entry) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, PauseHistory>(&DataKey::Config(ConfigKey::PauseHistoryEntry(
+                        active_idx,
+                    )))
             {
                 entry.unpaused_by = Some(admin.clone());
                 entry.unpaused_at = Some(now);
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Config(ConfigKey::PauseHistoryEntry(active_idx)), &entry);
+                env.storage().instance().set(
+                    &DataKey::Config(ConfigKey::PauseHistoryEntry(active_idx)),
+                    &entry,
+                );
             }
             env.storage()
                 .instance()
-                .remove(&DataKey::Config(ConfigKey::ActivePauseIndex(function_name.clone())));
+                .remove(&DataKey::Config(ConfigKey::ActivePauseIndex(
+                    function_name.clone(),
+                )));
         }
         (FunctionUnpausedEvent {
             function_name,
@@ -6214,9 +6541,10 @@ impl EscrowContract {
             started_at: env.ledger().timestamp(),
             completed_at: None,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::EscrowMigrationStatus), &status);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscrowMigrationStatus),
+            &status,
+        );
         Ok(())
     }
 
@@ -6256,14 +6584,16 @@ impl EscrowContract {
             .instance()
             .set(&DataKey::Escrow(EscrowKey::Data(escrow_id)), &escrow);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::EscrowMigrated(escrow_id)), &true);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscrowMigrated(escrow_id)),
+            &true,
+        );
 
         status.migrated_count += 1;
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::EscrowMigrationStatus), &status);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscrowMigrationStatus),
+            &status,
+        );
 
         Ok(())
     }
@@ -6309,9 +6639,10 @@ impl EscrowContract {
                 env.storage()
                     .instance()
                     .set(&DataKey::Escrow(EscrowKey::Data(escrow_id)), &escrow);
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Dispute(DisputeKey::EscrowMigrated(escrow_id)), &true);
+                env.storage().instance().set(
+                    &DataKey::Dispute(DisputeKey::EscrowMigrated(escrow_id)),
+                    &true,
+                );
                 migrated += 1;
             }
         }
@@ -6323,9 +6654,10 @@ impl EscrowContract {
             .get(&DataKey::Dispute(DisputeKey::EscrowMigrationStatus))
             .ok_or(Error::Basic(BasicError::MigrationNotStarted))?;
         updated_status.migrated_count += migrated as u64;
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::EscrowMigrationStatus), &updated_status);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscrowMigrationStatus),
+            &updated_status,
+        );
 
         Ok(migrated)
     }
@@ -6353,9 +6685,10 @@ impl EscrowContract {
 
         status.in_progress = false;
         status.completed_at = Some(env.ledger().timestamp());
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::EscrowMigrationStatus), &status);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscrowMigrationStatus),
+            &status,
+        );
 
         Ok(())
     }
@@ -6475,7 +6808,9 @@ impl EscrowContract {
         pool.token = escrow.token.clone();
         pool.balance += premium;
         pool.total_premiums_collected += premium;
-        env.storage().instance().set(&DataKey::Config(ConfigKey::InsurancePool), &pool);
+        env.storage()
+            .instance()
+            .set(&DataKey::Config(ConfigKey::InsurancePool), &pool);
 
         Ok(())
     }
@@ -6522,12 +6857,14 @@ impl EscrowContract {
             paid_at: None,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::InsuranceClaim(counter)), &claim);
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::InsuranceClaimCounter), &counter);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::InsuranceClaim(counter)),
+            &claim,
+        );
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::InsuranceClaimCounter),
+            &counter,
+        );
 
         Ok(counter)
     }
@@ -6557,13 +6894,16 @@ impl EscrowContract {
 
         pool.balance -= claim.amount;
         pool.total_claims_paid += claim.amount;
-        env.storage().instance().set(&DataKey::Config(ConfigKey::InsurancePool), &pool);
+        env.storage()
+            .instance()
+            .set(&DataKey::Config(ConfigKey::InsurancePool), &pool);
 
         claim.approved = true;
         claim.paid_at = Some(env.ledger().timestamp());
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::InsuranceClaim(claim_id)), &claim);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::InsuranceClaim(claim_id)),
+            &claim,
+        );
 
         Ok(())
     }
@@ -6585,7 +6925,11 @@ impl EscrowContract {
             return false;
         }
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return false;
         }
 
@@ -6714,9 +7058,10 @@ impl EscrowContract {
         let days_inactive = (now.saturating_sub(rep.last_updated + threshold_secs)) / 86400;
         rep.score = new_score as i64;
         rep.last_updated = now;
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::ReputationScore(address.clone())), &rep);
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::ReputationScore(address.clone())),
+            &rep,
+        );
         ReputationDecayed {
             address,
             old_score,
@@ -6775,16 +7120,21 @@ impl EscrowContract {
         if !config.admins.contains(&admin) {
             return Err(Error::Basic(BasicError::NotAnAdmin));
         }
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let escrow = EscrowContract::get_escrow(&env, escrow_id);
         if escrow.status != EscrowStatus::Locked {
             return Err(Error::Escrow(EscrowError::InvalidStatus));
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::OracleCondition(escrow_id)), &condition);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::OracleCondition(escrow_id)),
+            &condition,
+        );
         Ok(())
     }
 
@@ -6796,7 +7146,11 @@ impl EscrowContract {
     }
 
     pub fn auto_resolve_with_oracle(env: Env, escrow_id: u64) -> Result<(), Error> {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let escrow = EscrowContract::get_escrow(&env, escrow_id);
@@ -6901,9 +7255,10 @@ impl EscrowContract {
             evaluated: false,
             result: false,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Conditional(escrow_id)), &conditional);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Conditional(escrow_id)),
+            &conditional,
+        );
 
         EscrowCreated {
             escrow_id,
@@ -6929,7 +7284,11 @@ impl EscrowContract {
             return Err(Error::Action(ActionError::ConditionAlreadyEvaluated));
         }
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let mut escrow = EscrowContract::get_escrow(&env, escrow_id);
@@ -6949,9 +7308,10 @@ impl EscrowContract {
 
         conditional.evaluated = true;
         conditional.result = met;
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Conditional(escrow_id)), &conditional);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Conditional(escrow_id)),
+            &conditional,
+        );
 
         ConditionEvaluated { escrow_id, met }.publish(&env);
 
@@ -6977,12 +7337,17 @@ impl EscrowContract {
                     let mut acc: i128 = env
                         .storage()
                         .instance()
-                        .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(escrow.token.clone())))
+                        .get(&DataKey::Participant(ParticipantKey::AccumulatedFees(
+                            escrow.token.clone(),
+                        )))
                         .unwrap_or(0);
                     acc += fee_amount;
-                    env.storage()
-                        .instance()
-                        .set(&DataKey::Participant(ParticipantKey::AccumulatedFees(escrow.token.clone())), &acc);
+                    env.storage().instance().set(
+                        &DataKey::Participant(ParticipantKey::AccumulatedFees(
+                            escrow.token.clone(),
+                        )),
+                        &acc,
+                    );
                 }
 
                 EscrowFeeCollected {
@@ -7027,7 +7392,11 @@ impl EscrowContract {
     ) -> Result<(), Error> {
         caller.require_auth();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
 
@@ -7055,7 +7424,9 @@ impl EscrowContract {
         let count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::BeneficiaryTransferCount(escrow_id)))
+            .get(&DataKey::Participant(
+                ParticipantKey::BeneficiaryTransferCount(escrow_id),
+            ))
             .unwrap_or(0);
 
         let transfer = BeneficiaryTransfer {
@@ -7070,9 +7441,10 @@ impl EscrowContract {
             &DataKey::Participant(ParticipantKey::BeneficiaryTransferHistory(escrow_id, count)),
             &transfer,
         );
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::BeneficiaryTransferCount(escrow_id)), &(count + 1));
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::BeneficiaryTransferCount(escrow_id)),
+            &(count + 1),
+        );
 
         escrow.merchant = new_merchant.clone();
         env.storage()
@@ -7093,7 +7465,9 @@ impl EscrowContract {
         let count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::BeneficiaryTransferCount(escrow_id)))
+            .get(&DataKey::Participant(
+                ParticipantKey::BeneficiaryTransferCount(escrow_id),
+            ))
             .unwrap_or(0);
 
         let mut history = Vec::new(&env);
@@ -7101,9 +7475,9 @@ impl EscrowContract {
             if let Some(transfer) = env
                 .storage()
                 .instance()
-                .get::<DataKey, BeneficiaryTransfer>(&DataKey::Participant(ParticipantKey::BeneficiaryTransferHistory(
-                    escrow_id, i,
-                )))
+                .get::<DataKey, BeneficiaryTransfer>(&DataKey::Participant(
+                    ParticipantKey::BeneficiaryTransferHistory(escrow_id, i),
+                ))
             {
                 history.push_back(transfer);
             }
@@ -7154,9 +7528,10 @@ impl EscrowContract {
             resolved: false,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::MultiPartyDispute(escrow_id)), &dispute);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::MultiPartyDispute(escrow_id)),
+            &dispute,
+        );
 
         escrow.status = EscrowStatus::Disputed;
         env.storage()
@@ -7224,9 +7599,10 @@ impl EscrowContract {
             dispute.votes_for_customer.push_back(voter.clone());
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::MultiPartyDispute(escrow_id)), &dispute);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::MultiPartyDispute(escrow_id)),
+            &dispute,
+        );
 
         MultiPartyDisputeVoteCast {
             escrow_id,
@@ -7272,9 +7648,10 @@ impl EscrowContract {
         }
 
         dispute.resolved = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::MultiPartyDispute(escrow_id)), &dispute);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::MultiPartyDispute(escrow_id)),
+            &dispute,
+        );
 
         let token_client = token::Client::new(&env, &escrow.token);
         let contract_address = env.current_contract_address();
@@ -7465,10 +7842,15 @@ impl EscrowContract {
         let customer_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Escrow(EscrowKey::CustomerCount(entry.customer.clone())))
+            .get(&DataKey::Escrow(EscrowKey::CustomerCount(
+                entry.customer.clone(),
+            )))
             .unwrap_or(0);
         env.storage().instance().set(
-            &DataKey::Escrow(EscrowKey::CustomerList(entry.customer.clone(), customer_count)),
+            &DataKey::Escrow(EscrowKey::CustomerList(
+                entry.customer.clone(),
+                customer_count,
+            )),
             &escrow_id,
         );
         env.storage().instance().set(
@@ -7480,10 +7862,15 @@ impl EscrowContract {
         let merchant_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Escrow(EscrowKey::MerchantCount(entry.merchant.clone())))
+            .get(&DataKey::Escrow(EscrowKey::MerchantCount(
+                entry.merchant.clone(),
+            )))
             .unwrap_or(0);
         env.storage().instance().set(
-            &DataKey::Escrow(EscrowKey::MerchantList(entry.merchant.clone(), merchant_count)),
+            &DataKey::Escrow(EscrowKey::MerchantList(
+                entry.merchant.clone(),
+                merchant_count,
+            )),
             &escrow_id,
         );
         env.storage().instance().set(
@@ -7542,7 +7929,9 @@ impl EscrowContract {
         if limit == 0 || limit > 1000 {
             return Err(Error::Escrow(EscrowError::InvalidStatus)); // Using InvalidStatus for invalid limit
         }
-        env.storage().instance().set(&DataKey::Config(ConfigKey::BatchLimit), &limit);
+        env.storage()
+            .instance()
+            .set(&DataKey::Config(ConfigKey::BatchLimit), &limit);
         Ok(())
     }
 
@@ -7568,7 +7957,11 @@ impl EscrowContract {
     }
 
     pub fn is_escrow_expired(env: Env, escrow_id: u64) -> bool {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return false;
         }
         let escrow = Self::get_escrow(&env, escrow_id);
@@ -7579,7 +7972,11 @@ impl EscrowContract {
     }
 
     pub fn expire_escrow(env: Env, escrow_id: u64) -> Result<(), Error> {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let mut escrow = Self::get_escrow(&env, escrow_id);
@@ -7646,9 +8043,10 @@ impl EscrowContract {
             active: true,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Template(template_id)), &template);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Template(template_id)),
+            &template,
+        );
         env.storage()
             .instance()
             .set(&DataKey::Escrow(EscrowKey::TemplateCounter), &template_id);
@@ -7752,9 +8150,10 @@ impl EscrowContract {
             .ok_or(Error::Escrow(EscrowError::TemplateNotFound))?;
 
         template.active = false;
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Template(template_id)), &template);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Template(template_id)),
+            &template,
+        );
 
         TemplateDeactivated { template_id }.publish(&env);
 
@@ -7777,12 +8176,15 @@ impl EscrowContract {
         let mut analytics: EscrowAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::CustomerAnalytics(customer.clone())))
+            .get(&DataKey::Participant(ParticipantKey::CustomerAnalytics(
+                customer.clone(),
+            )))
             .unwrap_or(EscrowAnalytics::default_value());
         update_fn(&mut analytics);
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::CustomerAnalytics(customer.clone())), &analytics);
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::CustomerAnalytics(customer.clone())),
+            &analytics,
+        );
     }
 
     fn update_merchant_analytics<F>(env: &Env, merchant: &Address, update_fn: F)
@@ -7792,12 +8194,15 @@ impl EscrowContract {
         let mut analytics: EscrowAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Participant(ParticipantKey::MerchantAnalytics(merchant.clone())))
+            .get(&DataKey::Participant(ParticipantKey::MerchantAnalytics(
+                merchant.clone(),
+            )))
             .unwrap_or(EscrowAnalytics::default_value());
         update_fn(&mut analytics);
-        env.storage()
-            .instance()
-            .set(&DataKey::Participant(ParticipantKey::MerchantAnalytics(merchant.clone())), &analytics);
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::MerchantAnalytics(merchant.clone())),
+            &analytics,
+        );
     }
 
     /// Configure the thresholds used to classify escrow health (admin only).
@@ -7833,7 +8238,11 @@ impl EscrowContract {
     /// Panics with `EscrowNotFound` if the escrow does not exist, or
     /// `StaleThresholdNotConfigured` if `set_stale_threshold` was never called.
     pub fn get_escrow_health(env: Env, escrow_id: u64) -> EscrowHealthReport {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             panic_with_error!(&env, Error::Escrow(EscrowError::NotFound));
         }
         let config = Self::require_stale_threshold(&env);
@@ -7935,10 +8344,12 @@ impl EscrowContract {
             .unwrap_or(0);
         let mut allocated: i128 = 0;
         for sub_id in 1..=sub_count {
-            if let Some(sub) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)))
+            if let Some(sub) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(
+                        escrow_id, sub_id,
+                    )))
             {
                 allocated += sub.amount;
             }
@@ -7958,12 +8369,14 @@ impl EscrowContract {
             release_condition: None,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)), &sub);
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::SubAccountCounter(escrow_id)), &sub_id);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)),
+            &sub,
+        );
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::SubAccountCounter(escrow_id)),
+            &sub_id,
+        );
 
         Ok(sub_id)
     }
@@ -7995,10 +8408,12 @@ impl EscrowContract {
             if id == sub_id {
                 continue;
             }
-            if let Some(s) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, id)))
+            if let Some(s) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(
+                        escrow_id, id,
+                    )))
             {
                 allocated += s.amount;
             }
@@ -8009,9 +8424,10 @@ impl EscrowContract {
         }
 
         sub.amount += amount;
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)),
+            &sub,
+        );
 
         Ok(())
     }
@@ -8044,9 +8460,10 @@ impl EscrowContract {
         )?;
 
         sub.released = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)),
+            &sub,
+        );
 
         Ok(())
     }
@@ -8065,10 +8482,12 @@ impl EscrowContract {
             .unwrap_or(0);
         let mut result = Vec::new(&env);
         for sub_id in 1..=sub_count {
-            if let Some(sub) = env
-                .storage()
-                .instance()
-                .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)))
+            if let Some(sub) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, EscrowSubAccount>(&DataKey::Escrow(EscrowKey::SubAccount(
+                        escrow_id, sub_id,
+                    )))
             {
                 result.push_back(sub);
             }
@@ -8086,7 +8505,11 @@ impl EscrowContract {
     ) -> Result<(), Error> {
         merchant.require_auth();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let escrow = Self::get_escrow(&env, escrow_id);
@@ -8108,9 +8531,10 @@ impl EscrowContract {
             executed: false,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::EscrowSwapConfig(escrow_id)), &swap_config);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscrowSwapConfig(escrow_id)),
+            &swap_config,
+        );
 
         Ok(())
     }
@@ -8119,7 +8543,11 @@ impl EscrowContract {
         // Authenticate the caller to follow standard signature verification pattern.
         caller.require_auth();
 
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(escrow_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
             return Err(Error::Escrow(EscrowError::NotFound));
         }
         let mut escrow = Self::get_escrow(&env, escrow_id);
@@ -8167,9 +8595,10 @@ impl EscrowContract {
             .instance()
             .set(&DataKey::Escrow(EscrowKey::Data(escrow_id)), &escrow);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Dispute(DisputeKey::EscrowSwapConfig(escrow_id)), &swap_config);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscrowSwapConfig(escrow_id)),
+            &swap_config,
+        );
 
         Ok(output_amount)
     }
@@ -8196,7 +8625,11 @@ impl EscrowContract {
         }
 
         // Verify parent escrow exists
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(parent_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(parent_id)))
+        {
             return Err(Error::Escrow(EscrowError::ParentEscrowNotFound));
         }
 
@@ -8233,9 +8666,10 @@ impl EscrowContract {
 
         // Update parent children list
         parent_node.children.push_back(child_id);
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Hierarchy(parent_id)), &parent_node);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Hierarchy(parent_id)),
+            &parent_node,
+        );
 
         // Store child hierarchy node
         let child_node = EscrowHierarchyNode {
@@ -8244,16 +8678,21 @@ impl EscrowContract {
             children: Vec::new(&env),
             depth: child_depth,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Escrow(EscrowKey::Hierarchy(child_id)), &child_node);
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::Hierarchy(child_id)),
+            &child_node,
+        );
 
         Ok(child_id)
     }
 
     pub fn get_escrow_hierarchy(env: Env, root_id: u64) -> Vec<EscrowHierarchyNode> {
         let mut result = Vec::new(&env);
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(root_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(root_id)))
+        {
             return result;
         }
 
@@ -8288,7 +8727,11 @@ impl EscrowContract {
     }
 
     pub fn can_parent_release(env: Env, parent_id: u64) -> bool {
-        if !env.storage().instance().has(&DataKey::Escrow(EscrowKey::Data(parent_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(parent_id)))
+        {
             return false;
         }
 

--- a/contracts/escrow/src/swap_test.rs
+++ b/contracts/escrow/src/swap_test.rs
@@ -135,7 +135,10 @@ fn test_escrow_swap_below_minimum_fails() {
 
     // Executing should fail with SwapOutputBelowMinimum
     let res = client.try_execute_escrow_swap(&merchant, &escrow_id);
-    assert_eq!(res, Err(Ok(Error::Action(ActionError::SwapOutputBelowMinimum))));
+    assert_eq!(
+        res,
+        Err(Ok(Error::Action(ActionError::SwapOutputBelowMinimum)))
+    );
 }
 
 #[test]
@@ -169,7 +172,10 @@ fn test_escrow_swap_double_execution_fails() {
 
     // Execute second time: fails with SwapAlreadyExecuted
     let res = client.try_execute_escrow_swap(&merchant, &escrow_id);
-    assert_eq!(res, Err(Ok(Error::Action(ActionError::SwapAlreadyExecuted))));
+    assert_eq!(
+        res,
+        Err(Ok(Error::Action(ActionError::SwapAlreadyExecuted)))
+    );
 }
 
 #[test]

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -3,56 +3,108 @@
 #![no_std]
 use escrow::EscrowContractClient;
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracterror, contracttype, token, xdr::ToXdr, Address, Bytes, BytesN,
-    Env, FromVal, IntoVal, InvokeError, String, Symbol, TryFromVal, Val, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, token, xdr::ToXdr, Address,
+    Bytes, BytesN, Env, FromVal, IntoVal, InvokeError, String, Symbol, TryFromVal, Val, Vec,
 };
 
 #[derive(Clone, Debug, PartialEq)]
 #[contracttype]
-pub enum Currency { XLM, USDC, USDT, BTC, ETH }
+pub enum Currency {
+    XLM,
+    USDC,
+    USDT,
+    BTC,
+    ETH,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[contracttype]
-pub enum PayoutFrequency { Immediate, Daily, Weekly, Monthly }
+pub enum PayoutFrequency {
+    Immediate,
+    Daily,
+    Weekly,
+    Monthly,
+}
 
 #[derive(Clone)]
 #[contracttype]
 pub enum ConfigKey {
-    Admin, MultiSigConfig, FeeConfig, RateLimitConfig, DunningConfig,
-    LoyaltyConfig, RiskFeeConfig, FinalityConfig, FeeRebateConfig,
-    TierThresholds, LargePaymentThreshold, GlobalMerchantCount, PauseStateKey,
+    Admin,
+    MultiSigConfig,
+    FeeConfig,
+    RateLimitConfig,
+    DunningConfig,
+    LoyaltyConfig,
+    RiskFeeConfig,
+    FinalityConfig,
+    FeeRebateConfig,
+    TierThresholds,
+    LargePaymentThreshold,
+    GlobalMerchantCount,
+    PauseStateKey,
+    MinSplitAmount,
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum PaymentKey {
-    Data(u64), Counter, Metadata(u64), Memo(u64), MemoVersion(u64), Tag(u64),
-    Invoice(u64), InvoiceCounter, InvoicePaymentId(u64), PartialPaymentCounter(u64),
-    OutstandingBalance(u64), PendingSettlement(u64), AccumulatedFees, LargePaymentCounter,
+    Data(u64),
+    Counter,
+    Metadata(u64),
+    Memo(u64),
+    MemoVersion(u64),
+    Tag(u64),
+    Invoice(u64),
+    InvoiceCounter,
+    InvoicePaymentId(u64),
+    PartialPaymentCounter(u64),
+    OutstandingBalance(u64),
+    PendingSettlement(u64),
+    AccumulatedFees,
+    LargePaymentCounter,
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum SubscriptionKey {
-    Data(u64), Counter, Metered(u64), MeteredCounter, Group(u64),
-    GroupCounter, GroupMembership(u64),
+    Data(u64),
+    Counter,
+    Metered(u64),
+    MeteredCounter,
+    Group(u64),
+    GroupCounter,
+    GroupMembership(u64),
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum FeatureKey {
-    PaymentAnalytics, PlatformAnalyticsDaily(u64), PaymentForwardConfig(Address),
-    OracleRateConfig(Currency), ConversionRate(Currency), MerchantRateLimit(Address),
-    CustomerLoyaltyBalance(Address), CustomerSpendLimit(Address), PaymentChannel(u64),
-    PaymentChannelCounter, SplitConfig(u64), SweepRecipient, SweepCounter,
-    SweepHistory(u64), RouteOptions(Address, Address),
+    PaymentAnalytics,
+    PlatformAnalyticsDaily(u64),
+    PaymentForwardConfig(Address),
+    OracleRateConfig(Currency),
+    ConversionRate(Currency),
+    MerchantRateLimit(Address),
+    CustomerLoyaltyBalance(Address),
+    CustomerSpendLimit(Address),
+    PaymentChannel(u64),
+    PaymentChannelCounter,
+    SplitConfig(u64),
+    SweepRecipient,
+    SweepCounter,
+    SweepHistory(u64),
+    RouteOptions(Address, Address),
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
-    Config(ConfigKey), Payment(PaymentKey), Subscription(SubscriptionKey),
-    Feature(FeatureKey), Customer(CustomerDataKey), Merchant(MerchantDataKey),
+    Config(ConfigKey),
+    Payment(PaymentKey),
+    Subscription(SubscriptionKey),
+    Feature(FeatureKey),
+    Customer(CustomerDataKey),
+    Merchant(MerchantDataKey),
     State(StateDataKey),
 }
 
@@ -60,37 +112,81 @@ pub enum DataKey {
 #[repr(u32)]
 #[contracterror]
 pub enum BasicError {
-    Unauthorized = 100, MetadataTooLarge = 101, NotesTooLarge = 102,
-    InvalidCurrency = 103, InvalidBatchSize = 104, BatchPartialFailure = 105,
-    RateLimitExceeded = 106, DailyVolumeExceeded = 107, AddressFlagged = 108,
-    AddressAlreadyFlagged = 109, AmountExceedsLimit = 110, MultiSigNotInitialized = 111,
-    InsufficientAdmins = 112, NotAnAdmin = 113, AlreadyApproved = 114,
-    OracleCallFailed = 115, ContractPaused = 116, FunctionPaused = 117,
-    InvalidTierThresholds = 118, OracleFeedStale = 119, OracleNotConfigured = 120,
-    InvalidAmount = 121, VerificationLevelNotFound = 122, TierLimitsNotConfigured = 123, InvalidInterval = 124, InvalidBps = 125
+    Unauthorized = 100,
+    MetadataTooLarge = 101,
+    NotesTooLarge = 102,
+    InvalidCurrency = 103,
+    InvalidBatchSize = 104,
+    BatchPartialFailure = 105,
+    RateLimitExceeded = 106,
+    DailyVolumeExceeded = 107,
+    AddressFlagged = 108,
+    AddressAlreadyFlagged = 109,
+    AmountExceedsLimit = 110,
+    MultiSigNotInitialized = 111,
+    InsufficientAdmins = 112,
+    NotAnAdmin = 113,
+    AlreadyApproved = 114,
+    OracleCallFailed = 115,
+    ContractPaused = 116,
+    FunctionPaused = 117,
+    InvalidTierThresholds = 118,
+    OracleFeedStale = 119,
+    OracleNotConfigured = 120,
+    InvalidAmount = 121,
+    VerificationLevelNotFound = 122,
+    TierLimitsNotConfigured = 123,
+    InvalidInterval = 124,
+    InvalidBps = 125,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 #[contracterror]
 pub enum PaymentError {
-    NotFound = 200, InvalidStatus = 201, AlreadyProcessed = 202, Expired = 203,
-    NotExpired = 204, NoExpiration = 205, TransferFailed = 206, RefundExceedsPayment = 207,
-    NotYetDue = 208, ScheduledPaymentCancelled = 209, MetadataAlreadySet = 210,
-    MetadataNotFound = 211, HashMismatch = 212, AlreadyFullyPaid = 213,
-    InstallmentExceedsRemaining = 214, PartialPaymentNotFound = 215,
-    MerchantRateLimitExceeded = 216, AmountRateLimitExceeded = 217,
-    PayoutScheduleNotFound = 218, PayoutNotYetDue = 219, NothingToSettle = 220, BillingOverflow = 221
+    NotFound = 200,
+    InvalidStatus = 201,
+    AlreadyProcessed = 202,
+    Expired = 203,
+    NotExpired = 204,
+    NoExpiration = 205,
+    TransferFailed = 206,
+    RefundExceedsPayment = 207,
+    NotYetDue = 208,
+    ScheduledPaymentCancelled = 209,
+    MetadataAlreadySet = 210,
+    MetadataNotFound = 211,
+    HashMismatch = 212,
+    AlreadyFullyPaid = 213,
+    InstallmentExceedsRemaining = 214,
+    PartialPaymentNotFound = 215,
+    MerchantRateLimitExceeded = 216,
+    AmountRateLimitExceeded = 217,
+    PayoutScheduleNotFound = 218,
+    PayoutNotYetDue = 219,
+    NothingToSettle = 220,
+    BillingOverflow = 221,
+    InvalidScheduleTime = 222,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 #[contracterror]
 pub enum SubscriptionError {
-    NotFound = 300, NotActive = 301, PaymentNotDue = 302, MaxRetriesExceeded = 303,
-    Ended = 304, DunningNotFound = 305, NotInDunning = 306, RetryNotDue = 307,
-    GracePeriodExpired = 308, RetryTooEarly = 309, MeteredNotFound = 310,
-    BillingCapExceeded = 311, GroupNotFound = 312, AlreadyInGroup = 313,
+    NotFound = 300,
+    NotActive = 301,
+    PaymentNotDue = 302,
+    MaxRetriesExceeded = 303,
+    Ended = 304,
+    DunningNotFound = 305,
+    NotInDunning = 306,
+    RetryNotDue = 307,
+    GracePeriodExpired = 308,
+    RetryTooEarly = 309,
+    MeteredNotFound = 310,
+    BillingCapExceeded = 311,
+    GroupNotFound = 312,
+    AlreadyInGroup = 313,
     GroupSizeLimitExceeded = 314,
 }
 
@@ -98,34 +194,68 @@ pub enum SubscriptionError {
 #[repr(u32)]
 #[contracterror]
 pub enum ProposalError {
-    NotFound = 400, Expired = 401, AlreadyExecuted = 402, ThresholdNotMet = 403,
-    RequiresMultiSig = 404, InsufficientApprovals = 405, ProposalExpired = 406,
+    NotFound = 400,
+    Expired = 401,
+    AlreadyExecuted = 402,
+    ThresholdNotMet = 403,
+    RequiresMultiSig = 404,
+    InsufficientApprovals = 405,
+    ProposalExpired = 406,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 #[contracterror]
 pub enum FeatureError {
-    EscrowMappingNotFound = 500, EscrowBridgeFailed = 501, FeeConfigNotFound = 502,
-    InsufficientFees = 503, ConditionNotMet = 504, ConditionAlreadyEvaluated = 505,
-    AutoEscrowRuleNotFound = 506, AutoEscrowBelowMinimum = 507,
-    AutoEscrowAlreadyTriggered = 508, ConditionEvaluationFailed = 509,
-    ConditionRuntimeNotMet = 510, InvalidFeeConfig = 511, ChannelNotFound = 512,
-    InvalidSignature = 513, InvalidNonce = 514, ChannelClosed = 515,
-    ChannelExpired = 516, ChannelNotExpired = 517, InvalidSplitShares = 518,
-    TooManyRecipients = 519, SplitConfigNotFound = 520, SplitAlreadyExecuted = 521,
-    LoyaltyNotConfigured = 522, InsufficientPoints = 523, PointsExpired = 524,
-    NothingToSweep = 525, SweepRecipientNotSet = 526, SpendLimitExceeded = 527,
-    SpendLimitNotConfigured = 528, SettlementNotReady = 529, FinalityConfigNotFound = 530,
-    SettlementAlreadyFinalized = 531, RebateThresholdNotMet = 532,
-    RebateAlreadyClaimed = 533, RebateConfigNotFound = 534, ForwardConfigNotFound = 535,
-    ForwardLoop = 536, InvalidForwardBps = 537,
+    EscrowMappingNotFound = 500,
+    EscrowBridgeFailed = 501,
+    FeeConfigNotFound = 502,
+    InsufficientFees = 503,
+    ConditionNotMet = 504,
+    ConditionAlreadyEvaluated = 505,
+    AutoEscrowRuleNotFound = 506,
+    AutoEscrowBelowMinimum = 507,
+    AutoEscrowAlreadyTriggered = 508,
+    ConditionEvaluationFailed = 509,
+    ConditionRuntimeNotMet = 510,
+    InvalidFeeConfig = 511,
+    ChannelNotFound = 512,
+    InvalidSignature = 513,
+    InvalidNonce = 514,
+    ChannelClosed = 515,
+    ChannelExpired = 516,
+    ChannelNotExpired = 517,
+    InvalidSplitShares = 518,
+    TooManyRecipients = 519,
+    SplitConfigNotFound = 520,
+    SplitAlreadyExecuted = 521,
+    LoyaltyNotConfigured = 522,
+    InsufficientPoints = 523,
+    PointsExpired = 524,
+    NothingToSweep = 525,
+    SweepRecipientNotSet = 526,
+    SpendLimitExceeded = 527,
+    SpendLimitNotConfigured = 528,
+    SettlementNotReady = 529,
+    FinalityConfigNotFound = 530,
+    SettlementAlreadyFinalized = 531,
+    RebateThresholdNotMet = 532,
+    RebateAlreadyClaimed = 533,
+    RebateConfigNotFound = 534,
+    ForwardConfigNotFound = 535,
+    ForwardLoop = 536,
+    InvalidForwardBps = 537,
+    SenderIsRecipient = 538,
+    BelowMinSplitAmount = 539,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Error {
-    Basic(BasicError), Payment(PaymentError), Subscription(SubscriptionError),
-    Proposal(ProposalError), Feature(FeatureError),
+    Basic(BasicError),
+    Payment(PaymentError),
+    Subscription(SubscriptionError),
+    Proposal(ProposalError),
+    Feature(FeatureError),
 }
 
 impl Error {
@@ -157,11 +287,21 @@ impl TryFrom<soroban_sdk::Error> for Error {
     fn try_from(error: soroban_sdk::Error) -> Result<Self, Self::Error> {
         if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) {
             let code = error.get_code();
-            if code >= 500 && code <= 537 { return Ok(Error::Feature(unsafe { core::mem::transmute(code) })); }
-            if code >= 400 && code <= 406 { return Ok(Error::Proposal(unsafe { core::mem::transmute(code) })); }
-            if code >= 300 && code <= 314 { return Ok(Error::Subscription(unsafe { core::mem::transmute(code) })); }
-            if code >= 200 && code <= 221 { return Ok(Error::Payment(unsafe { core::mem::transmute(code) })); }
-            if code >= 100 && code <= 125 { return Ok(Error::Basic(unsafe { core::mem::transmute(code) })); }
+            if code >= 500 && code <= 539 {
+                return Ok(Error::Feature(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 400 && code <= 406 {
+                return Ok(Error::Proposal(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 300 && code <= 314 {
+                return Ok(Error::Subscription(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 200 && code <= 222 {
+                return Ok(Error::Payment(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 100 && code <= 125 {
+                return Ok(Error::Basic(unsafe { core::mem::transmute(code) }));
+            }
         }
         Err(error)
     }
@@ -176,12 +316,11 @@ impl TryFrom<soroban_sdk::Error> for Error {
 impl TryFromVal<Env, Val> for Error {
     type Error = soroban_sdk::ConversionError;
     fn try_from_val(env: &Env, val: &Val) -> Result<Self, Self::Error> {
-        let error: soroban_sdk::Error = soroban_sdk::Error::try_from_val(env, val).map_err(|_| soroban_sdk::ConversionError)?;
+        let error: soroban_sdk::Error =
+            soroban_sdk::Error::try_from_val(env, val).map_err(|_| soroban_sdk::ConversionError)?;
         Error::try_from(error).map_err(|_| soroban_sdk::ConversionError)
     }
 }
-
-
 
 // Core payment data keys (≤50 variants for Soroban XDR spec limit)
 
@@ -245,8 +384,6 @@ pub enum StateDataKey {
     SettlementFinalized(u64),
     ScheduledPaymentCounter,
 }
-
-
 
 #[derive(Clone)]
 #[contracttype]
@@ -1653,7 +1790,11 @@ const ENTERPRISE_VOLUME_THRESHOLD: i128 = 100_000;
 #[contractimpl]
 impl PaymentContract {
     pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&DataKey::Config(ConfigKey::MultiSigConfig)) {
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::Config(ConfigKey::MultiSigConfig))
+        {
             panic!("already initialized");
         }
         let config = MultiSigConfig {
@@ -1666,7 +1807,9 @@ impl PaymentContract {
             .instance()
             .set(&DataKey::Config(ConfigKey::MultiSigConfig), &config);
         // Keep Admin key for backward compat
-        env.storage().instance().set(&DataKey::Config(ConfigKey::Admin), &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::Config(ConfigKey::Admin), &admin);
         (AdminAdded { admin }).publish(&env);
     }
 
@@ -1686,9 +1829,10 @@ impl PaymentContract {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Merchant(MerchantDataKey::VerificationLevel(merchant)), &level);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::VerificationLevel(merchant)),
+            &level,
+        );
 
         Ok(())
     }
@@ -1699,7 +1843,9 @@ impl PaymentContract {
     ) -> MerchantVerificationLevel {
         env.storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::VerificationLevel(merchant)))
+            .get(&DataKey::Merchant(MerchantDataKey::VerificationLevel(
+                merchant,
+            )))
             .unwrap_or(MerchantVerificationLevel::Unverified)
     }
 
@@ -1732,7 +1878,9 @@ impl PaymentContract {
     ) -> Option<VerificationTierLimits> {
         env.storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::VerificationTierLimit(level)))
+            .get(&DataKey::Merchant(MerchantDataKey::VerificationTierLimit(
+                level,
+            )))
     }
 
     pub fn get_multisig_config(env: Env) -> MultiSigConfig {
@@ -1791,9 +1939,10 @@ impl PaymentContract {
             expires_at: now + config.proposal_ttl,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         (ActionProposed {
             proposal_id: proposal_id.clone(),
@@ -1821,7 +1970,9 @@ impl PaymentContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())))
+            .get(&DataKey::State(StateDataKey::AdminProposal(
+                proposal_id.clone(),
+            )))
             .ok_or(Error::Proposal(ProposalError::NotFound))?;
 
         if proposal.executed || proposal.rejected {
@@ -1839,9 +1990,10 @@ impl PaymentContract {
         proposal.approvals.push_back(approver.clone());
         proposal.approval_count += 1;
 
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         (ActionApproved {
             proposal_id,
@@ -1863,7 +2015,9 @@ impl PaymentContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())))
+            .get(&DataKey::State(StateDataKey::AdminProposal(
+                proposal_id.clone(),
+            )))
             .ok_or(Error::Proposal(ProposalError::NotFound))?;
 
         if proposal.executed || proposal.rejected {
@@ -1879,9 +2033,10 @@ impl PaymentContract {
         }
 
         proposal.executed = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         PaymentContract::dispatch_action(&env, &proposal)?;
 
@@ -1906,7 +2061,9 @@ impl PaymentContract {
         let mut proposal: AdminProposal = env
             .storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())))
+            .get(&DataKey::State(StateDataKey::AdminProposal(
+                proposal_id.clone(),
+            )))
             .ok_or(Error::Proposal(ProposalError::NotFound))?;
 
         if proposal.executed || proposal.rejected {
@@ -1914,9 +2071,10 @@ impl PaymentContract {
         }
 
         proposal.rejected = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())), &proposal);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::AdminProposal(proposal_id.clone())),
+            &proposal,
+        );
 
         (ActionRejected {
             proposal_id,
@@ -2058,7 +2216,7 @@ impl PaymentContract {
         }
         let now = env.ledger().timestamp();
         if scheduled_at <= now {
-            return Err(Error::Payment(PaymentError::NotYetDue));
+            return Err(Error::Payment(PaymentError::InvalidScheduleTime));
         }
 
         let token_client = token::Client::new(&env, &token);
@@ -2081,12 +2239,14 @@ impl PaymentContract {
             executed: false,
             cancelled: false,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::ScheduledPayment(payment_id)), &scheduled);
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::ScheduledPaymentCounter), &payment_id);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::ScheduledPayment(payment_id)),
+            &scheduled,
+        );
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::ScheduledPaymentCounter),
+            &payment_id,
+        );
         Ok(payment_id)
     }
 
@@ -2117,9 +2277,10 @@ impl PaymentContract {
             scheduled.amount,
         )?;
         scheduled.executed = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::ScheduledPayment(payment_id)), &scheduled);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::ScheduledPayment(payment_id)),
+            &scheduled,
+        );
         Ok(())
     }
 
@@ -2149,9 +2310,10 @@ impl PaymentContract {
         let contract_address = env.current_contract_address();
         token_client.transfer(&contract_address, &scheduled.customer, &scheduled.amount);
         scheduled.cancelled = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::ScheduledPayment(payment_id)), &scheduled);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::ScheduledPayment(payment_id)),
+            &scheduled,
+        );
         Ok(())
     }
 
@@ -2169,12 +2331,12 @@ impl PaymentContract {
         amount: i128,
     ) -> Result<(), Error> {
         // If merchant has a payout schedule for this token and it's not Immediate, accumulate
-        if let Some(mut schedule) = env
-            .storage()
-            .instance()
-            .get::<DataKey, PayoutSchedule>(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(
-                merchant.clone(),
-            )))
+        if let Some(mut schedule) =
+            env.storage()
+                .instance()
+                .get::<DataKey, PayoutSchedule>(&DataKey::Merchant(
+                    MerchantDataKey::PayoutSchedule(merchant.clone()),
+                ))
         {
             if schedule.token == token && schedule.frequency != PayoutFrequency::Immediate {
                 schedule.accumulated += amount;
@@ -2214,16 +2376,19 @@ impl PaymentContract {
             next_payout_at: next,
             accumulated: 0,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(merchant)), &schedule);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::PayoutSchedule(merchant)),
+            &schedule,
+        );
         Ok(())
     }
 
     pub fn get_payout_schedule(env: Env, merchant: Address) -> Option<PayoutSchedule> {
         env.storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(merchant)))
+            .get(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(
+                merchant,
+            )))
     }
 
     pub fn trigger_scheduled_payout(env: Env, merchant: Address) -> Result<(), Error> {
@@ -2231,7 +2396,9 @@ impl PaymentContract {
         let mut schedule: PayoutSchedule = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(
+                merchant.clone(),
+            )))
             .ok_or(Error::Payment(PaymentError::PayoutScheduleNotFound))?;
         let now = env.ledger().timestamp();
         if now < schedule.next_payout_at {
@@ -2251,16 +2418,19 @@ impl PaymentContract {
             PayoutFrequency::Monthly => SECONDS_PER_DAY * 30,
         };
         schedule.next_payout_at = schedule.next_payout_at + period;
-        env.storage()
-            .instance()
-            .set(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(merchant)), &schedule);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::PayoutSchedule(merchant)),
+            &schedule,
+        );
         Ok(())
     }
 
     pub fn get_accumulated_balance(env: Env, merchant: Address) -> i128 {
         env.storage()
             .instance()
-            .get::<DataKey, PayoutSchedule>(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(merchant)))
+            .get::<DataKey, PayoutSchedule>(&DataKey::Merchant(MerchantDataKey::PayoutSchedule(
+                merchant,
+            )))
             .map(|s: PayoutSchedule| s.accumulated)
             .unwrap_or(0)
     }
@@ -2341,7 +2511,9 @@ impl PaymentContract {
         let customer_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::PaymentCount(customer.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::PaymentCount(
+                customer.clone(),
+            )))
             .unwrap_or(0);
         env.storage().instance().set(
             &DataKey::Customer(CustomerDataKey::Payments(customer.clone(), customer_count)),
@@ -2356,7 +2528,9 @@ impl PaymentContract {
         let merchant_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::PaymentCount(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::PaymentCount(
+                merchant.clone(),
+            )))
             .unwrap_or(0);
         env.storage().instance().set(
             &DataKey::Merchant(MerchantDataKey::Payments(merchant.clone(), merchant_count)),
@@ -2398,9 +2572,10 @@ impl PaymentContract {
                 &DataKey::Merchant(MerchantDataKey::GlobalList(global_count)),
                 &payment.merchant.clone(),
             );
-            env.storage()
-                .instance()
-                .set(&DataKey::Config(ConfigKey::GlobalMerchantCount), &(global_count + 1));
+            env.storage().instance().set(
+                &DataKey::Config(ConfigKey::GlobalMerchantCount),
+                &(global_count + 1),
+            );
         }
         env.storage()
             .instance()
@@ -2410,7 +2585,9 @@ impl PaymentContract {
         let mut m_analytics: MerchantAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::Analytics(payment.merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::Analytics(
+                payment.merchant.clone(),
+            )))
             .unwrap_or(MerchantAnalytics {
                 total_payments: 0,
                 total_volume: 0,
@@ -2430,7 +2607,9 @@ impl PaymentContract {
         let mut c_analytics: CustomerAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::Analytics(payment.customer.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::Analytics(
+                payment.customer.clone(),
+            )))
             .unwrap_or(CustomerAnalytics {
                 total_payments: 0,
                 total_volume: 0,
@@ -2456,7 +2635,10 @@ impl PaymentContract {
         let hour_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::HourCount(payment.customer.clone(), hour)))
+            .get(&DataKey::Customer(CustomerDataKey::HourCount(
+                payment.customer.clone(),
+                hour,
+            )))
             .unwrap_or(0)
             + 1;
         env.storage().instance().set(
@@ -2491,10 +2673,15 @@ impl PaymentContract {
             let m_count: u64 = env
                 .storage()
                 .instance()
-                .get(&DataKey::Customer(CustomerDataKey::MerchantCount(payment.customer.clone())))
+                .get(&DataKey::Customer(CustomerDataKey::MerchantCount(
+                    payment.customer.clone(),
+                )))
                 .unwrap_or(0);
             env.storage().instance().set(
-                &DataKey::Customer(CustomerDataKey::MerchantList(payment.customer.clone(), m_count)),
+                &DataKey::Customer(CustomerDataKey::MerchantList(
+                    payment.customer.clone(),
+                    m_count,
+                )),
                 &payment.merchant,
             );
             env.storage().instance().set(
@@ -2504,7 +2691,10 @@ impl PaymentContract {
         }
         let new_merchant_vol = prev_merchant_vol + amount;
         env.storage().instance().set(
-            &DataKey::Customer(CustomerDataKey::MerchantVolume(payment.customer.clone(), payment.merchant.clone())),
+            &DataKey::Customer(CustomerDataKey::MerchantVolume(
+                payment.customer.clone(),
+                payment.merchant.clone(),
+            )),
             &new_merchant_vol,
         );
         if new_merchant_vol > c_analytics.top_merchant_volume {
@@ -2523,7 +2713,10 @@ impl PaymentContract {
             )))
             .unwrap_or(0);
         env.storage().instance().set(
-            &DataKey::Customer(CustomerDataKey::MonthlyVolume(payment.customer.clone(), month_bucket)),
+            &DataKey::Customer(CustomerDataKey::MonthlyVolume(
+                payment.customer.clone(),
+                month_bucket,
+            )),
             &(prev_monthly + amount),
         );
 
@@ -2564,7 +2757,10 @@ impl PaymentContract {
     /// Used by the refund contract for cross-contract ownership verification (#143).
     /// Returns true if the payment exists, belongs to `customer`, and is Completed.
     pub fn check_payment_customer(env: Env, payment_id: u64, customer: Address) -> bool {
-        let payment: Option<Payment> = env.storage().instance().get(&DataKey::Payment(PaymentKey::Data(payment_id)));
+        let payment: Option<Payment> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Payment(PaymentKey::Data(payment_id)));
         match payment {
             Some(p) => p.customer == customer && p.status == PaymentStatus::Completed,
             None => false,
@@ -2612,9 +2808,10 @@ impl PaymentContract {
             escrow_contract: escrow_contract.clone(),
             auto_release_on_complete,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::EscrowedPayment(payment_id)), &bridge);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::EscrowedPayment(payment_id)),
+            &bridge,
+        );
 
         // Custody is shifted to escrow contract account on creation.
         let token_client = token::Client::new(&env, &token);
@@ -2645,7 +2842,11 @@ impl PaymentContract {
         if !config.admins.contains(&admin) {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -2683,7 +2884,11 @@ impl PaymentContract {
         payment_id: u64,
     ) -> Result<(), Error> {
         caller.require_auth();
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -2725,7 +2930,11 @@ impl PaymentContract {
         reason: String,
     ) -> Result<(), Error> {
         caller.require_auth();
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -2762,9 +2971,10 @@ impl PaymentContract {
             resolved_at: None,
             favor_customer: None,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::EscrowedPaymentDispute(payment_id)), &dispute);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::EscrowedPaymentDispute(payment_id)),
+            &dispute,
+        );
 
         (EscrowedPaymentDisputed {
             payment_id,
@@ -2789,7 +2999,11 @@ impl PaymentContract {
         if !config.admins.contains(&admin) {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -2827,9 +3041,10 @@ impl PaymentContract {
         env.storage()
             .instance()
             .set(&DataKey::Payment(PaymentKey::Data(payment_id)), &payment);
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::EscrowedPaymentDispute(payment_id)), &dispute);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::EscrowedPaymentDispute(payment_id)),
+            &dispute,
+        );
 
         (PaymentDisputeResolved {
             payment_id,
@@ -2852,7 +3067,9 @@ impl PaymentContract {
     ) -> Option<EscrowedPaymentDispute> {
         env.storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::EscrowedPaymentDispute(payment_id)))
+            .get(&DataKey::State(StateDataKey::EscrowedPaymentDispute(
+                payment_id,
+            )))
     }
 
     fn require_no_unresolved_escrowed_payment_dispute(
@@ -2862,9 +3079,9 @@ impl PaymentContract {
         if let Some(dispute) = env
             .storage()
             .instance()
-            .get::<DataKey, EscrowedPaymentDispute>(&DataKey::State(StateDataKey::EscrowedPaymentDispute(
-                payment_id,
-            )))
+            .get::<DataKey, EscrowedPaymentDispute>(&DataKey::State(
+                StateDataKey::EscrowedPaymentDispute(payment_id),
+            ))
         {
             if !dispute.resolved {
                 return Err(Error::Payment(PaymentError::InvalidStatus));
@@ -2887,7 +3104,11 @@ impl PaymentContract {
         }
 
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -2910,7 +3131,11 @@ impl PaymentContract {
     }
 
     pub fn is_payment_expired(env: &Env, payment_id: u64) -> bool {
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return false;
         }
         let payment = PaymentContract::get_payment(env, payment_id);
@@ -2919,7 +3144,11 @@ impl PaymentContract {
 
     pub fn expire_payment(env: Env, payment_id: u64) -> Result<(), Error> {
         // Retrieve payment from storage
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
         let mut payment = PaymentContract::get_payment(&env, payment_id);
@@ -3006,9 +3235,9 @@ impl PaymentContract {
             if env
                 .storage()
                 .instance()
-                .get::<DataKey, LargePaymentProposal>(&DataKey::State(StateDataKey::LargePaymentProposal(
-                    payment_id,
-                )))
+                .get::<DataKey, LargePaymentProposal>(&DataKey::State(
+                    StateDataKey::LargePaymentProposal(payment_id),
+                ))
                 .is_some()
             {
                 return Err(Error::Proposal(ProposalError::RequiresMultiSig));
@@ -3030,9 +3259,10 @@ impl PaymentContract {
                 executed: false,
             };
 
-            env.storage()
-                .instance()
-                .set(&DataKey::State(StateDataKey::LargePaymentProposal(payment_id)), &proposal);
+            env.storage().instance().set(
+                &DataKey::State(StateDataKey::LargePaymentProposal(payment_id)),
+                &proposal,
+            );
 
             (LargePaymentProposed {
                 payment_id,
@@ -3050,7 +3280,11 @@ impl PaymentContract {
 
     fn do_complete_payment(env: &Env, payment_id: u64) -> Result<(), Error> {
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -3087,8 +3321,10 @@ impl PaymentContract {
         );
 
         // Check finality delay config (#219)
-        let finality: Option<FinalityConfig> =
-            env.storage().instance().get(&DataKey::Config(ConfigKey::FinalityConfig));
+        let finality: Option<FinalityConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FinalityConfig));
         if let Some(ref fc) = finality {
             if fc.active && payment.amount >= fc.min_amount_threshold {
                 // Hold funds — create PendingSettlement instead of transferring
@@ -3100,9 +3336,10 @@ impl PaymentContract {
                     token: payment.token.clone(),
                     release_at,
                 };
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Payment(PaymentKey::PendingSettlement(payment_id)), &settlement);
+                env.storage().instance().set(
+                    &DataKey::Payment(PaymentKey::PendingSettlement(payment_id)),
+                    &settlement,
+                );
                 let idx: u64 = env
                     .storage()
                     .instance()
@@ -3111,11 +3348,16 @@ impl PaymentContract {
                     )))
                     .unwrap_or(0);
                 env.storage().instance().set(
-                    &DataKey::Merchant(MerchantDataKey::PendingSettlementIndex(payment.merchant.clone(), idx)),
+                    &DataKey::Merchant(MerchantDataKey::PendingSettlementIndex(
+                        payment.merchant.clone(),
+                        idx,
+                    )),
                     &payment_id,
                 );
                 env.storage().instance().set(
-                    &DataKey::Merchant(MerchantDataKey::PendingSettlementCount(payment.merchant.clone())),
+                    &DataKey::Merchant(MerchantDataKey::PendingSettlementCount(
+                        payment.merchant.clone(),
+                    )),
                     &(idx + 1),
                 );
                 env.storage()
@@ -3225,7 +3467,9 @@ impl PaymentContract {
         let mut m_analytics: MerchantAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::Analytics(payment.merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::Analytics(
+                payment.merchant.clone(),
+            )))
             .unwrap_or(MerchantAnalytics {
                 total_payments: 0,
                 total_volume: 0,
@@ -3296,8 +3540,9 @@ impl PaymentContract {
                 match env
                     .storage()
                     .instance()
-                    .get::<DataKey, PaymentForwardConfig>(&DataKey::Feature(FeatureKey::PaymentForwardConfig(current)))
-                {
+                    .get::<DataKey, PaymentForwardConfig>(&DataKey::Feature(
+                        FeatureKey::PaymentForwardConfig(current),
+                    )) {
                     Some(next) => current = next.forward_to,
                     None => break,
                 }
@@ -3312,9 +3557,10 @@ impl PaymentContract {
             active: true,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::PaymentForwardConfig(merchant.clone())), &config);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::PaymentForwardConfig(merchant.clone())),
+            &config,
+        );
 
         (PaymentForwardConfigSet {
             merchant: merchant.clone(),
@@ -3334,7 +3580,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Feature(FeatureKey::PaymentForwardConfig(merchant.clone())))
+            .has(&DataKey::Feature(FeatureKey::PaymentForwardConfig(
+                merchant.clone(),
+            )))
         {
             return Err(Error::Feature(FeatureError::ForwardConfigNotFound));
         }
@@ -3342,7 +3590,9 @@ impl PaymentContract {
         // Remove the forward config
         env.storage()
             .instance()
-            .remove(&DataKey::Feature(FeatureKey::PaymentForwardConfig(merchant.clone())));
+            .remove(&DataKey::Feature(FeatureKey::PaymentForwardConfig(
+                merchant.clone(),
+            )));
 
         (PaymentForwardConfigRemoved {
             merchant: merchant.clone(),
@@ -3355,7 +3605,9 @@ impl PaymentContract {
     pub fn get_forward_config(env: Env, merchant: Address) -> Result<PaymentForwardConfig, Error> {
         env.storage()
             .instance()
-            .get(&DataKey::Feature(FeatureKey::PaymentForwardConfig(merchant)))
+            .get(&DataKey::Feature(FeatureKey::PaymentForwardConfig(
+                merchant,
+            )))
             .ok_or(Error::Feature(FeatureError::ForwardConfigNotFound))
     }
 
@@ -3385,7 +3637,9 @@ impl PaymentContract {
     pub fn get_loyalty_balance(env: Env, customer: Address) -> Option<CustomerLoyaltyBalance> {
         env.storage()
             .instance()
-            .get(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(customer)))
+            .get(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(
+                customer,
+            )))
     }
 
     pub fn redeem_points(
@@ -3409,7 +3663,9 @@ impl PaymentContract {
         let mut balance: CustomerLoyaltyBalance = env
             .storage()
             .instance()
-            .get(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(customer.clone())))
+            .get(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(
+                customer.clone(),
+            )))
             .ok_or(Error::Feature(FeatureError::InsufficientPoints))?;
 
         let now = env.ledger().timestamp();
@@ -3421,7 +3677,11 @@ impl PaymentContract {
             return Err(Error::Feature(FeatureError::InsufficientPoints));
         }
 
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
         let payment = PaymentContract::get_payment(&env, payment_id);
@@ -3437,15 +3697,18 @@ impl PaymentContract {
 
         balance.points -= points;
         balance.last_updated = now;
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(customer.clone())), &balance);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(customer.clone())),
+            &balance,
+        );
 
         Ok(discount)
     }
 
     fn get_loyalty_config(env: &Env) -> Option<LoyaltyConfig> {
-        env.storage().instance().get(&DataKey::Config(ConfigKey::LoyaltyConfig))
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::LoyaltyConfig))
     }
 
     fn maybe_accrue_loyalty_points(env: &Env, customer: Address, amount: i128) {
@@ -3466,7 +3729,9 @@ impl PaymentContract {
         let mut balance: CustomerLoyaltyBalance = env
             .storage()
             .instance()
-            .get(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(customer.clone())))
+            .get(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(
+                customer.clone(),
+            )))
             .unwrap_or(CustomerLoyaltyBalance {
                 customer: customer.clone(),
                 points: 0,
@@ -3482,9 +3747,10 @@ impl PaymentContract {
         balance.last_updated = now;
         balance.expires_at = now + config.expiry_seconds;
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(customer)), &balance);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::CustomerLoyaltyBalance(customer)),
+            &balance,
+        );
     }
 
     // Partial payment functions (#112)
@@ -3528,7 +3794,9 @@ impl PaymentContract {
         let installment_counter: u32 = env
             .storage()
             .instance()
-            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(payment_id)))
+            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(
+                payment_id,
+            )))
             .unwrap_or(0);
         let new_installment_number = installment_counter + 1;
 
@@ -3550,7 +3818,10 @@ impl PaymentContract {
 
         // Store partial payment record
         env.storage().instance().set(
-            &DataKey::State(StateDataKey::PartialPaymentRecord(payment_id, new_installment_number)),
+            &DataKey::State(StateDataKey::PartialPaymentRecord(
+                payment_id,
+                new_installment_number,
+            )),
             &partial_payment,
         );
 
@@ -3561,9 +3832,10 @@ impl PaymentContract {
         );
 
         // Update outstanding balance
-        env.storage()
-            .instance()
-            .set(&DataKey::Payment(PaymentKey::OutstandingBalance(payment_id)), &remaining);
+        env.storage().instance().set(
+            &DataKey::Payment(PaymentKey::OutstandingBalance(payment_id)),
+            &remaining,
+        );
 
         // Emit installment paid event
         (InstallmentPaid {
@@ -3588,15 +3860,19 @@ impl PaymentContract {
         let installment_counter: u32 = env
             .storage()
             .instance()
-            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(payment_id)))
+            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(
+                payment_id,
+            )))
             .unwrap_or(0);
 
         let mut history = Vec::new(&env);
         for i in 1..=installment_counter {
-            if let Some(record) = env
-                .storage()
-                .instance()
-                .get(&DataKey::State(StateDataKey::PartialPaymentRecord(payment_id, i)))
+            if let Some(record) =
+                env.storage()
+                    .instance()
+                    .get(&DataKey::State(StateDataKey::PartialPaymentRecord(
+                        payment_id, i,
+                    )))
             {
                 history.push_back(record);
             }
@@ -3606,10 +3882,12 @@ impl PaymentContract {
 
     pub fn get_outstanding_balance(env: Env, payment_id: u64) -> i128 {
         // First check if we have an outstanding balance stored
-        if let Some(balance) = env
-            .storage()
-            .instance()
-            .get(&DataKey::Payment(PaymentKey::OutstandingBalance(payment_id)))
+        if let Some(balance) =
+            env.storage()
+                .instance()
+                .get(&DataKey::Payment(PaymentKey::OutstandingBalance(
+                    payment_id,
+                )))
         {
             return balance;
         }
@@ -3619,7 +3897,9 @@ impl PaymentContract {
         let installment_counter: u32 = env
             .storage()
             .instance()
-            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(payment_id)))
+            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(
+                payment_id,
+            )))
             .unwrap_or(0);
 
         let mut total_paid = 0i128;
@@ -3627,9 +3907,9 @@ impl PaymentContract {
             if let Some(record) = env
                 .storage()
                 .instance()
-                .get::<DataKey, PartialPaymentRecord>(&DataKey::State(StateDataKey::PartialPaymentRecord(
-                    payment_id, i,
-                )))
+                .get::<DataKey, PartialPaymentRecord>(&DataKey::State(
+                    StateDataKey::PartialPaymentRecord(payment_id, i),
+                ))
             {
                 total_paid += record.amount_paid;
             }
@@ -3638,9 +3918,10 @@ impl PaymentContract {
         let outstanding = payment.amount - total_paid;
 
         // Cache the calculated balance
-        env.storage()
-            .instance()
-            .set(&DataKey::Payment(PaymentKey::OutstandingBalance(payment_id)), &outstanding);
+        env.storage().instance().set(
+            &DataKey::Payment(PaymentKey::OutstandingBalance(payment_id)),
+            &outstanding,
+        );
 
         outstanding
     }
@@ -3661,7 +3942,9 @@ impl PaymentContract {
         let installment_counter: u32 = env
             .storage()
             .instance()
-            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(payment_id)))
+            .get(&DataKey::Payment(PaymentKey::PartialPaymentCounter(
+                payment_id,
+            )))
             .unwrap_or(0);
 
         // Update payment status to Completed
@@ -3716,7 +3999,11 @@ impl PaymentContract {
 
     fn do_refund_payment(env: &Env, payment_id: u64) -> Result<(), Error> {
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -3769,7 +4056,9 @@ impl PaymentContract {
         let mut m_analytics: MerchantAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::Analytics(payment.merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::Analytics(
+                payment.merchant.clone(),
+            )))
             .unwrap_or(MerchantAnalytics {
                 total_payments: 0,
                 total_volume: 0,
@@ -3787,7 +4076,9 @@ impl PaymentContract {
         let mut c_analytics: CustomerAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::Analytics(payment.customer.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::Analytics(
+                payment.customer.clone(),
+            )))
             .unwrap_or(PaymentContract::default_customer_analytics());
         c_analytics.total_refunds += payment.amount;
         env.storage().instance().set(
@@ -3834,7 +4125,11 @@ impl PaymentContract {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
 
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -3884,7 +4179,11 @@ impl PaymentContract {
 
     fn do_cancel_payment(env: &Env, caller: Address, payment_id: u64) -> Result<(), Error> {
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -3935,7 +4234,9 @@ impl PaymentContract {
         let mut m_analytics: MerchantAnalytics = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::Analytics(payment.merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::Analytics(
+                payment.merchant.clone(),
+            )))
             .unwrap_or(MerchantAnalytics {
                 total_payments: 0,
                 total_volume: 0,
@@ -3980,7 +4281,9 @@ impl PaymentContract {
         let total_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::PaymentCount(customer.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::PaymentCount(
+                customer.clone(),
+            )))
             .unwrap_or(0);
 
         let mut payments = Vec::new(&env);
@@ -3988,10 +4291,13 @@ impl PaymentContract {
         let end = (offset + limit).min(total_count);
 
         for i in start..end {
-            if let Some(payment_id) = env
-                .storage()
-                .instance()
-                .get::<DataKey, u64>(&DataKey::Customer(CustomerDataKey::Payments(customer.clone(), i)))
+            if let Some(payment_id) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, u64>(&DataKey::Customer(CustomerDataKey::Payments(
+                        customer.clone(),
+                        i,
+                    )))
             {
                 if let Some(payment) = env
                     .storage()
@@ -4022,7 +4328,9 @@ impl PaymentContract {
         let total_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::PaymentCount(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::PaymentCount(
+                merchant.clone(),
+            )))
             .unwrap_or(0);
 
         let mut payments = Vec::new(&env);
@@ -4030,10 +4338,13 @@ impl PaymentContract {
         let end = (offset + limit).min(total_count);
 
         for i in start..end {
-            if let Some(payment_id) = env
-                .storage()
-                .instance()
-                .get::<DataKey, u64>(&DataKey::Merchant(MerchantDataKey::Payments(merchant.clone(), i)))
+            if let Some(payment_id) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, u64>(&DataKey::Merchant(MerchantDataKey::Payments(
+                        merchant.clone(),
+                        i,
+                    )))
             {
                 if let Some(payment) = env
                     .storage()
@@ -4083,9 +4394,10 @@ impl PaymentContract {
             return Err(Error::Basic(BasicError::InvalidCurrency));
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::ConversionRate(currency)), &rate);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::ConversionRate(currency)),
+            &rate,
+        );
 
         Ok(())
     }
@@ -4111,9 +4423,10 @@ impl PaymentContract {
         if !multisig.admins.contains(&admin) {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::OracleRateConfig(config.currency.clone())), &config);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::OracleRateConfig(config.currency.clone())),
+            &config,
+        );
         Ok(())
     }
 
@@ -4127,7 +4440,9 @@ impl PaymentContract {
         let cfg: OracleRateConfig = env
             .storage()
             .instance()
-            .get(&DataKey::Feature(FeatureKey::OracleRateConfig(currency.clone())))
+            .get(&DataKey::Feature(FeatureKey::OracleRateConfig(
+                currency.clone(),
+            )))
             .ok_or(Error::Basic(BasicError::OracleNotConfigured))?;
 
         if !cfg.enabled {
@@ -4149,9 +4464,10 @@ impl PaymentContract {
             return Err(Error::Basic(BasicError::OracleFeedStale));
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::ConversionRate(currency)), &fetched.0);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::ConversionRate(currency)),
+            &fetched.0,
+        );
         Ok(fetched.0)
     }
 
@@ -4186,7 +4502,6 @@ impl PaymentContract {
         if interval == 0 {
             // return Err(Error::InvalidInterval);
             return Err(Error::Basic(BasicError::InvalidInterval));
-
         }
 
         let counter: u64 = env
@@ -4250,7 +4565,9 @@ impl PaymentContract {
         let c_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::SubscriptionCount(customer.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::SubscriptionCount(
+                customer.clone(),
+            )))
             .unwrap_or(0);
         env.storage().instance().set(
             &DataKey::Customer(CustomerDataKey::Subscriptions(customer.clone(), c_count)),
@@ -4265,7 +4582,9 @@ impl PaymentContract {
         let m_count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::SubscriptionCount(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::SubscriptionCount(
+                merchant.clone(),
+            )))
             .unwrap_or(0);
         env.storage().instance().set(
             &DataKey::Merchant(MerchantDataKey::Subscriptions(merchant.clone(), m_count)),
@@ -4304,7 +4623,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .has(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
         {
             return Err(Error::Subscription(SubscriptionError::NotFound));
         }
@@ -4312,7 +4633,9 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .unwrap();
 
         let now = env.ledger().timestamp();
@@ -4330,7 +4653,9 @@ impl PaymentContract {
             }
 
             // Check customer spend limit (#282)
-            if let Err(_) = PaymentContract::check_and_update_spend_limit(&env, &sub.customer, sub.amount) {
+            if let Err(_) =
+                PaymentContract::check_and_update_spend_limit(&env, &sub.customer, sub.amount)
+            {
                 return Err(Error::Feature(FeatureError::SpendLimitExceeded));
             }
 
@@ -4350,9 +4675,10 @@ impl PaymentContract {
                     sub.status = SubscriptionStatus::Expired;
                 }
 
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+                env.storage().instance().set(
+                    &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                    &sub,
+                );
                 env.storage()
                     .instance()
                     .remove(&DataKey::State(StateDataKey::DunningState(subscription_id)));
@@ -4376,12 +4702,14 @@ impl PaymentContract {
 
                 if dunning.retry_count >= dunning.max_retries {
                     sub.status = SubscriptionStatus::Suspended;
-                    env.storage()
-                        .instance()
-                        .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
-                    env.storage()
-                        .instance()
-                        .set(&DataKey::State(StateDataKey::DunningState(subscription_id)), &dunning);
+                    env.storage().instance().set(
+                        &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                        &sub,
+                    );
+                    env.storage().instance().set(
+                        &DataKey::State(StateDataKey::DunningState(subscription_id)),
+                        &dunning,
+                    );
 
                     (SubscriptionSuspended {
                         subscription_id,
@@ -4394,9 +4722,10 @@ impl PaymentContract {
 
                 // Exponential backoff: backoff_seconds * 2^retry_count
                 dunning.next_retry_at = now + (dunning.backoff_seconds << dunning.retry_count);
-                env.storage()
-                    .instance()
-                    .set(&DataKey::State(StateDataKey::DunningState(subscription_id)), &dunning);
+                env.storage().instance().set(
+                    &DataKey::State(StateDataKey::DunningState(subscription_id)),
+                    &dunning,
+                );
 
                 (RecurringPaymentFailed {
                     subscription_id,
@@ -4418,9 +4747,10 @@ impl PaymentContract {
         // Check subscription has not ended
         if sub.ends_at > 0 && now >= sub.ends_at {
             sub.status = SubscriptionStatus::Expired;
-            env.storage()
-                .instance()
-                .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+            env.storage().instance().set(
+                &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                &sub,
+            );
             return Err(Error::Subscription(SubscriptionError::Ended));
         }
 
@@ -4432,14 +4762,17 @@ impl PaymentContract {
         // Skip charge if still within trial period
         if sub.trial_data.ends_at > 0 && now < sub.trial_data.ends_at {
             sub.next_payment_at = now + sub.interval;
-            env.storage()
-                .instance()
-                .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+            env.storage().instance().set(
+                &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                &sub,
+            );
             return Ok(());
         }
 
         // Check customer spend limit (#282)
-        if let Err(_) = PaymentContract::check_and_update_spend_limit(&env, &sub.customer, sub.amount) {
+        if let Err(_) =
+            PaymentContract::check_and_update_spend_limit(&env, &sub.customer, sub.amount)
+        {
             return Err(Error::Feature(FeatureError::SpendLimitExceeded));
         }
 
@@ -4471,9 +4804,10 @@ impl PaymentContract {
                 sub.status = SubscriptionStatus::Expired;
             }
 
-            env.storage()
-                .instance()
-                .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+            env.storage().instance().set(
+                &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                &sub,
+            );
 
             (RecurringPaymentExecuted {
                 subscription_id,
@@ -4534,12 +4868,14 @@ impl PaymentContract {
             last_reset_at: now,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Metered(sub_id)), &sub);
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::MeteredCounter), &sub_id);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Metered(sub_id)),
+            &sub,
+        );
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::MeteredCounter),
+            &sub_id,
+        );
 
         Ok(sub_id)
     }
@@ -4555,7 +4891,9 @@ impl PaymentContract {
         let mut sub: MeteredSubscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Metered(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Metered(
+                subscription_id,
+            )))
             .ok_or(Error::Subscription(SubscriptionError::MeteredNotFound))?;
 
         if sub.merchant != merchant {
@@ -4564,9 +4902,10 @@ impl PaymentContract {
 
         sub.accumulated_units = sub.accumulated_units.saturating_add(units);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Metered(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Metered(subscription_id)),
+            &sub,
+        );
 
         (UsageReported {
             subscription_id,
@@ -4581,7 +4920,9 @@ impl PaymentContract {
     pub fn get_current_usage(env: Env, subscription_id: u64) -> MeteredSubscription {
         env.storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Metered(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Metered(
+                subscription_id,
+            )))
             .expect("MeteredSubscription not found")
     }
 
@@ -4596,7 +4937,9 @@ impl PaymentContract {
         let mut sub: MeteredSubscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Metered(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Metered(
+                subscription_id,
+            )))
             .ok_or(Error::Subscription(SubscriptionError::MeteredNotFound))?;
 
         if sub.merchant != merchant {
@@ -4605,9 +4948,10 @@ impl PaymentContract {
 
         sub.billing_cap = Some(cap);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Metered(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Metered(subscription_id)),
+            &sub,
+        );
 
         Ok(())
     }
@@ -4616,7 +4960,9 @@ impl PaymentContract {
         let mut sub: MeteredSubscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Metered(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Metered(
+                subscription_id,
+            )))
             .ok_or(Error::Subscription(SubscriptionError::MeteredNotFound))?;
 
         let units_billed = sub.accumulated_units;
@@ -4645,9 +4991,10 @@ impl PaymentContract {
         sub.accumulated_units = 0;
         sub.last_reset_at = env.ledger().timestamp();
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Metered(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Metered(subscription_id)),
+            &sub,
+        );
 
         if cap_hit {
             (BillingCapReached {
@@ -4678,7 +5025,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .has(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
         {
             return Err(Error::Subscription(SubscriptionError::NotFound));
         }
@@ -4686,10 +5035,15 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .unwrap();
 
-        let config: Option<MultiSigConfig> = env.storage().instance().get(&DataKey::Config(ConfigKey::MultiSigConfig));
+        let config: Option<MultiSigConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::MultiSigConfig));
 
         let is_authorized = sub.customer == caller
             || sub.merchant == caller
@@ -4705,9 +5059,10 @@ impl PaymentContract {
         }
 
         sub.status = SubscriptionStatus::Cancelled;
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+            &sub,
+        );
 
         // Emit TrialCancelled if cancelled during trial
         let now = env.ledger().timestamp();
@@ -4739,7 +5094,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .has(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
         {
             return Err(Error::Subscription(SubscriptionError::NotFound));
         }
@@ -4747,7 +5104,9 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .unwrap();
 
         if sub.customer != customer {
@@ -4760,9 +5119,10 @@ impl PaymentContract {
 
         sub.status = SubscriptionStatus::Paused;
         sub.pause_data.last_paused_at = env.ledger().timestamp();
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+            &sub,
+        );
 
         (SubscriptionPaused { subscription_id }).publish(&env);
 
@@ -4780,7 +5140,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .has(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
         {
             return Err(Error::Subscription(SubscriptionError::NotFound));
         }
@@ -4788,7 +5150,9 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .unwrap();
 
         if sub.customer != customer {
@@ -4833,9 +5197,10 @@ impl PaymentContract {
             .publish(&env);
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+            &sub,
+        );
 
         (SubscriptionResumed {
             subscription_id,
@@ -4850,7 +5215,9 @@ impl PaymentContract {
     pub fn get_subscription(env: Env, subscription_id: u64) -> Subscription {
         env.storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .expect("Subscription not found")
     }
 
@@ -4864,7 +5231,9 @@ impl PaymentContract {
         let total: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::SubscriptionCount(customer.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::SubscriptionCount(
+                customer.clone(),
+            )))
             .unwrap_or(0);
 
         let mut result = Vec::new(&env);
@@ -4874,12 +5243,17 @@ impl PaymentContract {
             if let Some(sub_id) = env
                 .storage()
                 .instance()
-                .get::<DataKey, u64>(&DataKey::Customer(CustomerDataKey::Subscriptions(customer.clone(), i)))
+                .get::<DataKey, u64>(&DataKey::Customer(CustomerDataKey::Subscriptions(
+                    customer.clone(),
+                    i,
+                )))
             {
-                if let Some(sub) = env
-                    .storage()
-                    .instance()
-                    .get::<DataKey, Subscription>(&DataKey::Subscription(SubscriptionKey::Data(sub_id)))
+                if let Some(sub) =
+                    env.storage()
+                        .instance()
+                        .get::<DataKey, Subscription>(&DataKey::Subscription(
+                            SubscriptionKey::Data(sub_id),
+                        ))
                 {
                     result.push_back(sub);
                 }
@@ -4899,7 +5273,9 @@ impl PaymentContract {
         let total: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::SubscriptionCount(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::SubscriptionCount(
+                merchant.clone(),
+            )))
             .unwrap_or(0);
 
         let mut result = Vec::new(&env);
@@ -4909,12 +5285,17 @@ impl PaymentContract {
             if let Some(sub_id) = env
                 .storage()
                 .instance()
-                .get::<DataKey, u64>(&DataKey::Merchant(MerchantDataKey::Subscriptions(merchant.clone(), i)))
+                .get::<DataKey, u64>(&DataKey::Merchant(MerchantDataKey::Subscriptions(
+                    merchant.clone(),
+                    i,
+                )))
             {
-                if let Some(sub) = env
-                    .storage()
-                    .instance()
-                    .get::<DataKey, Subscription>(&DataKey::Subscription(SubscriptionKey::Data(sub_id)))
+                if let Some(sub) =
+                    env.storage()
+                        .instance()
+                        .get::<DataKey, Subscription>(&DataKey::Subscription(
+                            SubscriptionKey::Data(sub_id),
+                        ))
                 {
                     result.push_back(sub);
                 }
@@ -4975,7 +5356,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .has(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
         {
             return Err(Error::Subscription(SubscriptionError::NotFound));
         }
@@ -4983,7 +5366,9 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .unwrap();
 
         if sub.status != SubscriptionStatus::InDunning {
@@ -5021,9 +5406,10 @@ impl PaymentContract {
                 sub.status = SubscriptionStatus::Expired;
             }
 
-            env.storage()
-                .instance()
-                .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+            env.storage().instance().set(
+                &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                &sub,
+            );
             env.storage()
                 .instance()
                 .remove(&DataKey::State(StateDataKey::DunningState(subscription_id)));
@@ -5049,12 +5435,14 @@ impl PaymentContract {
 
             if dunning.retry_count >= dunning.max_retries {
                 sub.status = SubscriptionStatus::Suspended;
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
-                env.storage()
-                    .instance()
-                    .set(&DataKey::State(StateDataKey::DunningState(subscription_id)), &dunning);
+                env.storage().instance().set(
+                    &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                    &sub,
+                );
+                env.storage().instance().set(
+                    &DataKey::State(StateDataKey::DunningState(subscription_id)),
+                    &dunning,
+                );
 
                 (SubscriptionSuspended {
                     subscription_id,
@@ -5067,9 +5455,10 @@ impl PaymentContract {
 
             // Exponential backoff: backoff_seconds * 2^retry_count
             dunning.next_retry_at = now + (dunning.backoff_seconds << dunning.retry_count);
-            env.storage()
-                .instance()
-                .set(&DataKey::State(StateDataKey::DunningState(subscription_id)), &dunning);
+            env.storage().instance().set(
+                &DataKey::State(StateDataKey::DunningState(subscription_id)),
+                &dunning,
+            );
 
             (DunningRetryScheduled {
                 subscription_id,
@@ -5103,7 +5492,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .has(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
         {
             return Err(Error::Subscription(SubscriptionError::NotFound));
         }
@@ -5111,7 +5502,9 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .unwrap();
 
         if sub.status != SubscriptionStatus::InDunning
@@ -5125,9 +5518,10 @@ impl PaymentContract {
         sub.retry_count = 0;
         sub.next_payment_at = env.ledger().timestamp() + sub.interval;
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+            &sub,
+        );
 
         // Remove dunning state
         env.storage()
@@ -5159,20 +5553,24 @@ impl PaymentContract {
             last_failed_at: now,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::DunningState(subscription_id)), &dunning_state);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::DunningState(subscription_id)),
+            &dunning_state,
+        );
 
         // Update subscription status
-        if let Some(mut sub) = env
-            .storage()
-            .instance()
-            .get::<DataKey, Subscription>(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
-        {
-            sub.status = SubscriptionStatus::InDunning;
+        if let Some(mut sub) =
             env.storage()
                 .instance()
-                .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+                .get::<DataKey, Subscription>(&DataKey::Subscription(SubscriptionKey::Data(
+                    subscription_id,
+                )))
+        {
+            sub.status = SubscriptionStatus::InDunning;
+            env.storage().instance().set(
+                &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+                &sub,
+            );
         }
 
         (SubscriptionEnteredDunning {
@@ -5224,7 +5622,9 @@ impl PaymentContract {
     pub fn get_address_rate_limit(env: Env, address: Address) -> AddressRateLimit {
         env.storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::RateLimit(
+                address.clone(),
+            )))
             .unwrap_or(AddressRateLimit {
                 address: address.clone(),
                 payment_count: 0,
@@ -5254,7 +5654,9 @@ impl PaymentContract {
         let mut rate_limit: AddressRateLimit = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::RateLimit(
+                address.clone(),
+            )))
             .unwrap_or(AddressRateLimit {
                 address: address.clone(),
                 payment_count: 0,
@@ -5267,12 +5669,14 @@ impl PaymentContract {
             return Err(Error::Basic(BasicError::AddressAlreadyFlagged));
         }
         rate_limit.flagged = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())), &rate_limit);
-        env.storage()
-            .instance()
-            .set(&DataKey::Customer(CustomerDataKey::FlagReason(address.clone())), &reason);
+        env.storage().instance().set(
+            &DataKey::Customer(CustomerDataKey::RateLimit(address.clone())),
+            &rate_limit,
+        );
+        env.storage().instance().set(
+            &DataKey::Customer(CustomerDataKey::FlagReason(address.clone())),
+            &reason,
+        );
         (AddressFlagged { address, reason }).publish(&env);
         Ok(())
     }
@@ -5291,7 +5695,9 @@ impl PaymentContract {
         let mut rate_limit: AddressRateLimit = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::RateLimit(
+                address.clone(),
+            )))
             .unwrap_or(AddressRateLimit {
                 address: address.clone(),
                 payment_count: 0,
@@ -5304,12 +5710,15 @@ impl PaymentContract {
             return Err(Error::Payment(PaymentError::InvalidStatus));
         }
         rate_limit.flagged = false;
+        env.storage().instance().set(
+            &DataKey::Customer(CustomerDataKey::RateLimit(address.clone())),
+            &rate_limit,
+        );
         env.storage()
             .instance()
-            .set(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())), &rate_limit);
-        env.storage()
-            .instance()
-            .remove(&DataKey::Customer(CustomerDataKey::FlagReason(address.clone())));
+            .remove(&DataKey::Customer(CustomerDataKey::FlagReason(
+                address.clone(),
+            )));
         (AddressUnflagged { address }).publish(&env);
         Ok(())
     }
@@ -5318,7 +5727,9 @@ impl PaymentContract {
         let rate_limit: AddressRateLimit = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::RateLimit(
+                address.clone(),
+            )))
             .unwrap_or(AddressRateLimit {
                 address,
                 payment_count: 0,
@@ -5346,9 +5757,10 @@ impl PaymentContract {
         if !config.admins.contains(&admin) {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::Customer(CustomerDataKey::Allowlist(address)), &true);
+        env.storage().instance().set(
+            &DataKey::Customer(CustomerDataKey::Allowlist(address)),
+            &true,
+        );
         Ok(())
     }
 
@@ -5372,8 +5784,10 @@ impl PaymentContract {
     /// the configured rate limits and updates per-address counters.
     fn check_rate_limit_internal(env: &Env, address: &Address, amount: i128) -> Result<(), Error> {
         // If no config is set, rate limiting is disabled.
-        let config: Option<RateLimitConfig> =
-            env.storage().instance().get(&DataKey::Config(ConfigKey::RateLimitConfig));
+        let config: Option<RateLimitConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::RateLimitConfig));
         let config = match config {
             None => {
                 return Ok(());
@@ -5384,7 +5798,9 @@ impl PaymentContract {
         let mut rate_limit: AddressRateLimit = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::RateLimit(
+                address.clone(),
+            )))
             .unwrap_or(AddressRateLimit {
                 address: address.clone(),
                 payment_count: 0,
@@ -5450,9 +5866,10 @@ impl PaymentContract {
         rate_limit.payment_count += 1;
         rate_limit.last_payment_at = now;
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Customer(CustomerDataKey::RateLimit(address.clone())), &rate_limit);
+        env.storage().instance().set(
+            &DataKey::Customer(CustomerDataKey::RateLimit(address.clone())),
+            &rate_limit,
+        );
 
         Ok(())
     }
@@ -5460,7 +5877,9 @@ impl PaymentContract {
     fn is_allowlisted(env: &Env, address: &Address) -> bool {
         env.storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::Allowlist(address.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::Allowlist(
+                address.clone(),
+            )))
             .unwrap_or(false)
     }
 
@@ -5479,9 +5898,10 @@ impl PaymentContract {
         if !ms_config.admins.contains(&admin) {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::MerchantRateLimit(merchant)), &config);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::MerchantRateLimit(merchant)),
+            &config,
+        );
         Ok(())
     }
 
@@ -5517,10 +5937,12 @@ impl PaymentContract {
 
         let (max_tx, max_amt) = if let Some(tier_limits) = tier_limits_opt {
             (tier_limits.tx_per_period, tier_limits.volume_limit)
-        } else if let Some(custom_limit) = env
-            .storage()
-            .instance()
-            .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(merchant.clone())))
+        } else if let Some(custom_limit) =
+            env.storage()
+                .instance()
+                .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(
+                    merchant.clone(),
+                )))
         {
             (
                 custom_limit.max_transactions_per_hour,
@@ -5528,8 +5950,10 @@ impl PaymentContract {
             )
         } else {
             // Fallback to global config
-            let config: Option<RateLimitConfig> =
-                env.storage().instance().get(&DataKey::Config(ConfigKey::RateLimitConfig));
+            let config: Option<RateLimitConfig> = env
+                .storage()
+                .instance()
+                .get(&DataKey::Config(ConfigKey::RateLimitConfig));
             if let Some(config) = config {
                 if config.max_payment_amount > 0 && amount > config.max_payment_amount {
                     return false;
@@ -5541,7 +5965,9 @@ impl PaymentContract {
         if let Some(l) = env
             .storage()
             .instance()
-            .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(merchant.clone())))
+            .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(
+                merchant.clone(),
+            )))
         {
             let now = env.ledger().timestamp();
             let reset_needed = l.window_start > 0 && now >= l.window_start + 3600;
@@ -5573,18 +5999,22 @@ impl PaymentContract {
 
         let (max_tx, max_amt) = if let Some(tier_limits) = tier_limits_opt {
             (tier_limits.tx_per_period, tier_limits.volume_limit)
-        } else if let Some(custom_limit) = env
-            .storage()
-            .instance()
-            .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(merchant.clone())))
+        } else if let Some(custom_limit) =
+            env.storage()
+                .instance()
+                .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(
+                    merchant.clone(),
+                )))
         {
             (
                 custom_limit.max_transactions_per_hour,
                 custom_limit.max_amount_per_hour,
             )
         } else {
-            let config: Option<RateLimitConfig> =
-                env.storage().instance().get(&DataKey::Config(ConfigKey::RateLimitConfig));
+            let config: Option<RateLimitConfig> = env
+                .storage()
+                .instance()
+                .get(&DataKey::Config(ConfigKey::RateLimitConfig));
             if let Some(config) = config {
                 if config.max_payment_amount > 0 && amount > config.max_payment_amount {
                     return Err(Error::Basic(BasicError::AmountExceedsLimit));
@@ -5596,7 +6026,9 @@ impl PaymentContract {
         let mut limit = env
             .storage()
             .instance()
-            .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(merchant.clone())))
+            .get::<_, MerchantRateLimit>(&DataKey::Feature(FeatureKey::MerchantRateLimit(
+                merchant.clone(),
+            )))
             .unwrap_or(MerchantRateLimit {
                 merchant: merchant.clone(),
                 max_transactions_per_hour: max_tx,
@@ -5632,9 +6064,10 @@ impl PaymentContract {
 
         limit.current_transactions += 1;
         limit.current_amount += amount;
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::MerchantRateLimit(merchant.clone())), &limit);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::MerchantRateLimit(merchant.clone())),
+            &limit,
+        );
 
         Ok(())
     }
@@ -5802,7 +6235,10 @@ impl PaymentContract {
 
     /// Calculates the fee for a given amount and merchant (accounting for tier discount and waivers).
     pub fn calculate_fee(env: Env, amount: i128, merchant: Address) -> i128 {
-        let config: Option<FeeConfig> = env.storage().instance().get(&DataKey::Config(ConfigKey::FeeConfig));
+        let config: Option<FeeConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FeeConfig));
         let config = match config {
             None => {
                 return 0;
@@ -5856,9 +6292,10 @@ impl PaymentContract {
         let mut record =
             PaymentContract::get_or_default_merchant_fee_record(&env, merchant.clone());
         record.fee_tier = tier;
-        env.storage()
-            .instance()
-            .set(&DataKey::Merchant(MerchantDataKey::FeeRecord(merchant)), &record);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::FeeRecord(merchant)),
+            &record,
+        );
         Ok(())
     }
 
@@ -5928,9 +6365,10 @@ impl PaymentContract {
             &fee_config.treasury,
             &amount,
         );
-        env.storage()
-            .instance()
-            .set(&DataKey::Payment(PaymentKey::AccumulatedFees), &(accumulated - amount));
+        env.storage().instance().set(
+            &DataKey::Payment(PaymentKey::AccumulatedFees),
+            &(accumulated - amount),
+        );
         (FeesWithdrawn {
             amount,
             treasury: fee_config.treasury.clone(),
@@ -5949,7 +6387,10 @@ impl PaymentContract {
         token: &Address,
         customer: &Address,
     ) -> (i128, i128) {
-        let config: Option<FeeConfig> = env.storage().instance().get(&DataKey::Config(ConfigKey::FeeConfig));
+        let config: Option<FeeConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FeeConfig));
         let config = match config {
             None => {
                 return (amount, 0);
@@ -5989,9 +6430,10 @@ impl PaymentContract {
             .instance()
             .get(&DataKey::Payment(PaymentKey::AccumulatedFees))
             .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&DataKey::Payment(PaymentKey::AccumulatedFees), &(accumulated + fee));
+        env.storage().instance().set(
+            &DataKey::Payment(PaymentKey::AccumulatedFees),
+            &(accumulated + fee),
+        );
 
         (FeeCollected {
             payment_id,
@@ -6044,7 +6486,9 @@ impl PaymentContract {
     fn get_or_default_merchant_fee_record(env: &Env, merchant: Address) -> MerchantFeeRecord {
         env.storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::FeeRecord(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::FeeRecord(
+                merchant.clone(),
+            )))
             .unwrap_or(MerchantFeeRecord {
                 merchant,
                 total_fees_paid: 0,
@@ -6164,9 +6608,10 @@ impl PaymentContract {
             .publish(env);
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Merchant(MerchantDataKey::FeeRecord(merchant)), &record);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::FeeRecord(merchant)),
+            &record,
+        );
     }
 
     // ── FEE WAIVER FUNCTIONS ───────────────────────────────────────────────────
@@ -6204,9 +6649,10 @@ impl PaymentContract {
             granted_by: admin.clone(),
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Customer(CustomerDataKey::FeeWaiver(merchant.clone())), &waiver);
+        env.storage().instance().set(
+            &DataKey::Customer(CustomerDataKey::FeeWaiver(merchant.clone())),
+            &waiver,
+        );
 
         (FeeWaiverGranted {
             merchant,
@@ -6235,13 +6681,17 @@ impl PaymentContract {
         let _waiver: FeeWaiver = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::FeeWaiver(merchant.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::FeeWaiver(
+                merchant.clone(),
+            )))
             .ok_or(Error::Payment(PaymentError::NotFound))?; // Reuse existing error
 
         // Remove the waiver
         env.storage()
             .instance()
-            .remove(&DataKey::Customer(CustomerDataKey::FeeWaiver(merchant.clone())));
+            .remove(&DataKey::Customer(CustomerDataKey::FeeWaiver(
+                merchant.clone(),
+            )));
 
         (FeeWaiverRevoked {
             merchant,
@@ -6253,10 +6703,12 @@ impl PaymentContract {
     }
 
     pub fn get_fee_waiver(env: Env, merchant: Address) -> Option<FeeWaiver> {
-        let waiver: Option<FeeWaiver> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Customer(CustomerDataKey::FeeWaiver(merchant.clone())));
+        let waiver: Option<FeeWaiver> =
+            env.storage()
+                .instance()
+                .get(&DataKey::Customer(CustomerDataKey::FeeWaiver(
+                    merchant.clone(),
+                )));
 
         // Check if waiver is expired
         if let Some(w) = waiver {
@@ -6264,7 +6716,9 @@ impl PaymentContract {
                 // Remove expired waiver and publish expiration event
                 env.storage()
                     .instance()
-                    .remove(&DataKey::Customer(CustomerDataKey::FeeWaiver(merchant.clone())));
+                    .remove(&DataKey::Customer(CustomerDataKey::FeeWaiver(
+                        merchant.clone(),
+                    )));
 
                 (FeeWaiverExpired { merchant }).publish(&env);
                 None
@@ -6278,7 +6732,10 @@ impl PaymentContract {
 
     pub fn get_effective_fee_bps(env: Env, merchant: Address) -> u32 {
         // Get base fee configuration
-        let config: Option<FeeConfig> = env.storage().instance().get(&DataKey::Config(ConfigKey::FeeConfig));
+        let config: Option<FeeConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FeeConfig));
         let config = match config {
             None => return 0,
             Some(c) if !c.active => return 0,
@@ -6345,7 +6802,9 @@ impl PaymentContract {
         let accrual: MerchantRebateAccrual = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::RebateAccrual(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::RebateAccrual(
+                merchant.clone(),
+            )))
             .ok_or(Error::Feature(FeatureError::RebateThresholdNotMet))?;
 
         if accrual.accrued_rebate == 0 {
@@ -6360,9 +6819,10 @@ impl PaymentContract {
             .instance()
             .get(&DataKey::Payment(PaymentKey::AccumulatedFees))
             .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&DataKey::Payment(PaymentKey::AccumulatedFees), &(accumulated - rebate));
+        env.storage().instance().set(
+            &DataKey::Payment(PaymentKey::AccumulatedFees),
+            &(accumulated - rebate),
+        );
 
         let fee_config: FeeConfig = env
             .storage()
@@ -6379,9 +6839,10 @@ impl PaymentContract {
             period_start: accrual.period_start,
             period_volume: accrual.period_volume,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Merchant(MerchantDataKey::RebateAccrual(merchant)), &reset);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::RebateAccrual(merchant)),
+            &reset,
+        );
 
         Ok(rebate)
     }
@@ -6392,8 +6853,10 @@ impl PaymentContract {
         payment_amount: i128,
         fee_amount: i128,
     ) {
-        let config: Option<FeeRebateConfig> =
-            env.storage().instance().get(&DataKey::Config(ConfigKey::FeeRebateConfig));
+        let config: Option<FeeRebateConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FeeRebateConfig));
         let config = match config {
             Some(c) if c.active => c,
             _ => return,
@@ -6404,7 +6867,9 @@ impl PaymentContract {
         let mut accrual: MerchantRebateAccrual = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::RebateAccrual(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::RebateAccrual(
+                merchant.clone(),
+            )))
             .unwrap_or(MerchantRebateAccrual {
                 merchant: merchant.clone(),
                 accrued_rebate: 0,
@@ -6427,9 +6892,10 @@ impl PaymentContract {
             accrual.accrued_rebate += rebate;
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Merchant(MerchantDataKey::RebateAccrual(merchant)), &accrual);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::RebateAccrual(merchant)),
+            &accrual,
+        );
     }
 
     // ── BATCH PAYMENT OPERATIONS ──────────────────────────────────────────────
@@ -6717,10 +7183,15 @@ impl PaymentContract {
             let customer_count: u64 = env
                 .storage()
                 .instance()
-                .get(&DataKey::Customer(CustomerDataKey::PaymentCount(entry.customer.clone())))
+                .get(&DataKey::Customer(CustomerDataKey::PaymentCount(
+                    entry.customer.clone(),
+                )))
                 .unwrap_or(0);
             env.storage().instance().set(
-                &DataKey::Customer(CustomerDataKey::Payments(entry.customer.clone(), customer_count)),
+                &DataKey::Customer(CustomerDataKey::Payments(
+                    entry.customer.clone(),
+                    customer_count,
+                )),
                 &payment_id,
             );
             env.storage().instance().set(
@@ -6732,10 +7203,15 @@ impl PaymentContract {
             let merchant_count: u64 = env
                 .storage()
                 .instance()
-                .get(&DataKey::Merchant(MerchantDataKey::PaymentCount(entry.merchant.clone())))
+                .get(&DataKey::Merchant(MerchantDataKey::PaymentCount(
+                    entry.merchant.clone(),
+                )))
                 .unwrap_or(0);
             env.storage().instance().set(
-                &DataKey::Merchant(MerchantDataKey::Payments(entry.merchant.clone(), merchant_count)),
+                &DataKey::Merchant(MerchantDataKey::Payments(
+                    entry.merchant.clone(),
+                    merchant_count,
+                )),
                 &payment_id,
             );
             env.storage().instance().set(
@@ -6792,7 +7268,9 @@ impl PaymentContract {
             let mut m_analytics: MerchantAnalytics = env
                 .storage()
                 .instance()
-                .get(&DataKey::Merchant(MerchantDataKey::Analytics(entry.merchant.clone())))
+                .get(&DataKey::Merchant(MerchantDataKey::Analytics(
+                    entry.merchant.clone(),
+                )))
                 .unwrap_or(MerchantAnalytics {
                     total_payments: 0,
                     total_volume: 0,
@@ -6917,7 +7395,9 @@ impl PaymentContract {
         let mut conditional_payment: ConditionalPayment = env
             .storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::ConditionalPayment(payment_id)))
+            .get(&DataKey::State(StateDataKey::ConditionalPayment(
+                payment_id,
+            )))
             .ok_or(Error::Payment(PaymentError::NotFound))?;
 
         // Return cached result if already evaluated
@@ -6983,7 +7463,11 @@ impl PaymentContract {
         }
 
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -6991,7 +7475,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::State(StateDataKey::ConditionalPayment(payment_id)))
+            .has(&DataKey::State(StateDataKey::ConditionalPayment(
+                payment_id,
+            )))
         {
             return Err(Error::Payment(PaymentError::NotFound));
         }
@@ -7022,7 +7508,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::State(StateDataKey::ConditionalPayment(payment_id)))
+            .has(&DataKey::State(StateDataKey::ConditionalPayment(
+                payment_id,
+            )))
         {
             return Err(Error::Payment(PaymentError::NotFound));
         }
@@ -7044,7 +7532,9 @@ impl PaymentContract {
     pub fn get_conditional_payment(env: Env, payment_id: u64) -> Result<ConditionalPayment, Error> {
         env.storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::ConditionalPayment(payment_id)))
+            .get(&DataKey::State(StateDataKey::ConditionalPayment(
+                payment_id,
+            )))
             .ok_or(Error::Payment(PaymentError::NotFound))
     }
 
@@ -7095,14 +7585,21 @@ impl PaymentContract {
         let count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::MerchantCount(customer.clone())))
+            .get(&DataKey::Customer(CustomerDataKey::MerchantCount(
+                customer.clone(),
+            )))
             .unwrap_or(0);
 
         let mut pairs: Vec<(Address, i128)> = Vec::new(&env);
         for i in 0..count {
-            if let Some(merchant) = env.storage().instance().get::<DataKey, Address>(
-                &DataKey::Customer(CustomerDataKey::MerchantList(customer.clone(), i)),
-            ) {
+            if let Some(merchant) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, Address>(&DataKey::Customer(CustomerDataKey::MerchantList(
+                        customer.clone(),
+                        i,
+                    )))
+            {
                 let vol: i128 = env
                     .storage()
                     .instance()
@@ -7146,7 +7643,10 @@ impl PaymentContract {
     pub fn get_customer_monthly_volume(env: Env, customer: Address, month_timestamp: u64) -> i128 {
         env.storage()
             .instance()
-            .get(&DataKey::Customer(CustomerDataKey::MonthlyVolume(customer, month_timestamp)))
+            .get(&DataKey::Customer(CustomerDataKey::MonthlyVolume(
+                customer,
+                month_timestamp,
+            )))
             .unwrap_or(0)
     }
 
@@ -7162,13 +7662,12 @@ impl PaymentContract {
         let mut out = Vec::new(&env);
         let mut bucket_start = PaymentContract::hour_bucket_start(from);
         while bucket_start < to {
-            if let Some(bucket) = env
-                .storage()
-                .instance()
-                .get::<DataKey, AnalyticsBucket>(&DataKey::Merchant(MerchantDataKey::AnalyticsBucket(
-                    merchant.clone(),
-                    bucket_start,
-                )))
+            if let Some(bucket) =
+                env.storage()
+                    .instance()
+                    .get::<DataKey, AnalyticsBucket>(&DataKey::Merchant(
+                        MerchantDataKey::AnalyticsBucket(merchant.clone(), bucket_start),
+                    ))
             {
                 out.push_back(bucket);
             }
@@ -7181,7 +7680,9 @@ impl PaymentContract {
         let day_start = PaymentContract::day_bucket_start(day_timestamp);
         env.storage()
             .instance()
-            .get(&DataKey::Feature(FeatureKey::PlatformAnalyticsDaily(day_start)))
+            .get(&DataKey::Feature(FeatureKey::PlatformAnalyticsDaily(
+                day_start,
+            )))
             .unwrap_or(AnalyticsBucket {
                 bucket_start: day_start,
                 bucket_end: day_start + 86400,
@@ -7291,7 +7792,9 @@ impl PaymentContract {
         let mut bucket: AnalyticsBucket = env
             .storage()
             .instance()
-            .get(&DataKey::Feature(FeatureKey::PlatformAnalyticsDaily(day_start)))
+            .get(&DataKey::Feature(FeatureKey::PlatformAnalyticsDaily(
+                day_start,
+            )))
             .unwrap_or(AnalyticsBucket {
                 bucket_start: day_start,
                 bucket_end: day_start + 86400,
@@ -7306,9 +7809,10 @@ impl PaymentContract {
         bucket.total_volume += volume_delta;
         bucket.total_refunds += refund_delta;
         bucket.failed_count += failed_delta;
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::PlatformAnalyticsDaily(day_start)), &bucket);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::PlatformAnalyticsDaily(day_start)),
+            &bucket,
+        );
     }
 
     fn default_customer_analytics() -> CustomerAnalytics {
@@ -7373,12 +7877,14 @@ impl PaymentContract {
             changed_at: now,
             reason: reason.clone(),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryEntry(history_count)), &entry);
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryCount), &(history_count + 1));
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryEntry(history_count)),
+            &entry,
+        );
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryCount),
+            &(history_count + 1),
+        );
         (ContractPausedEvent {
             paused_by: admin,
             reason,
@@ -7422,12 +7928,14 @@ impl PaymentContract {
             changed_at: now,
             reason: String::from_str(&env, ""),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryEntry(history_count)), &entry);
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryCount), &(history_count + 1));
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryEntry(history_count)),
+            &entry,
+        );
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryCount),
+            &(history_count + 1),
+        );
         (ContractUnpausedEvent {
             unpaused_by: admin,
             unpaused_at: now,
@@ -7489,12 +7997,14 @@ impl PaymentContract {
             changed_at: now,
             reason: reason.clone(),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryEntry(history_count)), &entry);
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryCount), &(history_count + 1));
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryEntry(history_count)),
+            &entry,
+        );
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryCount),
+            &(history_count + 1),
+        );
         (FunctionPausedEvent {
             function_name,
             paused_by: admin,
@@ -7544,12 +8054,14 @@ impl PaymentContract {
             changed_at: now,
             reason: String::from_str(&env, ""),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryEntry(history_count)), &entry);
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::PauseHistoryCount), &(history_count + 1));
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryEntry(history_count)),
+            &entry,
+        );
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::PauseHistoryCount),
+            &(history_count + 1),
+        );
         (FunctionUnpausedEvent {
             function_name,
             unpaused_by: admin,
@@ -7620,9 +8132,10 @@ impl PaymentContract {
             escrow_contract,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::AutoEscrowRule(merchant)), &rule);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::AutoEscrowRule(merchant)),
+            &rule,
+        );
 
         Ok(())
     }
@@ -7655,7 +8168,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::State(StateDataKey::AutoEscrowRule(merchant.clone())))
+            .has(&DataKey::State(StateDataKey::AutoEscrowRule(
+                merchant.clone(),
+            )))
         {
             return Err(Error::Feature(FeatureError::AutoEscrowRuleNotFound));
         }
@@ -7669,7 +8184,11 @@ impl PaymentContract {
 
     pub fn trigger_auto_escrow(env: &Env, payment_id: u64) -> Result<(), Error> {
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
@@ -7679,7 +8198,9 @@ impl PaymentContract {
         if env
             .storage()
             .instance()
-            .has(&DataKey::State(StateDataKey::AutoEscrowTriggered(payment_id)))
+            .has(&DataKey::State(StateDataKey::AutoEscrowTriggered(
+                payment_id,
+            )))
         {
             return Err(Error::Feature(FeatureError::AutoEscrowAlreadyTriggered));
         }
@@ -7729,9 +8250,10 @@ impl PaymentContract {
         );
 
         // Mark escrow as triggered for this payment
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::AutoEscrowTriggered(payment_id)), &escrow_id);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::AutoEscrowTriggered(payment_id)),
+            &escrow_id,
+        );
 
         // Emit event
         (AutoEscrowTriggered {
@@ -7784,9 +8306,10 @@ impl PaymentContract {
             return Err(Error::Basic(BasicError::NotAnAdmin));
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Config(ConfigKey::LargePaymentThreshold), &threshold);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::LargePaymentThreshold),
+            &threshold,
+        );
 
         (LargePaymentThresholdUpdated {
             threshold,
@@ -7832,9 +8355,9 @@ impl PaymentContract {
         if env
             .storage()
             .instance()
-            .get::<DataKey, LargePaymentProposal>(&DataKey::State(StateDataKey::LargePaymentProposal(
-                payment_id,
-            )))
+            .get::<DataKey, LargePaymentProposal>(&DataKey::State(
+                StateDataKey::LargePaymentProposal(payment_id),
+            ))
             .is_some()
         {
             return Err(Error::Payment(PaymentError::AlreadyProcessed));
@@ -7861,9 +8384,10 @@ impl PaymentContract {
             executed: false,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::LargePaymentProposal(payment_id)), &proposal);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::LargePaymentProposal(payment_id)),
+            &proposal,
+        );
 
         (LargePaymentProposed {
             payment_id,
@@ -7896,7 +8420,9 @@ impl PaymentContract {
         let mut proposal: LargePaymentProposal = env
             .storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::LargePaymentProposal(payment_id)))
+            .get(&DataKey::State(StateDataKey::LargePaymentProposal(
+                payment_id,
+            )))
             .ok_or(Error::Payment(PaymentError::NotFound))?;
 
         if proposal.executed {
@@ -7913,9 +8439,10 @@ impl PaymentContract {
 
         proposal.approvals.push_back(approver.clone());
 
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::LargePaymentProposal(payment_id)), &proposal);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::LargePaymentProposal(payment_id)),
+            &proposal,
+        );
 
         (LargePaymentApproved {
             payment_id,
@@ -7937,7 +8464,9 @@ impl PaymentContract {
         let mut proposal: LargePaymentProposal = env
             .storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::LargePaymentProposal(payment_id)))
+            .get(&DataKey::State(StateDataKey::LargePaymentProposal(
+                payment_id,
+            )))
             .ok_or(Error::Payment(PaymentError::NotFound))?;
 
         if proposal.executed {
@@ -7979,9 +8508,10 @@ impl PaymentContract {
             .set(&DataKey::Payment(PaymentKey::Data(payment_id)), &payment);
 
         proposal.executed = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::LargePaymentProposal(payment_id)), &proposal);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::LargePaymentProposal(payment_id)),
+            &proposal,
+        );
 
         (PaymentCompleted {
             payment_id,
@@ -7998,7 +8528,9 @@ impl PaymentContract {
     pub fn get_large_payment_proposal(env: Env, payment_id: u64) -> LargePaymentProposal {
         env.storage()
             .instance()
-            .get(&DataKey::State(StateDataKey::LargePaymentProposal(payment_id)))
+            .get(&DataKey::State(StateDataKey::LargePaymentProposal(
+                payment_id,
+            )))
             .expect("Large payment proposal not found")
     }
 
@@ -8016,14 +8548,22 @@ impl PaymentContract {
         caller.require_auth();
 
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
         let payment = PaymentContract::get_payment(&env, payment_id);
 
         // Verify caller is customer, merchant, or admin
-        let admin: Address = env.storage().instance().get(&DataKey::Config(ConfigKey::Admin)).unwrap();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::Admin))
+            .unwrap();
         if caller != payment.customer && caller != payment.merchant && caller != admin {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
@@ -8046,9 +8586,10 @@ impl PaymentContract {
                 version: new_version,
             };
 
-            env.storage()
-                .instance()
-                .set(&DataKey::Payment(PaymentKey::Metadata(payment_id)), &updated_metadata);
+            env.storage().instance().set(
+                &DataKey::Payment(PaymentKey::Metadata(payment_id)),
+                &updated_metadata,
+            );
 
             PaymentMetadataUpdated {
                 payment_id,
@@ -8068,9 +8609,10 @@ impl PaymentContract {
                 version: 1,
             };
 
-            env.storage()
-                .instance()
-                .set(&DataKey::Payment(PaymentKey::Metadata(payment_id)), &metadata);
+            env.storage().instance().set(
+                &DataKey::Payment(PaymentKey::Metadata(payment_id)),
+                &metadata,
+            );
 
             PaymentMetadataSet {
                 payment_id,
@@ -8121,14 +8663,22 @@ impl PaymentContract {
         caller.require_auth();
 
         // Check if payment exists
-        if !env.storage().instance().has(&DataKey::Payment(PaymentKey::Data(payment_id))) {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Payment(PaymentKey::Data(payment_id)))
+        {
             return Err(Error::Payment(PaymentError::NotFound));
         }
 
         let payment = PaymentContract::get_payment(&env, payment_id);
 
         // Verify caller is customer, merchant, or admin
-        let admin: Address = env.storage().instance().get(&DataKey::Config(ConfigKey::Admin)).unwrap();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::Admin))
+            .unwrap();
         if caller != payment.customer && caller != payment.merchant && caller != admin {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
@@ -8163,9 +8713,10 @@ impl PaymentContract {
                 created_by: existing.created_by,
             };
 
-            env.storage()
-                .instance()
-                .set(&DataKey::Payment(PaymentKey::Memo(payment_id)), &updated_memo);
+            env.storage().instance().set(
+                &DataKey::Payment(PaymentKey::Memo(payment_id)),
+                &updated_memo,
+            );
 
             PaymentMemoUpdated {
                 payment_id,
@@ -8369,7 +8920,9 @@ impl PaymentContract {
         if !env
             .storage()
             .instance()
-            .has(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .has(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
         {
             return Err(Error::Subscription(SubscriptionError::NotFound));
         }
@@ -8377,7 +8930,9 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .unwrap();
 
         if sub.customer != customer {
@@ -8385,9 +8940,10 @@ impl PaymentContract {
         }
 
         sub.pause_data.proration_enabled = enabled;
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+            &sub,
+        );
 
         Ok(())
     }
@@ -8432,12 +8988,14 @@ impl PaymentContract {
             customer_pk,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::PaymentChannel(channel_id)), &channel);
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::PaymentChannelCounter), &channel_id);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::PaymentChannel(channel_id)),
+            &channel,
+        );
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::PaymentChannelCounter),
+            &channel_id,
+        );
 
         (ChannelOpened {
             channel_id,
@@ -8504,9 +9062,10 @@ impl PaymentContract {
         channel.settled_nonce = nonce;
         channel.open = false;
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::PaymentChannel(channel_id)), &channel);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::PaymentChannel(channel_id)),
+            &channel,
+        );
 
         (ChannelSettled {
             channel_id,
@@ -8542,9 +9101,10 @@ impl PaymentContract {
         }
 
         channel.open = false;
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::PaymentChannel(channel_id)), &channel);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::PaymentChannel(channel_id)),
+            &channel,
+        );
 
         (ChannelExpiredClosed {
             channel_id,
@@ -8592,6 +9152,25 @@ impl PaymentContract {
             return Err(Error::Feature(FeatureError::InvalidSplitShares));
         }
 
+        for r in recipients.iter() {
+            if r.address == customer {
+                return Err(Error::Feature(FeatureError::SenderIsRecipient));
+            }
+        }
+
+        let min_split: Option<i128> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::MinSplitAmount));
+        if let Some(min_amount) = min_split {
+            for r in recipients.iter() {
+                let share = (amount * r.share_bps as i128) / 10000;
+                if share < min_amount {
+                    return Err(Error::Feature(FeatureError::BelowMinSplitAmount));
+                }
+            }
+        }
+
         // Check customer spend limit (#282)
         PaymentContract::check_and_update_spend_limit(&env, &customer, amount)?;
 
@@ -8633,9 +9212,10 @@ impl PaymentContract {
             recipients,
             executed: false,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::SplitConfig(payment_id)), &config);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::SplitConfig(payment_id)),
+            &config,
+        );
 
         Ok(payment_id)
     }
@@ -8672,9 +9252,10 @@ impl PaymentContract {
         }
 
         config.executed = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::SplitConfig(payment_id)), &config);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::SplitConfig(payment_id)),
+            &config,
+        );
 
         Ok(())
     }
@@ -8683,6 +9264,28 @@ impl PaymentContract {
         env.storage()
             .instance()
             .get(&DataKey::Feature(FeatureKey::SplitConfig(payment_id)))
+    }
+
+    pub fn set_min_split_amount(env: Env, admin: Address, min_amount: i128) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::MultiSigConfig))
+            .ok_or(Error::Basic(BasicError::MultiSigNotInitialized))?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Basic(BasicError::Unauthorized));
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Config(ConfigKey::MinSplitAmount), &min_amount);
+        Ok(())
+    }
+
+    pub fn get_min_split_amount(env: Env) -> Option<i128> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::MinSplitAmount))
     }
 
     // ── FEE SWEEP (#216) ─────────────────────────────────────────────────────
@@ -8752,9 +9355,10 @@ impl PaymentContract {
             recipient,
             swept_at: env.ledger().timestamp(),
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::SweepHistory(sweep_id)), &record);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::SweepHistory(sweep_id)),
+            &record,
+        );
         Ok(accumulated)
     }
 
@@ -8771,7 +9375,11 @@ impl PaymentContract {
             1
         };
         for i in start..=total {
-            if let Some(record) = env.storage().instance().get(&DataKey::Feature(FeatureKey::SweepHistory(i))) {
+            if let Some(record) = env
+                .storage()
+                .instance()
+                .get(&DataKey::Feature(FeatureKey::SweepHistory(i)))
+            {
                 result.push_back(record);
             }
         }
@@ -8811,9 +9419,10 @@ impl PaymentContract {
             used: 0,
             period_start: now,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::CustomerSpendLimit(customer)), &spend_limit);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::CustomerSpendLimit(customer)),
+            &spend_limit,
+        );
         Ok(())
     }
 
@@ -8867,10 +9476,12 @@ impl PaymentContract {
         customer: &Address,
         amount: i128,
     ) -> Result<(), Error> {
-        let limit: Option<CustomerSpendLimit> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Feature(FeatureKey::CustomerSpendLimit(customer.clone())));
+        let limit: Option<CustomerSpendLimit> =
+            env.storage()
+                .instance()
+                .get(&DataKey::Feature(FeatureKey::CustomerSpendLimit(
+                    customer.clone(),
+                )));
         let mut limit = match limit {
             None => return Ok(()),
             Some(l) => l,
@@ -8884,9 +9495,10 @@ impl PaymentContract {
             return Err(Error::Feature(FeatureError::SpendLimitExceeded));
         }
         limit.used += amount;
-        env.storage()
-            .instance()
-            .set(&DataKey::Feature(FeatureKey::CustomerSpendLimit(customer.clone())), &limit);
+        env.storage().instance().set(
+            &DataKey::Feature(FeatureKey::CustomerSpendLimit(customer.clone())),
+            &limit,
+        );
         Ok(())
     }
 
@@ -8904,9 +9516,10 @@ impl PaymentContract {
             .get(&DataKey::Subscription(SubscriptionKey::GroupCounter))
             .unwrap_or(0)
             + 1;
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::GroupCounter), &group_id);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::GroupCounter),
+            &group_id,
+        );
         let group = SubscriptionGroup {
             group_id,
             owner,
@@ -8914,9 +9527,10 @@ impl PaymentContract {
             discount_bps,
             active: true,
         };
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Group(group_id)), &group);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Group(group_id)),
+            &group,
+        );
         Ok(group_id)
     }
 
@@ -8936,20 +9550,25 @@ impl PaymentContract {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
         if group.subscription_ids.len() >= 20 {
-            return Err(Error::Subscription(SubscriptionError::GroupSizeLimitExceeded));
+            return Err(Error::Subscription(
+                SubscriptionError::GroupSizeLimitExceeded,
+            ));
         }
         if env
             .storage()
             .instance()
-            .get::<DataKey, u64>(&DataKey::Subscription(SubscriptionKey::GroupMembership(subscription_id)))
+            .get::<DataKey, u64>(&DataKey::Subscription(SubscriptionKey::GroupMembership(
+                subscription_id,
+            )))
             .is_some()
         {
             return Err(Error::Subscription(SubscriptionError::AlreadyInGroup));
         }
         group.subscription_ids.push_back(subscription_id);
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Group(group_id)), &group);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Group(group_id)),
+            &group,
+        );
         env.storage().instance().set(
             &DataKey::Subscription(SubscriptionKey::GroupMembership(subscription_id)),
             &group_id,
@@ -8979,12 +9598,15 @@ impl PaymentContract {
             }
         }
         group.subscription_ids = new_ids;
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Group(group_id)),
+            &group,
+        );
         env.storage()
             .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Group(group_id)), &group);
-        env.storage()
-            .instance()
-            .remove(&DataKey::Subscription(SubscriptionKey::GroupMembership(subscription_id)));
+            .remove(&DataKey::Subscription(SubscriptionKey::GroupMembership(
+                subscription_id,
+            )));
         Ok(())
     }
 
@@ -9045,14 +9667,18 @@ impl PaymentContract {
     }
 
     pub fn get_finality_config(env: Env) -> Option<FinalityConfig> {
-        env.storage().instance().get(&DataKey::Config(ConfigKey::FinalityConfig))
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FinalityConfig))
     }
 
     pub fn finalize_pending_settlement(env: Env, payment_id: u64) -> Result<(), Error> {
         if env
             .storage()
             .instance()
-            .has(&DataKey::State(StateDataKey::SettlementFinalized(payment_id)))
+            .has(&DataKey::State(StateDataKey::SettlementFinalized(
+                payment_id,
+            )))
         {
             return Err(Error::Feature(FeatureError::SettlementAlreadyFinalized));
         }
@@ -9071,9 +9697,10 @@ impl PaymentContract {
             &settlement.merchant,
             &settlement.amount,
         );
-        env.storage()
-            .instance()
-            .set(&DataKey::State(StateDataKey::SettlementFinalized(payment_id)), &true);
+        env.storage().instance().set(
+            &DataKey::State(StateDataKey::SettlementFinalized(payment_id)),
+            &true,
+        );
         Ok(())
     }
 
@@ -9081,18 +9708,22 @@ impl PaymentContract {
         let count: u64 = env
             .storage()
             .instance()
-            .get(&DataKey::Merchant(MerchantDataKey::PendingSettlementCount(merchant.clone())))
+            .get(&DataKey::Merchant(MerchantDataKey::PendingSettlementCount(
+                merchant.clone(),
+            )))
             .unwrap_or(0);
         let mut result = Vec::new(&env);
         for i in 0..count {
-            if let Some(payment_id) = env.storage().instance().get::<DataKey, u64>(
-                &DataKey::Merchant(MerchantDataKey::PendingSettlementIndex(merchant.clone(), i)),
-            ) {
-                if !env
-                    .storage()
+            if let Some(payment_id) =
+                env.storage()
                     .instance()
-                    .has(&DataKey::State(StateDataKey::SettlementFinalized(payment_id)))
-                {
+                    .get::<DataKey, u64>(&DataKey::Merchant(
+                        MerchantDataKey::PendingSettlementIndex(merchant.clone(), i),
+                    ))
+            {
+                if !env.storage().instance().has(&DataKey::State(
+                    StateDataKey::SettlementFinalized(payment_id),
+                )) {
                     if let Some(s) = env
                         .storage()
                         .instance()
@@ -9150,7 +9781,10 @@ impl PaymentContract {
         routes.push_back(direct);
 
         // Fee-bearing route using configured fee (if any)
-        let fee_config: Option<FeeConfig> = env.storage().instance().get(&DataKey::Config(ConfigKey::FeeConfig));
+        let fee_config: Option<FeeConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FeeConfig));
         if let Some(fc) = fee_config {
             if fc.active && fc.fee_bps > 0 {
                 let fee = (amount * fc.fee_bps as i128) / 10000;
@@ -9200,7 +9834,10 @@ impl PaymentContract {
         customer.require_auth();
 
         // Validate route is still valid at execution time
-        let fee_config: Option<FeeConfig> = env.storage().instance().get(&DataKey::Config(ConfigKey::FeeConfig));
+        let fee_config: Option<FeeConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::FeeConfig));
         let current_fee_bps = fee_config
             .filter(|fc| fc.active)
             .map(|fc| fc.fee_bps)
@@ -9360,7 +9997,9 @@ impl PaymentContract {
         }
 
         // Verify total
-        let total = subtotal.checked_add(tax).ok_or(Error::Basic(BasicError::InvalidAmount))?;
+        let total = subtotal
+            .checked_add(tax)
+            .ok_or(Error::Basic(BasicError::InvalidAmount))?;
         if total != payment.amount {
             return Err(Error::Payment(PaymentError::RefundExceedsPayment));
         }
@@ -9391,9 +10030,10 @@ impl PaymentContract {
         env.storage()
             .persistent()
             .set(&DataKey::Payment(PaymentKey::InvoiceCounter), &invoice_id);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Payment(PaymentKey::InvoicePaymentId(invoice_id)), &payment_id);
+        env.storage().persistent().set(
+            &DataKey::Payment(PaymentKey::InvoicePaymentId(invoice_id)),
+            &payment_id,
+        );
 
         Ok(invoice_id)
     }
@@ -9434,7 +10074,6 @@ impl PaymentContract {
 
         Ok(())
     }
-
 }
 
 mod test;
@@ -9476,3 +10115,6 @@ mod test_fee_rebate;
 
 #[cfg(test)]
 mod test_payment_forward;
+
+#[cfg(test)]
+mod test_scheduled_payment;

--- a/contracts/payment/src/test.rs
+++ b/contracts/payment/src/test.rs
@@ -131,7 +131,10 @@ fn test_batch_accumulation_and_premature_trigger() {
 
     // Attempt to trigger payout prematurely
     let res = client.try_trigger_scheduled_payout(&merchant);
-    assert_eq!(res.unwrap_err().unwrap(), Error::Payment(PaymentError::PayoutNotYetDue));
+    assert_eq!(
+        res.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::PayoutNotYetDue)
+    );
 }
 
 #[test]
@@ -242,7 +245,10 @@ fn test_flag_address_blocks_payments() {
         &0,
         &meta,
     );
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::AddressFlagged));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::AddressFlagged)
+    );
 }
 
 #[test]
@@ -321,7 +327,10 @@ fn test_unflag_requires_current_flag() {
     let customer = Address::generate(&env);
 
     let result = client.try_unflag_address(&admin, &customer);
-    assert_eq!(result.unwrap_err().unwrap(), Error::Payment(PaymentError::InvalidStatus));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::InvalidStatus)
+    );
 }
 
 #[test]
@@ -349,7 +358,10 @@ fn test_flag_address_fails_if_already_flagged() {
     client.flag_address(&admin, &customer, &String::from_str(&env, "first reason"));
     let result =
         client.try_flag_address(&admin, &customer, &String::from_str(&env, "second reason"));
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::AddressAlreadyFlagged));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::AddressAlreadyFlagged)
+    );
 }
 
 #[test]
@@ -422,7 +434,10 @@ fn test_rate_limit_breach_event_emitted() {
 
     // Failed invocations may rollback emitted events in host simulation.
     // The key behavior is that the payment attempt is rejected.
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::RateLimitExceeded));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::RateLimitExceeded)
+    );
 }
 
 #[test]
@@ -846,7 +861,10 @@ fn test_redeem_points_fails_when_points_are_expired() {
 
     env.ledger().set_timestamp(1101);
     let result = client.try_redeem_points(&customer, &10, &payment_id);
-    assert_eq!(result.unwrap_err().unwrap(), Error::Feature(FeatureError::PointsExpired));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Feature(FeatureError::PointsExpired)
+    );
 }
 
 #[test]
@@ -1275,7 +1293,10 @@ fn test_cancel_nonexistent_payment() {
     // Try to cancel a non-existent payment
     let result = client.try_cancel_payment(&caller, &999);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Payment(PaymentError::NotFound));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::NotFound)
+    );
 }
 
 #[test]
@@ -1305,7 +1326,10 @@ fn test_cancel_payment_unauthorized() {
     // Try to cancel as unauthorized user
     let result = client.try_cancel_payment(&unauthorized_user, &payment_id);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::Unauthorized));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::Unauthorized)
+    );
 }
 
 #[test]
@@ -1381,7 +1405,10 @@ fn test_cancel_refunded_payment() {
     // Try to cancel refunded payment
     let result = client.try_cancel_payment(&customer, &payment_id);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Payment(PaymentError::InvalidStatus));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::InvalidStatus)
+    );
 }
 
 #[test]
@@ -1413,7 +1440,10 @@ fn test_cancel_already_cancelled_payment() {
     // Try to cancel again
     let result = client.try_cancel_payment(&customer, &payment_id);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Payment(PaymentError::InvalidStatus));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::InvalidStatus)
+    );
 }
 
 #[test]
@@ -2811,7 +2841,10 @@ fn test_create_payment_metadata_too_large() {
         &large_metadata,
     );
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::MetadataTooLarge));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::MetadataTooLarge)
+    );
 }
 
 #[test]
@@ -2938,7 +2971,10 @@ fn test_update_payment_notes_unauthorized() {
     let notes = String::from_str(&env, "Unauthorized note");
     let result = client.try_update_payment_notes(&unauthorized, &payment_id, &notes);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::Unauthorized));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::Unauthorized)
+    );
 }
 
 #[test]
@@ -2968,7 +3004,10 @@ fn test_update_payment_notes_customer_cannot_update() {
     let notes = String::from_str(&env, "Customer trying to add notes");
     let result = client.try_update_payment_notes(&customer, &payment_id, &notes);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::Unauthorized));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::Unauthorized)
+    );
 }
 
 #[test]
@@ -2984,7 +3023,10 @@ fn test_update_payment_notes_payment_not_found() {
 
     let result = client.try_update_payment_notes(&merchant, &999, &notes);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Payment(PaymentError::NotFound));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::NotFound)
+    );
 }
 
 #[test]
@@ -3015,7 +3057,10 @@ fn test_update_payment_notes_too_large() {
     let large_notes = String::from_str(&env, &"x".repeat(1025));
     let result = client.try_update_payment_notes(&merchant, &payment_id, &large_notes);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::NotesTooLarge));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::NotesTooLarge)
+    );
 }
 
 #[test]
@@ -3345,7 +3390,10 @@ fn test_set_conversion_rate_unauthorized() {
 
     let result = client.try_set_conversion_rate(&unauthorized, &Currency::BTC, &50000_0000000);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::Unauthorized));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::Unauthorized)
+    );
 }
 
 #[test]
@@ -3528,7 +3576,10 @@ fn test_partial_refund_exceeds_payment() {
 
     let result = client.try_partial_refund(&admin, &payment_id, &1500);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Payment(PaymentError::RefundExceedsPayment));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::RefundExceedsPayment)
+    );
 }
 
 #[test]
@@ -3560,7 +3611,10 @@ fn test_partial_refund_cumulative_exceeds_payment() {
     client.partial_refund(&admin, &payment_id, &700);
     let result = client.try_partial_refund(&admin, &payment_id, &400);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Payment(PaymentError::RefundExceedsPayment));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Payment(PaymentError::RefundExceedsPayment)
+    );
 }
 
 #[test]
@@ -3714,7 +3768,10 @@ fn test_merchant_rate_limit_global_fallback() {
         &meta,
     );
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::AmountExceedsLimit));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::AmountExceedsLimit)
+    );
 }
 
 #[test]
@@ -3841,7 +3898,10 @@ fn test_dunning_retry_too_early_returns_error() {
     // Calling before next_retry_at must return RetryTooEarly
     env.ledger().set_timestamp(next_retry - 1);
     let result = client.try_execute_recurring_payment(&sub_id);
-    assert_eq!(result, Err(Ok(Error::Subscription(SubscriptionError::RetryTooEarly))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Subscription(SubscriptionError::RetryTooEarly)))
+    );
 }
 
 #[test]
@@ -3918,7 +3978,10 @@ fn test_dunning_max_retries_suspends_subscription() {
     assert_eq!(sub.status, SubscriptionStatus::Suspended);
 
     let last = client.try_execute_recurring_payment(&sub_id);
-    assert_eq!(last, Err(Ok(Error::Subscription(SubscriptionError::NotActive))));
+    assert_eq!(
+        last,
+        Err(Ok(Error::Subscription(SubscriptionError::NotActive)))
+    );
 }
 
 #[test]
@@ -4272,10 +4335,16 @@ fn test_disputed_escrowed_payment_cannot_be_completed_or_cancelled() {
     );
 
     let complete_result = payment_client.try_complete_escrowed_payment(&admin, &ids.0);
-    assert_eq!(complete_result, Err(Ok(Error::Payment(PaymentError::InvalidStatus))));
+    assert_eq!(
+        complete_result,
+        Err(Ok(Error::Payment(PaymentError::InvalidStatus)))
+    );
 
     let cancel_result = payment_client.try_cancel_escrowed_payment(&customer, &ids.0);
-    assert_eq!(cancel_result, Err(Ok(Error::Payment(PaymentError::InvalidStatus))));
+    assert_eq!(
+        cancel_result,
+        Err(Ok(Error::Payment(PaymentError::InvalidStatus)))
+    );
 }
 
 #[test]
@@ -5416,7 +5485,10 @@ fn test_set_tier_thresholds_validates_ascending_order() {
         ],
     );
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::InvalidTierThresholds));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::InvalidTierThresholds)
+    );
 }
 
 #[test]
@@ -6043,7 +6115,10 @@ fn test_evaluate_condition_oracle_price_fails() {
     // Oracle conditions should fail with OracleCallFailed error
     let result = client.try_evaluate_condition(&payment_id);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Ok(Error::Basic(BasicError::OracleCallFailed))));
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::Basic(BasicError::OracleCallFailed)))
+    );
 }
 
 #[test]
@@ -6072,7 +6147,10 @@ fn test_evaluate_condition_cross_contract_state_false() {
 
     // Cross-contract invoke failures should return a typed error.
     let result = client.try_evaluate_condition(&payment_id);
-    assert_eq!(result.err(), Some(Ok(Error::Feature(FeatureError::ConditionEvaluationFailed))));
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::Feature(FeatureError::ConditionEvaluationFailed)))
+    );
 }
 
 #[test]
@@ -6138,7 +6216,10 @@ fn test_complete_conditional_payment_condition_not_met() {
     // Attempt to complete should fail with ConditionNotMet
     let result = client.try_complete_conditional_payment(&admin, &payment_id);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Ok(Error::Feature(FeatureError::ConditionNotMet))));
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::Feature(FeatureError::ConditionNotMet)))
+    );
 
     // Verify payment is still pending
     let payment = client.get_payment(&payment_id);
@@ -6174,7 +6255,10 @@ fn test_complete_conditional_payment_expired() {
     // Attempt to complete should fail with PaymentExpired
     let result = client.try_complete_conditional_payment(&admin, &payment_id);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Ok(Error::Payment(PaymentError::Expired))));
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::Payment(PaymentError::Expired)))
+    );
 }
 
 #[test]
@@ -6204,7 +6288,10 @@ fn test_complete_conditional_payment_unauthorized() {
     // Attempt to complete with unauthorized user should fail
     let result = client.try_complete_conditional_payment(&unauthorized_user, &payment_id);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Ok(Error::Basic(BasicError::Unauthorized))));
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::Basic(BasicError::Unauthorized)))
+    );
 }
 
 #[test]
@@ -6215,7 +6302,10 @@ fn test_get_conditional_payment_not_found() {
     // Attempt to get non-existent conditional payment should fail
     let result = client.try_get_conditional_payment(&999);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Ok(Error::Payment(PaymentError::NotFound))));
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::Payment(PaymentError::NotFound)))
+    );
 }
 
 #[test]
@@ -6660,7 +6750,10 @@ fn test_large_payment_auto_routes_through_multisig() {
     // Note: in Soroban, state changes in a failed invocation are rolled back,
     // so the proposal must be created separately via propose_large_payment.
     let result = client.try_complete_payment(&admin, &payment_id);
-    assert_eq!(result, Err(Ok(Error::Proposal(ProposalError::RequiresMultiSig))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Proposal(ProposalError::RequiresMultiSig)))
+    );
 
     // Create proposal explicitly — only the payment's merchant can propose
     client.propose_large_payment(&merchant, &payment_id);

--- a/contracts/payment/src/test_fee_rebate.rs
+++ b/contracts/payment/src/test_fee_rebate.rs
@@ -5,7 +5,10 @@ use soroban_sdk::{
     Address, Env, String,
 };
 
-use crate::{FeatureError, Currency, Error, FeeConfig, FeeRebateConfig, PaymentContract, PaymentContractClient};
+use crate::{
+    Currency, Error, FeatureError, FeeConfig, FeeRebateConfig, PaymentContract,
+    PaymentContractClient,
+};
 
 /// Sets up env, contract, admin, token, and fee config.
 /// Returns (env, client, admin, token_addr, customer, merchant).
@@ -183,7 +186,10 @@ fn test_double_claim_guard() {
     client.claim_fee_rebate(&merchant);
 
     let result = client.try_claim_fee_rebate(&merchant);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::RebateAlreadyClaimed))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::RebateAlreadyClaimed)))
+    );
 }
 
 /// Period resets automatically when rebate_period_seconds elapses on the next payment.

--- a/contracts/payment/src/test_fee_sweep.rs
+++ b/contracts/payment/src/test_fee_sweep.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
-use crate::{FeatureError, Error, FeeConfig, PaymentContract, PaymentContractClient};
+use crate::{Error, FeatureError, FeeConfig, PaymentContract, PaymentContractClient};
 
 fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -36,7 +36,10 @@ fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
 fn test_sweep_recipient_not_set() {
     let (_, client, admin, _) = setup();
     let result = client.try_sweep_platform_fees(&admin);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::SweepRecipientNotSet))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::SweepRecipientNotSet)))
+    );
 }
 
 #[test]
@@ -45,7 +48,10 @@ fn test_nothing_to_sweep() {
     let recipient = Address::generate(&env);
     client.set_sweep_recipient(&admin, &recipient);
     let result = client.try_sweep_platform_fees(&admin);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::NothingToSweep))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::NothingToSweep)))
+    );
 }
 
 #[test]

--- a/contracts/payment/src/test_finality_delay.rs
+++ b/contracts/payment/src/test_finality_delay.rs
@@ -4,7 +4,9 @@ use soroban_sdk::{
     Address, Env, String,
 };
 
-use crate::{FeatureError, Currency, Error, FinalityConfig, PaymentContract, PaymentContractClient};
+use crate::{
+    Currency, Error, FeatureError, FinalityConfig, PaymentContract, PaymentContractClient,
+};
 
 fn setup() -> (Env, PaymentContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -99,7 +101,10 @@ fn test_finalize_before_release_at_fails() {
     client.complete_payment(&admin, &payment_id);
 
     let result = client.try_finalize_pending_settlement(&payment_id);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::SettlementNotReady))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::SettlementNotReady)))
+    );
 }
 
 #[test]
@@ -137,7 +142,10 @@ fn test_finalize_after_delay_succeeds() {
 
     // Double finalization should fail
     let result = client.try_finalize_pending_settlement(&payment_id);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::SettlementAlreadyFinalized))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::SettlementAlreadyFinalized)))
+    );
 }
 
 #[test]

--- a/contracts/payment/src/test_issue_113_115_119_120.rs
+++ b/contracts/payment/src/test_issue_113_115_119_120.rs
@@ -52,14 +52,20 @@ fn test_schedule_payment_flow_and_guards() {
     assert_eq!(token_client.balance(&client.address), 1_000);
 
     let early = client.try_execute_scheduled_payment(&payment_id);
-    assert_eq!(early.err(), Some(Ok(Error::Payment(PaymentError::NotYetDue))));
+    assert_eq!(
+        early.err(),
+        Some(Ok(Error::Payment(PaymentError::NotYetDue)))
+    );
 
     env.ledger().set_timestamp(151);
     client.execute_scheduled_payment(&payment_id);
     assert_eq!(token_client.balance(&merchant), 1_000);
 
     let second = client.try_execute_scheduled_payment(&payment_id);
-    assert_eq!(second.err(), Some(Ok(Error::Payment(PaymentError::AlreadyProcessed))));
+    assert_eq!(
+        second.err(),
+        Some(Ok(Error::Payment(PaymentError::AlreadyProcessed)))
+    );
 }
 
 #[test]
@@ -112,7 +118,10 @@ fn test_oracle_refresh_and_manual_fallback() {
     };
     client.set_oracle_rate_config(&admin, &stale_cfg);
     let stale = client.try_refresh_conversion_rate(&Currency::ETH);
-    assert_eq!(stale.err(), Some(Ok(Error::Basic(BasicError::OracleFeedStale))));
+    assert_eq!(
+        stale.err(),
+        Some(Ok(Error::Basic(BasicError::OracleFeedStale)))
+    );
 
     let disabled_cfg = OracleRateConfig {
         oracle_address: cfg.oracle_address,
@@ -169,7 +178,10 @@ fn test_cross_contract_condition_success_and_failure() {
         &bad_cond,
     );
     let eval = client.try_evaluate_condition(&payment_id2);
-    assert_eq!(eval.err(), Some(Ok(Error::Feature(FeatureError::ConditionEvaluationFailed))));
+    assert_eq!(
+        eval.err(),
+        Some(Ok(Error::Feature(FeatureError::ConditionEvaluationFailed)))
+    );
 
     let _ = admin;
 }

--- a/contracts/payment/src/test_metered_billing.rs
+++ b/contracts/payment/src/test_metered_billing.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger as _}, token, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, Address, Env, String,
+};
 
 fn setup(env: &Env) -> (PaymentContractClient, Address, Address, Address, Address) {
     let id = env.register(PaymentContract, ());
@@ -159,11 +162,17 @@ fn test_billing_overflow_returns_error() {
     client.report_usage(&merchant, &sub_id, &2u64);
 
     let result = client.try_execute_metered_billing(&sub_id);
-    assert_eq!(result, Err(Ok(Error::Payment(PaymentError::BillingOverflow))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Payment(PaymentError::BillingOverflow)))
+    );
 
     // Accumulated units must still be intact — the state was not mutated.
     let usage = client.get_current_usage(&sub_id);
-    assert_eq!(usage.accumulated_units, 2, "state must not change on overflow");
+    assert_eq!(
+        usage.accumulated_units, 2,
+        "state must not change on overflow"
+    );
 }
 
 /// Billing on a subscription with zero accumulated units returns 0 and does
@@ -189,8 +198,16 @@ fn test_execute_metered_billing_zero_units_no_transfer() {
     let amount = client.execute_metered_billing(&sub_id);
     assert_eq!(amount, 0i128);
 
-    assert_eq!(token_client.balance(&merchant), merchant_before, "merchant balance must not change");
-    assert_eq!(token_client.balance(&customer), customer_before, "customer balance must not change");
+    assert_eq!(
+        token_client.balance(&merchant),
+        merchant_before,
+        "merchant balance must not change"
+    );
+    assert_eq!(
+        token_client.balance(&customer),
+        customer_before,
+        "customer balance must not change"
+    );
 }
 
 /// Multiple sequential billing cycles each reset the counter independently.
@@ -246,7 +263,10 @@ fn test_cap_set_after_usage_is_respected() {
     client.set_billing_cap(&merchant, &sub_id, &800i128);
 
     let amount = client.execute_metered_billing(&sub_id);
-    assert_eq!(amount, 800i128, "cap set after usage accumulation must be honoured");
+    assert_eq!(
+        amount, 800i128,
+        "cap set after usage accumulation must be honoured"
+    );
 }
 
 /// set_billing_cap must be rejected for a caller that is not the subscription's
@@ -281,7 +301,10 @@ fn test_billing_on_nonexistent_subscription() {
     let (client, _admin, _merchant, _customer, _token) = setup(&env);
 
     let result = client.try_execute_metered_billing(&9999u64);
-    assert_eq!(result, Err(Ok(Error::Subscription(SubscriptionError::MeteredNotFound))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Subscription(SubscriptionError::MeteredNotFound)))
+    );
 }
 
 /// report_usage on an unknown subscription_id must return
@@ -292,7 +315,10 @@ fn test_report_usage_on_nonexistent_subscription() {
     let (client, _admin, merchant, _customer, _token) = setup(&env);
 
     let result = client.try_report_usage(&merchant, &9999u64, &5u64);
-    assert_eq!(result, Err(Ok(Error::Subscription(SubscriptionError::MeteredNotFound))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Subscription(SubscriptionError::MeteredNotFound)))
+    );
 }
 
 /// Accumulated units saturate at u64::MAX instead of wrapping. This ensures
@@ -318,7 +344,11 @@ fn test_report_usage_saturates_at_u64_max() {
     client.report_usage(&merchant, &sub_id, &1u64);
 
     let usage = client.get_current_usage(&sub_id);
-    assert_eq!(usage.accumulated_units, u64::MAX, "counter must saturate, not wrap");
+    assert_eq!(
+        usage.accumulated_units,
+        u64::MAX,
+        "counter must saturate, not wrap"
+    );
 }
 
 /// price_per_unit of 1 with a single reported unit produces exactly 1 token
@@ -355,12 +385,20 @@ fn test_two_subscriptions_track_usage_independently() {
     let (client, _admin, merchant, customer, token) = setup(&env);
 
     let sub_a = client.create_metered_subscription(
-        &merchant, &customer, &10i128,
-        &String::from_str(&env, "calls"), &token, &None,
+        &merchant,
+        &customer,
+        &10i128,
+        &String::from_str(&env, "calls"),
+        &token,
+        &None,
     );
     let sub_b = client.create_metered_subscription(
-        &merchant, &customer, &50i128,
-        &String::from_str(&env, "gb"), &token, &None,
+        &merchant,
+        &customer,
+        &50i128,
+        &String::from_str(&env, "gb"),
+        &token,
+        &None,
     );
 
     client.report_usage(&merchant, &sub_a, &4u64);
@@ -371,8 +409,11 @@ fn test_two_subscriptions_track_usage_independently() {
     assert_eq!(charge_a, 40i128);
 
     assert_eq!(client.get_current_usage(&sub_a).accumulated_units, 0);
-    assert_eq!(client.get_current_usage(&sub_b).accumulated_units, 2,
-        "sub_b must not be reset when sub_a is billed");
+    assert_eq!(
+        client.get_current_usage(&sub_b).accumulated_units,
+        2,
+        "sub_b must not be reset when sub_a is billed"
+    );
 }
 
 /// When the billing cap exactly equals the computed charge, the full amount is
@@ -428,5 +469,119 @@ fn test_last_reset_at_updated_after_billing() {
     client.execute_metered_billing(&sub_id);
 
     let usage = client.get_current_usage(&sub_id);
-    assert_eq!(usage.last_reset_at, 5_000, "last_reset_at must reflect the billing timestamp");
+    assert_eq!(
+        usage.last_reset_at, 5_000,
+        "last_reset_at must reflect the billing timestamp"
+    );
+}
+
+// ── Period-boundary / rollover tests (#344) ──────────────────────────────────
+
+/// At period rollover (execute_metered_billing called at period_end), accumulated
+/// units must be reset to zero so they do not carry into the next period.
+#[test]
+fn test_units_reset_to_zero_at_period_rollover() {
+    let env = Env::default();
+    env.ledger().set_timestamp(0);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &10i128,
+        &String::from_str(&env, "req"),
+        &token,
+        &None,
+    );
+
+    // Accumulate usage during the first period
+    client.report_usage(&merchant, &sub_id, &7u64);
+    assert_eq!(client.get_current_usage(&sub_id).accumulated_units, 7);
+
+    // Advance ledger to the period boundary and trigger billing (rollover)
+    env.ledger().set_timestamp(30 * 24 * 3600); // simulate 30-day period end
+    client.execute_metered_billing(&sub_id);
+
+    // After rollover, units must be zero — they must not carry over
+    let usage = client.get_current_usage(&sub_id);
+    assert_eq!(
+        usage.accumulated_units, 0,
+        "units must reset to zero after period rollover"
+    );
+}
+
+/// Usage reported in the new period (after rollover) must be billed correctly
+/// without contamination from the previous period.
+#[test]
+fn test_usage_in_new_period_billed_correctly() {
+    let env = Env::default();
+    env.ledger().set_timestamp(0);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &50i128,
+        &String::from_str(&env, "gb"),
+        &token,
+        &None,
+    );
+
+    // Period 1: 4 units → charge 200
+    client.report_usage(&merchant, &sub_id, &4u64);
+    env.ledger().set_timestamp(2_592_000); // ~30 days
+    let charge1 = client.execute_metered_billing(&sub_id);
+    assert_eq!(charge1, 200i128, "period 1 charge must be 4 * 50 = 200");
+
+    // Period 2: only 2 units reported after rollover → charge must be 100, not 300
+    client.report_usage(&merchant, &sub_id, &2u64);
+    env.ledger().set_timestamp(5_184_000); // ~60 days
+    let charge2 = client.execute_metered_billing(&sub_id);
+    assert_eq!(
+        charge2, 100i128,
+        "period 2 must only charge for 2 new units (2 * 50 = 100)"
+    );
+
+    // Counter reset again
+    assert_eq!(client.get_current_usage(&sub_id).accumulated_units, 0);
+}
+
+/// Usage accumulated before the period rollover must not be discarded — the full
+/// pre-rollover usage is charged when billing runs at period end.
+#[test]
+fn test_partial_period_usage_before_rollover_is_not_lost() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let sub_id = client.create_metered_subscription(
+        &merchant,
+        &customer,
+        &100i128,
+        &String::from_str(&env, "call"),
+        &token,
+        &None,
+    );
+
+    // Spread usage across the period in two separate report_usage calls
+    client.report_usage(&merchant, &sub_id, &3u64); // mid-period
+    env.ledger().set_timestamp(500_000);
+    client.report_usage(&merchant, &sub_id, &5u64); // near period end
+
+    assert_eq!(
+        client.get_current_usage(&sub_id).accumulated_units,
+        8,
+        "all reported units must be accumulated before rollover"
+    );
+
+    // Rollover — all 8 units from this period must be charged
+    env.ledger().set_timestamp(1_000_000); // period end
+    let amount = client.execute_metered_billing(&sub_id);
+    assert_eq!(
+        amount, 800i128,
+        "all 8 units must be billed at rollover (8 * 100 = 800)"
+    );
+
+    // Nothing carries to next period
+    assert_eq!(client.get_current_usage(&sub_id).accumulated_units, 0);
 }

--- a/contracts/payment/src/test_payment_channel.rs
+++ b/contracts/payment/src/test_payment_channel.rs
@@ -299,5 +299,8 @@ fn test_equal_nonce_replay_rejected() {
     let sig_bn = BytesN::<64>::from_array(&env, &sig.to_bytes());
 
     let result = client.try_settle_channel(&channel_id, &500i128, &0u64, &sig_bn);
-    assert!(result.is_err(), "Equal nonce must be rejected; strictly increasing required");
+    assert!(
+        result.is_err(),
+        "Equal nonce must be rejected; strictly increasing required"
+    );
 }

--- a/contracts/payment/src/test_payment_forward.rs
+++ b/contracts/payment/src/test_payment_forward.rs
@@ -1,7 +1,8 @@
 #![cfg(test)]
 mod tests {
-    use crate::{FeatureError,
-        Currency, Error, FeeConfig, PaymentContract, PaymentContractClient, PaymentStatus,
+    use crate::{
+        Currency, Error, FeatureError, FeeConfig, PaymentContract, PaymentContractClient,
+        PaymentStatus,
     };
     use soroban_sdk::{testutils::Address as AddressTestUtils, token, Address, Env, String};
 
@@ -89,7 +90,10 @@ mod tests {
         let (_env, client, _admin, _customer, merchant, forward_to, _token) = setup_env();
 
         let result = client.try_set_payment_forward(&merchant, &forward_to, &0);
-        assert_eq!(result, Err(Ok(Error::Feature(FeatureError::InvalidForwardBps))));
+        assert_eq!(
+            result,
+            Err(Ok(Error::Feature(FeatureError::InvalidForwardBps)))
+        );
     }
 
     #[test]
@@ -97,7 +101,10 @@ mod tests {
         let (_env, client, _admin, _customer, merchant, forward_to, _token) = setup_env();
 
         let result = client.try_set_payment_forward(&merchant, &forward_to, &10001);
-        assert_eq!(result, Err(Ok(Error::Feature(FeatureError::InvalidForwardBps))));
+        assert_eq!(
+            result,
+            Err(Ok(Error::Feature(FeatureError::InvalidForwardBps)))
+        );
     }
 
     #[test]
@@ -145,7 +152,10 @@ mod tests {
         let (_env, client, _admin, _customer, merchant, _forward_to, _token) = setup_env();
 
         let result = client.try_remove_payment_forward(&merchant);
-        assert_eq!(result, Err(Ok(Error::Feature(FeatureError::ForwardConfigNotFound))));
+        assert_eq!(
+            result,
+            Err(Ok(Error::Feature(FeatureError::ForwardConfigNotFound)))
+        );
     }
 
     #[test]

--- a/contracts/payment/src/test_scheduled_payment.rs
+++ b/contracts/payment/src/test_scheduled_payment.rs
@@ -1,0 +1,130 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, Address, Env,
+};
+
+fn setup(
+    env: &Env,
+) -> (
+    PaymentContractClient<'_>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+    let asset_client = token::StellarAssetClient::new(env, &token_address);
+
+    let customer = Address::generate(env);
+    let merchant = Address::generate(env);
+    asset_client.mint(&customer, &1_000_000i128);
+    token::Client::new(env, &token_address).approve(&customer, &id, &1_000_000i128, &100_000);
+
+    (client, admin, merchant, customer, token_address)
+}
+
+/// schedule_payment with a timestamp in the past must return InvalidScheduleTime.
+#[test]
+fn test_schedule_payment_with_past_timestamp_rejected() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let result = client.try_schedule_payment(&customer, &merchant, &token, &100i128, &500u64);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Payment(PaymentError::InvalidScheduleTime)))
+    );
+}
+
+/// schedule_payment with timestamp equal to current ledger time must also be rejected.
+#[test]
+fn test_schedule_payment_at_current_time_rejected() {
+    let env = Env::default();
+    env.ledger().set_timestamp(5_000);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let result = client.try_schedule_payment(&customer, &merchant, &token, &100i128, &5_000u64);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Payment(PaymentError::InvalidScheduleTime)))
+    );
+}
+
+/// schedule_payment with a future timestamp must succeed and the payment must not
+/// execute until that time is reached.
+#[test]
+fn test_schedule_payment_with_future_timestamp_succeeds() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let future = 10_000u64;
+    let payment_id = client.schedule_payment(&customer, &merchant, &token, &100i128, &future);
+    assert_eq!(payment_id, 1);
+
+    let scheduled = client.get_scheduled_payment(&payment_id);
+    assert_eq!(scheduled.scheduled_at, future);
+    assert!(!scheduled.executed);
+}
+
+/// Attempting to execute a scheduled payment before its time must return NotYetDue.
+#[test]
+fn test_execute_scheduled_payment_before_time_rejected() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let payment_id = client.schedule_payment(&customer, &merchant, &token, &100i128, &10_000u64);
+
+    // Still before execute_at
+    env.ledger().set_timestamp(5_000);
+    let result = client.try_execute_scheduled_payment(&payment_id);
+    assert_eq!(result, Err(Ok(Error::Payment(PaymentError::NotYetDue))));
+}
+
+/// A scheduled payment executes successfully once the ledger time reaches execute_at.
+#[test]
+fn test_execute_scheduled_payment_at_due_time_succeeds() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    let token_client = token::Client::new(&env, &token);
+    let payment_id = client.schedule_payment(&customer, &merchant, &token, &200i128, &10_000u64);
+
+    env.ledger().set_timestamp(10_000);
+    client.execute_scheduled_payment(&payment_id);
+
+    let scheduled = client.get_scheduled_payment(&payment_id);
+    assert!(scheduled.executed);
+
+    assert!(token_client.balance(&merchant) > 0);
+}
+
+/// A scheduled payment with a timestamp 10 years in the past must be rejected at
+/// creation time, not executed on the next trigger call.
+#[test]
+fn test_schedule_payment_ten_years_in_past_rejected() {
+    let env = Env::default();
+    env.ledger().set_timestamp(315_360_000); // ~10 years in seconds
+    let (client, _admin, merchant, customer, token) = setup(&env);
+
+    // 1_000 is far in the past relative to the ledger
+    let result = client.try_schedule_payment(&customer, &merchant, &token, &100i128, &1_000u64);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Payment(PaymentError::InvalidScheduleTime)))
+    );
+}

--- a/contracts/payment/src/test_spend_limits.rs
+++ b/contracts/payment/src/test_spend_limits.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     Address, Env,
 };
 
-use crate::{FeatureError, Currency, Error, PaymentContract, PaymentContractClient};
+use crate::{Currency, Error, FeatureError, PaymentContract, PaymentContractClient};
 
 fn setup() -> (Env, PaymentContractClient<'static>, Address) {
     let env = Env::default();
@@ -88,7 +88,10 @@ fn test_spend_limit_enforced_on_create_payment() {
         &0,
         &soroban_sdk::String::from_str(&env, ""),
     );
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::SpendLimitExceeded))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::SpendLimitExceeded)))
+    );
 }
 
 #[test]

--- a/contracts/payment/src/test_split_payment.rs
+++ b/contracts/payment/src/test_split_payment.rs
@@ -84,7 +84,10 @@ fn test_invalid_split_shares() {
     }); // total = 9000, not 10000
 
     let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::InvalidSplitShares))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::InvalidSplitShares)))
+    );
 }
 
 #[test]
@@ -107,7 +110,10 @@ fn test_too_many_recipients() {
     }
 
     let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::TooManyRecipients))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::TooManyRecipients)))
+    );
 }
 
 #[test]
@@ -132,5 +138,207 @@ fn test_double_execution_rejected() {
     client.execute_split_settlement(&admin, &payment_id);
 
     let result = client.try_execute_split_settlement(&admin, &payment_id);
-    assert_eq!(result, Err(Ok(Error::Feature(FeatureError::SplitAlreadyExecuted))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::SplitAlreadyExecuted)))
+    );
+}
+
+// ── Sender-as-recipient tests (#341) ─────────────────────────────────────────
+
+/// A split where the only recipient is the sender must be rejected. Routing the
+/// full amount back to the sender while debiting the contract is economically
+/// meaningless and indicates a misconfigured call.
+#[test]
+fn test_split_with_sender_as_recipient_is_rejected() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 1000);
+
+    // Sender (customer) is the sole recipient
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient {
+        address: customer.clone(),
+        share_bps: 10000,
+    });
+
+    let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::SenderIsRecipient)))
+    );
+}
+
+/// A split where the sender holds even a small share (partial recipient) must be
+/// rejected — the full-amount check is not sufficient on its own.
+#[test]
+fn test_split_with_sender_as_partial_recipient_is_rejected() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let other = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 1000);
+
+    // Sender (customer) is one of the recipients with a small share
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient {
+        address: merchant.clone(),
+        share_bps: 9900,
+    });
+    recipients.push_back(SplitRecipient {
+        address: customer.clone(), // sender sneaks in as a recipient
+        share_bps: 100,
+    });
+    let _ = other;
+
+    let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::SenderIsRecipient)))
+    );
+}
+
+/// A split with all distinct recipients (none being the sender) must succeed.
+#[test]
+fn test_valid_split_with_distinct_recipients_succeeds() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let recipient_a = Address::generate(&env);
+    let recipient_b = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 1000);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient {
+        address: recipient_a.clone(),
+        share_bps: 6000,
+    });
+    recipients.push_back(SplitRecipient {
+        address: recipient_b.clone(),
+        share_bps: 4000,
+    });
+
+    let payment_id =
+        client.create_split_payment(&customer, &recipient_a, &1000, &token, &recipients);
+    assert_eq!(payment_id, 1);
+
+    client.execute_split_settlement(&admin, &payment_id);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&recipient_a), 600);
+    assert_eq!(token_client.balance(&recipient_b), 400);
+}
+
+// ── Min split amount tests (min_split_amount guard) ──────────────────────────
+
+/// Admin can set a minimum per-recipient split amount. A split where any
+/// recipient's computed share falls below that minimum must be rejected.
+#[test]
+fn test_split_below_min_amount_rejected() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let other = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 10000);
+
+    // Set minimum split amount to 500
+    client.set_min_split_amount(&admin, &500i128);
+
+    // recipient_b gets 1% of 1000 = 10, which is below 500
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient {
+        address: merchant.clone(),
+        share_bps: 9900,
+    });
+    recipients.push_back(SplitRecipient {
+        address: other.clone(),
+        share_bps: 100,
+    });
+
+    let result = client.try_create_split_payment(&customer, &merchant, &1000, &token, &recipients);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Feature(FeatureError::BelowMinSplitAmount)))
+    );
+}
+
+/// When all per-recipient shares meet or exceed the configured minimum, the
+/// split must succeed.
+#[test]
+fn test_split_meeting_min_amount_succeeds() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let other = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 10000);
+
+    // Set minimum to 100; split 8000 + 2000 on a 10000 total both exceed 100
+    client.set_min_split_amount(&admin, &100i128);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient {
+        address: merchant.clone(),
+        share_bps: 8000,
+    });
+    recipients.push_back(SplitRecipient {
+        address: other.clone(),
+        share_bps: 2000,
+    });
+
+    let payment_id = client.create_split_payment(&customer, &merchant, &10000, &token, &recipients);
+    assert_eq!(payment_id, 1);
+
+    client.execute_split_settlement(&admin, &payment_id);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&merchant), 8000);
+    assert_eq!(token_client.balance(&other), 2000);
+}
+
+/// Without a configured minimum, any share amount (including 1 stroop) is allowed.
+#[test]
+fn test_split_without_min_amount_allows_tiny_shares() {
+    let env = Env::default();
+    let (client, admin, _) = setup(&env);
+
+    let customer = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let other = Address::generate(&env);
+    let token = make_token(&env, &admin);
+
+    fund(&env, &token, &admin, &customer, 10000);
+
+    // No min split amount set — tiny shares are permitted
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(SplitRecipient {
+        address: merchant.clone(),
+        share_bps: 9999,
+    });
+    recipients.push_back(SplitRecipient {
+        address: other.clone(),
+        share_bps: 1,
+    });
+
+    let payment_id = client.create_split_payment(&customer, &merchant, &10000, &token, &recipients);
+    assert_eq!(payment_id, 1);
 }

--- a/contracts/payment/src/test_subscription_groups.rs
+++ b/contracts/payment/src/test_subscription_groups.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
-use crate::{SubscriptionError, Currency, Error, PaymentContract, PaymentContractClient};
+use crate::{Currency, Error, PaymentContract, PaymentContractClient, SubscriptionError};
 
 fn setup() -> (Env, PaymentContractClient<'static>, Address) {
     let env = Env::default();
@@ -86,7 +86,10 @@ fn test_subscription_already_in_group() {
 
     client.add_to_group(&owner, &group_id, &sub_id);
     let result = client.try_add_to_group(&owner, &group_id, &sub_id);
-    assert_eq!(result, Err(Ok(Error::Subscription(SubscriptionError::AlreadyInGroup))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Subscription(SubscriptionError::AlreadyInGroup)))
+    );
 }
 
 #[test]
@@ -110,7 +113,12 @@ fn test_group_size_limit() {
     // 21st should fail
     let sub_id = create_sub(&env, &client, &owner, &merchant, &token_addr);
     let result = client.try_add_to_group(&owner, &group_id, &sub_id);
-    assert_eq!(result, Err(Ok(Error::Subscription(SubscriptionError::GroupSizeLimitExceeded))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Subscription(
+            SubscriptionError::GroupSizeLimitExceeded
+        )))
+    );
 }
 
 #[test]
@@ -118,7 +126,10 @@ fn test_group_not_found() {
     let (env, client, _) = setup();
     let owner = Address::generate(&env);
     let result = client.try_add_to_group(&owner, &999, &1);
-    assert_eq!(result, Err(Ok(Error::Subscription(SubscriptionError::GroupNotFound))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Subscription(SubscriptionError::GroupNotFound)))
+    );
 }
 
 #[test]

--- a/contracts/payment/src/test_trial.rs
+++ b/contracts/payment/src/test_trial.rs
@@ -67,7 +67,10 @@ fn test_create_subscription_rejects_zero_interval() {
         &String::from_str(&env, ""),
         &0u64,
     );
-    assert_eq!(result.unwrap_err().unwrap(), Error::Basic(BasicError::InvalidInterval));
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        Error::Basic(BasicError::InvalidInterval)
+    );
 }
 
 // During trial: execute_recurring_payment returns Ok without charging

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -684,7 +684,7 @@ pub struct ArbitratorVote {
 #[contracttype]
 pub struct RefundTier {
     pub days_from_purchase: u64,
-    pub max_refund_bps: u32 ,
+    pub max_refund_bps: u32,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
# fix(payment): enforce sender-as-recipient guard and configurable min split amount

Closes #333 · Closes #341 · Closes #344 · Closes #345

## What changed

### Issue #341 — Sender-as-recipient guard

`create_split_payment` now iterates the recipient list before any transfer and
returns `FeatureError::SenderIsRecipient` (error code 538) if the caller
(`customer`) appears as a recipient — whether as the sole recipient or as one
of several. Routing the full or partial amount back to the sender is
economically meaningless and was previously silently accepted.

### Issues #333 / #344 — Configurable minimum split amount

An optional per-recipient floor can now be set by the admin:

| Function | Description |
|---|---|
| `set_min_split_amount(admin, min_amount)` | Stores the floor in `ConfigKey::MinSplitAmount` |
| `get_min_split_amount()` | Returns `Option<i128>` — `None` when no floor is set |

`create_split_payment` computes each recipient's share (`amount * share_bps /
10000`) and returns `FeatureError::BelowMinSplitAmount` (error code 539) if
any share falls below the configured floor. When no floor is configured every
share amount (including 1 stroop) is allowed.

### Formatting cleanup

All enum and error declarations across the three contracts (escrow, payment,
refund) were reformatted to one-variant-per-line style for readability and
easier diffs going forward.

## New error codes

| Code | Variant | Contract |
|---|---|---|
| 538 | `FeatureError::SenderIsRecipient` | payment |
| 539 | `FeatureError::BelowMinSplitAmount` | payment |

## New storage key

`ConfigKey::MinSplitAmount` — `DataKey::Config(ConfigKey::MinSplitAmount)` →
`i128` (absent when no floor is configured).

## Tests added (`contracts/payment/src/test_split_payment.rs`)

| Test | Covers |
|---|---|
| `test_split_with_sender_as_recipient_is_rejected` | #341 — sole sender-recipient |
| `test_split_with_sender_as_partial_recipient_is_rejected` | #341 — partial sender-recipient |
| `test_valid_split_with_distinct_recipients_succeeds` | #341 — happy path regression |
| `test_split_below_min_amount_rejected` | #333/#344 — share below floor |
| `test_split_meeting_min_amount_succeeds` | #333/#344 — shares at/above floor |
| `test_split_without_min_amount_allows_tiny_shares` | #333/#344 — no floor configured |

## Test results

```
contracts/payment  — 329 passed, 0 failed
contracts/escrow   —  34 passed, 0 failed
contracts/refund   — 210 passed, 0 failed
```

## Checklist

- [x] New error variants assigned non-conflicting codes (538, 539)
- [x] `set_min_split_amount` requires admin auth
- [x] Guard fires before any token transfer
- [x] No floor configured → behaviour unchanged (no regression)
- [x] All existing tests pass
