### PR TITLE
Title: fix/perf-and-enhancement: memo history cap, merchant page index, escrow beneficiary transfer, funds-released event

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -105,7 +105,10 @@ pub enum DisputeKey {
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
-    Config(ConfigKey), Escrow(EscrowKey), Participant(ParticipantKey), Dispute(DisputeKey),
+    Config(ConfigKey),
+    Escrow(EscrowKey),
+    Participant(ParticipantKey),
+    Dispute(DisputeKey),
     VoteWeight(u64, Address),
     ReleaseThresholdBps(u64),
 }
@@ -522,8 +525,9 @@ pub struct MultiPartyEscrowCreated {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowReleased {
     pub escrow_id: u64,
-    pub merchant: Address,
+    pub recipient: Address,
     pub amount: i128,
+    pub token: Address,
 }
 
 #[contractevent]
@@ -2426,9 +2430,10 @@ impl EscrowContract {
             .set(&DataKey::Escrow(EscrowKey::MultiPartyCounter), &escrow_id);
 
         for p in escrow.participants.iter() {
-            env.storage()
-                .instance()
-                .set(&DataKey::VoteWeight(escrow_id, p.address.clone()), &p.share_bps);
+            env.storage().instance().set(
+                &DataKey::VoteWeight(escrow_id, p.address.clone()),
+                &p.share_bps,
+            );
         }
         env.storage()
             .instance()
@@ -2668,9 +2673,10 @@ impl EscrowContract {
             .instance()
             .set(&DataKey::Escrow(EscrowKey::MultiParty(escrow_id)), &escrow);
 
-        env.storage()
-            .instance()
-            .set(&DataKey::VoteWeight(escrow_id, participant.clone()), &weight_bps);
+        env.storage().instance().set(
+            &DataKey::VoteWeight(escrow_id, participant.clone()),
+            &weight_bps,
+        );
 
         WeightUpdated {
             escrow_id,
@@ -3067,8 +3073,9 @@ impl EscrowContract {
 
         EscrowReleased {
             escrow_id,
-            merchant: recipient,
+            recipient,
             amount: escrow.amount,
+            token: escrow.token,
         }
         .publish(&env);
 
@@ -5806,8 +5813,9 @@ impl EscrowContract {
 
                 EscrowReleased {
                     escrow_id,
-                    merchant: escrow.merchant,
+                    recipient: escrow.merchant.clone(),
                     amount: escrow.amount,
+                    token: escrow.token,
                 }
                 .publish(env);
             }
@@ -7541,6 +7549,80 @@ impl EscrowContract {
             }
         }
         history
+    }
+
+    /// Transfer escrow beneficiary to a new address. Callable only by the current beneficiary.
+    /// Records the transfer in BeneficiaryTransferHistory with timestamp.
+    pub fn transfer_beneficiary(
+        env: Env,
+        escrow_id: u64,
+        new_beneficiary: Address,
+    ) -> Result<(), Error> {
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
+            return Err(Error::Escrow(EscrowError::NotFound));
+        }
+
+        let mut escrow = EscrowContract::get_escrow(&env, escrow_id);
+
+        // Only the current beneficiary (merchant) may call this
+        escrow.merchant.require_auth();
+
+        match escrow.status {
+            EscrowStatus::Disputed | EscrowStatus::Resolved => {
+                return Err(Error::Action(ActionError::TransferNotAllowed));
+            }
+            _ => {}
+        }
+
+        if new_beneficiary == escrow.merchant {
+            return Err(Error::Action(ActionError::SameBeneficiary));
+        }
+
+        let old_beneficiary = escrow.merchant.clone();
+        let now = env.ledger().timestamp();
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Participant(
+                ParticipantKey::BeneficiaryTransferCount(escrow_id),
+            ))
+            .unwrap_or(0);
+
+        let transfer = BeneficiaryTransfer {
+            escrow_id,
+            from: old_beneficiary.clone(),
+            to: new_beneficiary.clone(),
+            transferred_at: now,
+            authorised_by: old_beneficiary.clone(),
+        };
+
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::BeneficiaryTransferHistory(escrow_id, count)),
+            &transfer,
+        );
+        env.storage().instance().set(
+            &DataKey::Participant(ParticipantKey::BeneficiaryTransferCount(escrow_id)),
+            &(count + 1),
+        );
+
+        escrow.merchant = new_beneficiary.clone();
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(EscrowKey::Data(escrow_id)), &escrow);
+
+        BeneficiaryTransferred {
+            escrow_id,
+            old_merchant: old_beneficiary,
+            new_merchant: new_beneficiary,
+        }
+        .publish(&env);
+
+        Ok(())
     }
 
     // ── MULTI-PARTY DISPUTE ────────────────────────────────────────────────

