### PR TITLE
feat: add metered billing unit cap, customer-tier refund policies, an…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,11 @@ jobs:
 
       - name: Build Contracts
         run: stellar contract build
+
+      - name: Check WASM Binary Sizes
+        run: |
+          MAX_SIZE=262144
+          for wasm in target/wasm32v1-none/release/*.wasm; do
+            size=$(wc -c < "$wasm")
+            [ "$size" -le "$MAX_SIZE" ] || (echo "$wasm is too large: $size bytes (limit: $MAX_SIZE)" && exit 1)
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "admin"
+version = "0.0.0"
+dependencies = [
+ "escrow",
+ "payments",
+ "refund",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,17 @@ test: build
 build:
 	stellar contract build
 	@ls -l target/wasm32v1-none/release/*.wasm
+	@$(MAKE) check-size
+
+check-size:
+	@MAX_SIZE=262144; \
+	for wasm in target/wasm32v1-none/release/*.wasm; do \
+		size=$$(wc -c < "$$wasm"); \
+		if [ "$$size" -gt "$$MAX_SIZE" ]; then \
+			echo "$$wasm is too large: $$size bytes (limit: $$MAX_SIZE)"; \
+			exit 1; \
+		fi; \
+	done
 
 fmt:
 	cargo fmt --all

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -181,7 +181,7 @@ pub enum SubscriptionError {
     GracePeriodExpired = 308, RetryTooEarly = 309, MeteredNotFound = 310,
     BillingCapExceeded = 311, GroupNotFound = 312, AlreadyInGroup = 313,
     GroupSizeLimitExceeded = 314, TrialExpired = 315, MaxTrialDurationExceeded = 316,
-    MerchantPaused = 317,
+    MerchantPaused = 317, UsageCapExceeded = 318,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -865,6 +865,7 @@ pub struct MeteredSubscription {
     pub accumulated_units: u64,
     pub billing_cap: Option<i128>,
     pub last_reset_at: u64,
+    pub max_units_per_period: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -4968,6 +4969,7 @@ impl PaymentContract {
         unit_name: String,
         token: Address,
         billing_cap: Option<i128>,
+        max_units_per_period: Option<u64>,
     ) -> Result<u64, Error> {
         merchant.require_auth();
 
@@ -4990,6 +4992,7 @@ impl PaymentContract {
             accumulated_units: 0,
             billing_cap,
             last_reset_at: now,
+            max_units_per_period,
         };
 
         env.storage().instance().set(
@@ -5022,6 +5025,12 @@ impl PaymentContract {
 
         if sub.merchant != merchant {
             return Err(Error::Basic(BasicError::Unauthorized));
+        }
+
+        if let Some(max_units) = sub.max_units_per_period {
+            if sub.accumulated_units.saturating_add(units) > max_units {
+                return Err(Error::Subscription(SubscriptionError::UsageCapExceeded));
+            }
         }
 
         sub.accumulated_units = sub.accumulated_units.saturating_add(units);

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -65,6 +65,10 @@ pub enum DataKey {
     // Payment refund caps
     PaymentRefundCap(u64),
     PaymentRefundUsage(u64),
+    // Issue #370: Customer-tier-based refund caps
+    CustomerTier(Address),
+    CustomerTierPolicy(Address, u32),
+    StrictTierPolicy(Address),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -239,6 +243,8 @@ pub enum Error {
     VoucherAlreadyRedeemed = 54,
     EvidenceAlreadySubmitted = 55,
     CaseAlreadyEscalated = 56,
+    // Issue #370: Customer tier policy errors
+    TierPolicyNotFound = 57,
 }
 
 #[contractevent]
@@ -606,6 +612,13 @@ pub struct PaymentRefundCap {
     pub payment_id: u64,
     pub max_refund_count: u32,
     pub max_total_amount: i128,
+}
+
+// Issue #370: Per-tier refund cap for customer loyalty tiers
+#[derive(Clone)]
+#[contracttype]
+pub struct RefundCap {
+    pub max_refund_bps: u32,
 }
 
 #[derive(Clone)]
@@ -3792,6 +3805,7 @@ impl RefundContract {
     fn validate_against_policy(
         env: &Env,
         merchant: &Address,
+        customer: &Address,
         amount: i128,
         original_amount: i128,
         payment_created_at: u64,
@@ -3819,6 +3833,34 @@ impl RefundContract {
 
         if !found_tier {
             return Err(Error::RefundWindowExpired);
+        }
+
+        // Issue #370: Override allowed_bps with customer tier policy if set
+        let tier_id_opt: Option<u32> = env
+            .storage()
+            .instance()
+            .get(&DataKey::CustomerTier(customer.clone()));
+
+        if let Some(tier_id) = tier_id_opt {
+            let tier_cap_opt: Option<RefundCap> = env
+                .storage()
+                .instance()
+                .get(&DataKey::CustomerTierPolicy(merchant.clone(), tier_id));
+            match tier_cap_opt {
+                Some(cap) => {
+                    allowed_bps = cap.max_refund_bps;
+                }
+                None => {
+                    let strict: bool = env
+                        .storage()
+                        .instance()
+                        .get(&DataKey::StrictTierPolicy(merchant.clone()))
+                        .unwrap_or(false);
+                    if strict {
+                        return Err(Error::TierPolicyNotFound);
+                    }
+                }
+            }
         }
 
         // Check refund percentage using overflow-safe math
@@ -4131,6 +4173,7 @@ impl RefundContract {
             Self::validate_against_policy(
                 &env,
                 &merchant,
+                &customer,
                 amount,
                 original_payment_amount,
                 payment_created_at,
@@ -6735,6 +6778,77 @@ impl RefundContract {
 
         Ok(())
     }
+
+    // Issue #370: Customer tier management
+
+    pub fn set_customer_tier(
+        env: Env,
+        admin: Address,
+        customer: Address,
+        tier_id: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::CustomerTier(customer), &tier_id);
+        Ok(())
+    }
+
+    pub fn get_customer_tier(env: Env, customer: Address) -> Option<u32> {
+        env.storage()
+            .instance()
+            .get(&DataKey::CustomerTier(customer))
+    }
+
+    pub fn set_customer_tier_policy(
+        env: Env,
+        merchant: Address,
+        tier_id: u32,
+        max_refund_bps: u32,
+    ) -> Result<(), Error> {
+        merchant.require_auth();
+        if max_refund_bps > 10000 {
+            return Err(Error::InvalidAmount);
+        }
+        let cap = RefundCap { max_refund_bps };
+        env.storage()
+            .instance()
+            .set(&DataKey::CustomerTierPolicy(merchant, tier_id), &cap);
+        Ok(())
+    }
+
+    pub fn get_customer_tier_policy(env: Env, merchant: Address, tier_id: u32) -> Option<RefundCap> {
+        env.storage()
+            .instance()
+            .get(&DataKey::CustomerTierPolicy(merchant, tier_id))
+    }
+
+    pub fn set_strict_tier_policy(
+        env: Env,
+        merchant: Address,
+        strict: bool,
+    ) -> Result<(), Error> {
+        merchant.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::StrictTierPolicy(merchant), &strict);
+        Ok(())
+    }
+
+    pub fn get_strict_tier_policy(env: Env, merchant: Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::StrictTierPolicy(merchant))
+            .unwrap_or(false)
+    }
 }
 
 mod test;
@@ -6781,3 +6895,6 @@ mod test_arbitration_timeout;
 
 #[cfg(test)]
 mod test_merchant_eligibility;
+
+#[cfg(test)]
+mod test_customer_tier_policy;

--- a/contracts/refund/src/test_customer_tier_policy.rs
+++ b/contracts/refund/src/test_customer_tier_policy.rs
@@ -1,0 +1,147 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String, Vec};
+
+fn setup(env: &Env) -> (RefundContractClient, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    (client, admin)
+}
+
+fn make_policy(env: &Env, merchant: &Address, client: &RefundContractClient) {
+    let tiers = Vec::from_array(
+        env,
+        &[RefundTier {
+            days_from_purchase: 30,
+            max_refund_bps: 10000,
+        }],
+    );
+    client.set_refund_policy(merchant, &tiers);
+}
+
+/// When a customer has a tier assigned but no corresponding tier policy entry
+/// exists for the merchant, the refund request should fall back to the default
+/// merchant policy cap and succeed for an amount within that cap.
+#[test]
+fn missing_tier_policy_falls_back_to_default_cap() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (client, admin) = setup(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    make_policy(&env, &merchant, &client);
+
+    // Assign customer to tier 1 but do NOT set a tier policy for tier 1
+    client.set_customer_tier(&admin, &customer, &1u32);
+
+    // Merchant has no tier policy for tier 1 → should fall back to 100% default
+    // Payment created at timestamp 0, current time is 1000 (< 30 days) → within window
+    let refund_id = client.request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &800i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "fallback test"),
+        &RefundReasonCode::CustomerRequest,
+        &0u64,
+    );
+    assert_eq!(refund_id, 1u64, "refund must succeed using default cap fallback");
+}
+
+/// When strict tier policy mode is enabled for a merchant and a customer has a
+/// tier ID with no matching tier policy entry, request_refund must return
+/// TierPolicyNotFound instead of falling back to the default cap.
+#[test]
+fn missing_tier_policy_returns_error_when_strict_mode_enabled() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (client, admin) = setup(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    make_policy(&env, &merchant, &client);
+
+    // Assign customer to tier 2 with no tier policy entry
+    client.set_customer_tier(&admin, &customer, &2u32);
+    // Enable strict mode for this merchant
+    client.set_strict_tier_policy(&merchant, &true);
+
+    let result = client.try_request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &500i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "strict mode test"),
+        &RefundReasonCode::CustomerRequest,
+        &0u64,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(Error::TierPolicyNotFound)),
+        "strict mode must reject refunds when tier policy is missing"
+    );
+}
+
+/// When a customer has a tier assigned and the merchant has a matching tier
+/// policy, the refund must be validated against that tier-specific cap rather
+/// than the default merchant policy.
+#[test]
+fn existing_tier_policy_applied_correctly() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (client, admin) = setup(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    // Default policy allows 100% refund within 30 days
+    make_policy(&env, &merchant, &client);
+
+    // Tier 3 (bronze) capped at 50%
+    const TIER_ID: u32 = 3;
+    client.set_customer_tier(&admin, &customer, &TIER_ID);
+    client.set_customer_tier_policy(&merchant, &TIER_ID, &5000u32);
+
+    // Requesting 60% of the original payment → must be rejected (exceeds 50% cap)
+    let result = client.try_request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &600i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "over tier cap"),
+        &RefundReasonCode::CustomerRequest,
+        &0u64,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(Error::RefundExceedsPolicy)),
+        "refund exceeding tier cap must be rejected"
+    );
+
+    // Requesting 40% → must succeed (within 50% cap)
+    let refund_id = client.request_refund(
+        &merchant,
+        &2u64,
+        &customer,
+        &400i128,
+        &1000i128,
+        &token,
+        &String::from_str(&env, "within tier cap"),
+        &RefundReasonCode::CustomerRequest,
+        &0u64,
+    );
+    assert_eq!(refund_id, 1u64, "refund within tier cap must succeed");
+}


### PR DESCRIPTION
…d WASM size CI gate

[Enhancement] Metered billing has no cap on units-per-period — a single period can exhaust merchant credit unexpectedly Fixes #339

[Enhancement] Refund policy caps are flat per-merchant — no customer-tier-based (bronze/silver/gold) differentiation is possible Fixes #370

[Test] No test for refund policy lookup when the customer tier does not exist in the policy map Fixes #375

[CI/CD] No WASM binary size check in CI — contract binary can silently exceed Soroban's 256 KB deployment limit Fixes #391