--- a/contracts/escrow/src/multi_party_weight_test.rs
+++ b/contracts/escrow/src/multi_party_weight_test.rs
@@ -81,7 +81,10 @@ fn test_multi_party_escrow_weight_governance() {
     // Trying to release at 60% (6000 < 10000) should fail
     env.ledger().set_timestamp(1001);
     let release_res = client.try_release_multi_party_escrow(&escrow_id);
-    assert_eq!(release_res, Err(Ok(Error::Action(ActionError::ApprovalsThresholdNotMet))));
+    assert_eq!(
+        release_res,
+        Err(Ok(Error::Action(ActionError::ApprovalsThresholdNotMet)))
+    );
 
     // Update threshold to 60% (6000 bps)
     client.update_approval_threshold_bps(&admin, &escrow_id, &6000);

--- a/contracts/escrow/src/observer_test.rs
+++ b/contracts/escrow/src/observer_test.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
 use crate::*;
-use soroban_sdk::testutils::Ledger;
 use crate::*;
+use soroban_sdk::testutils::Ledger;
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn setup(
@@ -32,14 +32,7 @@ fn create_escrow(
     token: &Address,
 ) -> u64 {
     client.create_escrow(
-        customer,
-        merchant,
-        &1000_i128,
-        token,
-        &5000_u64,
-        &0_u64,
-        &0_u64,
-        &false,
+        customer, merchant, &1000_i128, token, &5000_u64, &0_u64, &0_u64, &false,
     )
 }
 
@@ -96,7 +89,10 @@ fn test_duplicate_active_observer_rejected() {
     client.add_observer(&customer, &escrow_id, &observer, &3600_u64);
 
     let result = client.try_add_observer(&customer, &escrow_id, &observer, &3600_u64);
-    assert_eq!(result, Err(Ok(Error::Action(ActionError::ObserverAlreadyAdded))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Action(ActionError::ObserverAlreadyAdded)))
+    );
 }
 
 #[test]
@@ -130,7 +126,10 @@ fn test_remove_observer_not_found() {
 
     let escrow_id = create_escrow(&client, &customer, &merchant, &token);
     let result = client.try_remove_observer(&customer, &escrow_id, &observer);
-    assert_eq!(result, Err(Ok(Error::Action(ActionError::ObserverNotFound))));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Action(ActionError::ObserverNotFound)))
+    );
 }
 
 // Customer can read their own escrow via get_escrow_details
@@ -178,7 +177,10 @@ fn test_stranger_cannot_read_escrow_details() {
     let escrow_id = create_escrow(&client, &customer, &merchant, &token);
 
     let result = client.try_get_escrow_details(&stranger, &escrow_id);
-    assert!(matches!(result, Err(Ok(Error::Basic(BasicError::Unauthorized)))));
+    assert!(matches!(
+        result,
+        Err(Ok(Error::Basic(BasicError::Unauthorized)))
+    ));
 }
 
 // An expired observer is denied access
@@ -195,5 +197,8 @@ fn test_expired_observer_cannot_read_escrow_details() {
     env.ledger().set_timestamp(env.ledger().timestamp() + 200);
 
     let result = client.try_get_escrow_details(&observer, &escrow_id);
-    assert!(matches!(result, Err(Ok(Error::Basic(BasicError::Unauthorized)))));
+    assert!(matches!(
+        result,
+        Err(Ok(Error::Basic(BasicError::Unauthorized)))
+    ));
 }

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -64,6 +64,8 @@ pub enum PaymentKey {
     LargePaymentCounter,
 }
 
+pub const MAX_MEMO_VERSIONS: u32 = 10;
+
 #[derive(Clone)]
 #[contracttype]
 pub enum SubscriptionKey {
@@ -144,25 +146,53 @@ pub enum BasicError {
 #[repr(u32)]
 #[contracterror]
 pub enum PaymentError {
-    NotFound = 200, InvalidStatus = 201, AlreadyProcessed = 202, Expired = 203,
-    NotExpired = 204, NoExpiration = 205, TransferFailed = 206, RefundExceedsPayment = 207,
-    NotYetDue = 208, ScheduledPaymentCancelled = 209, MetadataAlreadySet = 210,
-    MetadataNotFound = 211, HashMismatch = 212, AlreadyFullyPaid = 213,
-    InstallmentExceedsRemaining = 214, PartialPaymentNotFound = 215,
-    MerchantRateLimitExceeded = 216, AmountRateLimitExceeded = 217,
-    PayoutScheduleNotFound = 218, PayoutNotYetDue = 219, NothingToSettle = 220, BillingOverflow = 221,
-    InvalidLineItem = 222
+    NotFound = 200,
+    InvalidStatus = 201,
+    AlreadyProcessed = 202,
+    Expired = 203,
+    NotExpired = 204,
+    NoExpiration = 205,
+    TransferFailed = 206,
+    RefundExceedsPayment = 207,
+    NotYetDue = 208,
+    ScheduledPaymentCancelled = 209,
+    MetadataAlreadySet = 210,
+    MetadataNotFound = 211,
+    HashMismatch = 212,
+    AlreadyFullyPaid = 213,
+    InstallmentExceedsRemaining = 214,
+    PartialPaymentNotFound = 215,
+    MerchantRateLimitExceeded = 216,
+    AmountRateLimitExceeded = 217,
+    PayoutScheduleNotFound = 218,
+    PayoutNotYetDue = 219,
+    NothingToSettle = 220,
+    BillingOverflow = 221,
+    InvalidLineItem = 222,
+    InvalidScheduleTime = 223,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 #[contracterror]
 pub enum SubscriptionError {
-    NotFound = 300, NotActive = 301, PaymentNotDue = 302, MaxRetriesExceeded = 303,
-    Ended = 304, DunningNotFound = 305, NotInDunning = 306, RetryNotDue = 307,
-    GracePeriodExpired = 308, RetryTooEarly = 309, MeteredNotFound = 310,
-    BillingCapExceeded = 311, GroupNotFound = 312, AlreadyInGroup = 313,
-    GroupSizeLimitExceeded = 314, TrialExpired = 315, MaxTrialDurationExceeded = 316,
+    NotFound = 300,
+    NotActive = 301,
+    PaymentNotDue = 302,
+    MaxRetriesExceeded = 303,
+    Ended = 304,
+    DunningNotFound = 305,
+    NotInDunning = 306,
+    RetryNotDue = 307,
+    GracePeriodExpired = 308,
+    RetryTooEarly = 309,
+    MeteredNotFound = 310,
+    BillingCapExceeded = 311,
+    GroupNotFound = 312,
+    AlreadyInGroup = 313,
+    GroupSizeLimitExceeded = 314,
+    TrialExpired = 315,
+    MaxTrialDurationExceeded = 316,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -262,11 +292,21 @@ impl TryFrom<soroban_sdk::Error> for Error {
     fn try_from(error: soroban_sdk::Error) -> Result<Self, Self::Error> {
         if error.is_type(soroban_sdk::xdr::ScErrorType::Contract) {
             let code = error.get_code();
-            if code >= 500 && code <= 537 { return Ok(Error::Feature(unsafe { core::mem::transmute(code) })); }
-            if code >= 400 && code <= 406 { return Ok(Error::Proposal(unsafe { core::mem::transmute(code) })); }
-            if code >= 300 && code <= 316 { return Ok(Error::Subscription(unsafe { core::mem::transmute(code) })); }
-            if code >= 200 && code <= 222 { return Ok(Error::Payment(unsafe { core::mem::transmute(code) })); }
-            if code >= 100 && code <= 125 { return Ok(Error::Basic(unsafe { core::mem::transmute(code) })); }
+            if code >= 500 && code <= 539 {
+                return Ok(Error::Feature(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 400 && code <= 406 {
+                return Ok(Error::Proposal(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 300 && code <= 316 {
+                return Ok(Error::Subscription(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 200 && code <= 223 {
+                return Ok(Error::Payment(unsafe { core::mem::transmute(code) }));
+            }
+            if code >= 100 && code <= 125 {
+                return Ok(Error::Basic(unsafe { core::mem::transmute(code) }));
+            }
         }
         Err(error)
     }
@@ -327,6 +367,7 @@ pub enum MerchantDataKey {
     PendingSettlementIndex(Address, u64),
     VerificationLevel(Address),
     VerificationTierLimit(MerchantVerificationLevel),
+    MerchantPaymentsPage(Address, u64),
 }
 
 // State and proposal data keys
@@ -2503,9 +2544,28 @@ impl PaymentContract {
             &payment_id,
         );
         env.storage().instance().set(
-            &DataKey::Merchant(MerchantDataKey::PaymentCount(merchant)),
+            &DataKey::Merchant(MerchantDataKey::PaymentCount(merchant.clone())),
             &(merchant_count + 1),
         );
+
+        // Paged merchant payment index (100 entries per page)
+        {
+            const PAGE_SIZE: u64 = 100;
+            let page_num = merchant_count / PAGE_SIZE;
+            let mut page: Vec<u64> = env
+                .storage()
+                .instance()
+                .get(&DataKey::Merchant(MerchantDataKey::MerchantPaymentsPage(
+                    merchant.clone(),
+                    page_num,
+                )))
+                .unwrap_or_else(|| Vec::new(&env));
+            page.push_back(payment_id);
+            env.storage().instance().set(
+                &DataKey::Merchant(MerchantDataKey::MerchantPaymentsPage(merchant, page_num)),
+                &page,
+            );
+        }
 
         // Update global analytics
         let mut analytics: PaymentAnalytics = env
@@ -4332,6 +4392,16 @@ impl PaymentContract {
             .unwrap_or(0)
     }
 
+    /// Returns the payment IDs for the given merchant on the requested page (100 per page).
+    pub fn get_merchant_payments(env: Env, merchant: Address, page: u64) -> Vec<u64> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Merchant(MerchantDataKey::MerchantPaymentsPage(
+                merchant, page,
+            )))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
     fn is_valid_currency(currency: &Currency) -> bool {
         matches!(
             currency,
@@ -4595,7 +4665,9 @@ impl PaymentContract {
         let mut sub: Subscription = env
             .storage()
             .instance()
-            .get(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)))
+            .get(&DataKey::Subscription(SubscriptionKey::Data(
+                subscription_id,
+            )))
             .ok_or(Error::Subscription(SubscriptionError::NotFound))?;
 
         if sub.merchant != merchant {
@@ -4615,22 +4687,29 @@ impl PaymentContract {
             .trial_data
             .period_seconds
             .checked_add(additional_seconds)
-            .ok_or(Error::Subscription(SubscriptionError::MaxTrialDurationExceeded))?;
+            .ok_or(Error::Subscription(
+                SubscriptionError::MaxTrialDurationExceeded,
+            ))?;
 
         if new_total > MAX_TRIAL_DURATION {
-            return Err(Error::Subscription(SubscriptionError::MaxTrialDurationExceeded));
+            return Err(Error::Subscription(
+                SubscriptionError::MaxTrialDurationExceeded,
+            ));
         }
 
         sub.trial_data.ends_at = sub
             .trial_data
             .ends_at
             .checked_add(additional_seconds)
-            .ok_or(Error::Subscription(SubscriptionError::MaxTrialDurationExceeded))?;
+            .ok_or(Error::Subscription(
+                SubscriptionError::MaxTrialDurationExceeded,
+            ))?;
         sub.trial_data.period_seconds = new_total;
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Subscription(SubscriptionKey::Data(subscription_id)), &sub);
+        env.storage().instance().set(
+            &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
+            &sub,
+        );
 
         Ok(())
     }
@@ -7238,6 +7317,28 @@ impl PaymentContract {
                 &(merchant_count + 1),
             );
 
+            // Paged merchant payment index (100 entries per page)
+            {
+                const PAGE_SIZE: u64 = 100;
+                let page_num = merchant_count / PAGE_SIZE;
+                let mut page: Vec<u64> = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Merchant(MerchantDataKey::MerchantPaymentsPage(
+                        entry.merchant.clone(),
+                        page_num,
+                    )))
+                    .unwrap_or_else(|| Vec::new(&env));
+                page.push_back(payment_id);
+                env.storage().instance().set(
+                    &DataKey::Merchant(MerchantDataKey::MerchantPaymentsPage(
+                        entry.merchant.clone(),
+                        page_num,
+                    )),
+                    &page,
+                );
+            }
+
             // Deduct fee
             let (net_amount, fee_amount) = PaymentContract::deduct_fee(
                 &env,
@@ -8711,6 +8812,26 @@ impl PaymentContract {
         let current_time = env.ledger().timestamp();
 
         if let Some(existing) = existing_memo {
+            // Archive current version into sliding-window history (capped at MAX_MEMO_VERSIONS)
+            let mut history: Vec<PaymentMemo> = env
+                .storage()
+                .instance()
+                .get(&DataKey::Payment(PaymentKey::MemoVersion(payment_id)))
+                .unwrap_or_else(|| Vec::new(&env));
+            if history.len() >= MAX_MEMO_VERSIONS {
+                // Drop oldest entry by rebuilding without index 0
+                let mut trimmed = Vec::new(&env);
+                for i in 1..history.len() {
+                    trimmed.push_back(history.get(i).unwrap());
+                }
+                history = trimmed;
+            }
+            history.push_back(existing.clone());
+            env.storage().instance().set(
+                &DataKey::Payment(PaymentKey::MemoVersion(payment_id)),
+                &history,
+            );
+
             // Memo already set - emit update event with new version
             let new_version = existing.version + 1;
 

--- a/contracts/payment/src/test_payment_channel.rs
+++ b/contracts/payment/src/test_payment_channel.rs
@@ -305,7 +305,14 @@ fn test_equal_nonce_replay_rejected() {
     );
 }
 
-fn setup_channel_env() -> (Env, PaymentContractClient<'static>, Address, Address, Address, u64) {
+fn setup_channel_env() -> (
+    Env,
+    PaymentContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    u64,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -327,7 +334,14 @@ fn setup_channel_env() -> (Env, PaymentContractClient<'static>, Address, Address
     env.ledger().set_timestamp(expires_at - 100);
 
     let dummy_pk = BytesN::<32>::from_array(&env, &[0u8; 32]);
-    let channel_id = client.open_channel(&customer, &merchant, &token_id, &1000i128, &expires_at, &dummy_pk);
+    let channel_id = client.open_channel(
+        &customer,
+        &merchant,
+        &token_id,
+        &1000i128,
+        &expires_at,
+        &dummy_pk,
+    );
 
     (env, client, customer, merchant, token_id, channel_id)
 }
@@ -360,7 +374,11 @@ fn opener_can_close_after_dispute_period() {
 
     let channel = client.get_channel(&channel_id);
     assert!(!channel.open, "Channel should be closed");
-    assert_eq!(token_client.balance(&customer), 1000i128, "Customer should receive full refund");
+    assert_eq!(
+        token_client.balance(&customer),
+        1000i128,
+        "Customer should receive full refund"
+    );
 }
 
 #[test]
@@ -376,7 +394,9 @@ fn counterparty_can_close_immediately_on_agreement() {
     let merchant = Address::generate(&env);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     token_admin_client.mint(&customer, &1000i128);
 
@@ -390,7 +410,14 @@ fn counterparty_can_close_immediately_on_agreement() {
     let customer_pk = BytesN::<32>::from_array(&env, &pk_bytes);
 
     // Channel with no expiry — counterparty (merchant) can settle immediately via signed state
-    let channel_id = client.open_channel(&customer, &merchant, &token_id, &1000i128, &0u64, &customer_pk);
+    let channel_id = client.open_channel(
+        &customer,
+        &merchant,
+        &token_id,
+        &1000i128,
+        &0u64,
+        &customer_pk,
+    );
 
     let merchant_amount: i128 = 400;
     let nonce: u64 = 1;
@@ -422,7 +449,9 @@ fn close_transfers_correct_balances_to_each_party() {
     let merchant = Address::generate(&env);
 
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     token::StellarAssetClient::new(&env, &token_id).mint(&customer, &1000i128);
     let token_client = token::Client::new(&env, &token_id);
 
@@ -435,7 +464,14 @@ fn close_transfers_correct_balances_to_each_party() {
     let pk_bytes = signing_key.verifying_key().to_bytes();
     let customer_pk = BytesN::<32>::from_array(&env, &pk_bytes);
 
-    let channel_id = client.open_channel(&customer, &merchant, &token_id, &1000i128, &0u64, &customer_pk);
+    let channel_id = client.open_channel(
+        &customer,
+        &merchant,
+        &token_id,
+        &1000i128,
+        &0u64,
+        &customer_pk,
+    );
 
     let merchant_amount: i128 = 300;
     let nonce: u64 = 1;
@@ -449,6 +485,14 @@ fn close_transfers_correct_balances_to_each_party() {
 
     client.settle_channel(&channel_id, &merchant_amount, &nonce, &sig_bn);
 
-    assert_eq!(token_client.balance(&merchant), 300i128, "Merchant gets agreed amount");
-    assert_eq!(token_client.balance(&customer), 700i128, "Customer gets remainder");
+    assert_eq!(
+        token_client.balance(&merchant),
+        300i128,
+        "Merchant gets agreed amount"
+    );
+    assert_eq!(
+        token_client.balance(&customer),
+        700i128,
+        "Customer gets remainder"
+    );
 }

--- a/contracts/payment/src/test_trial.rs
+++ b/contracts/payment/src/test_trial.rs
@@ -301,7 +301,9 @@ fn trial_extension_capped_at_max_trial_duration() {
     let result = client.try_extend_trial(&merchant, &sub_id, &(2 * 86400u64));
     assert_eq!(
         result,
-        Err(Ok(Error::Subscription(SubscriptionError::MaxTrialDurationExceeded))),
+        Err(Ok(Error::Subscription(
+            SubscriptionError::MaxTrialDurationExceeded
+        ))),
         "Extension beyond MAX_TRIAL_DURATION must be rejected"
     );
 }


### PR DESCRIPTION

Summary
Addresses four issues across the payment and escrow contracts:

closes #347 [Performance] Cap memo version history at MAX_MEMO_VERSIONS = 10. Each update archives the current memo into a sliding window stored at PaymentKey::MemoVersion(payment_id). When the cap is reached, the oldest entry is pruned before the new one is appended, preventing unbounded instruction-budget growth.

closes #346 [Performance] Add a paged merchant payment index (MerchantDataKey::MerchantPaymentsPage(merchant, page_num)) alongside the existing per-entry index. Each page holds up to 100 payment IDs. Both single-payment and batch-payment creation paths now write to this index. New get_merchant_payments(merchant, page) endpoint retrieves a single page of payment IDs.

closes #350 [Enhancement] Add transfer_beneficiary(escrow_id, new_beneficiary) callable only by the current beneficiary (escrow.merchant.require_auth()). Records every transfer with timestamp in BeneficiaryTransferHistory, queryable via the existing get_transfer_history.

closes #349 [Enhancement] Extend EscrowReleased event with a token: Address field and rename merchant → recipient to accurately reflect that the release target may differ from the original merchant. Both emission sites (internal_release_escrow and execute_queued_action) are updated.

Test plan
 Verify memo history is pruned to ≤ 10 entries after more than 10 sequential set_payment_memo calls on the same payment ID
 Verify get_merchant_payments(merchant, 0) returns the first 100 payment IDs and get_merchant_payments(merchant, 1) returns the next batch after 100+ payments are created
 Verify transfer_beneficiary succeeds when called by the current merchant and fails when called by any other address (including admins)
 Verify EscrowReleased events emitted by release_escrow and execute_queued_action include the correct recipient and token fields
 Run full cargo build — no errors ✅