### PR TITLE
Title: fix(escrow): enforce hold period on refund; test hold-period auto-refund and voucher expiry 

### DIFF
--- a/contracts/escrow/src/expiry_test.rs
+++ b/contracts/escrow/src/expiry_test.rs
@@ -218,7 +218,7 @@ fn test_extend_expiry_not_after_current_fails() {
 fn test_extend_expiry_released_escrow_fails() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _admin, customer, merchant, token) = setup(&env);
+    let (client, admin, customer, merchant, token) = setup(&env);
 
     env.ledger().set_timestamp(1000);
     let escrow_id = client.create_escrow(
@@ -226,7 +226,7 @@ fn test_extend_expiry_released_escrow_fails() {
     );
 
     env.ledger().set_timestamp(1600);
-    client.release_escrow(&escrow_id);
+    client.release_escrow(&admin, &escrow_id, &false);
 
     let result = client.try_extend_escrow_expiry(&customer, &escrow_id, &4000_u64);
     assert!(result.is_err());

--- a/contracts/escrow/src/hold_period_test.rs
+++ b/contracts/escrow/src/hold_period_test.rs
@@ -1,0 +1,89 @@
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
+
+fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let token_addr = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = token::StellarAssetClient::new(env, &token_addr);
+    let customer = Address::generate(env);
+    token_admin.mint(&customer, &10_000);
+    token_admin.mint(&contract_id, &10_000);
+
+    (client, admin, customer, Address::generate(env), token_addr)
+}
+
+#[test]
+fn escrow_refundable_after_hold_period_elapsed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    // Create escrow at t=1000 with hold period of 500s
+    env.ledger().set_timestamp(1000);
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &500_i128, &token, &0_u64, &500_u64, &0_u64, &false,
+    );
+
+    // Advance past hold period: 1000 + 500 = 1500
+    env.ledger().set_timestamp(1501);
+    let result = client.try_refund_escrow(&customer, &escrow_id);
+    assert!(result.is_ok(), "refund should succeed after hold period has elapsed");
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Resolved);
+}
+
+#[test]
+fn escrow_not_refundable_before_hold_period_elapsed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    // Create escrow at t=1000 with hold period of 500s
+    env.ledger().set_timestamp(1000);
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &500_i128, &token, &0_u64, &500_u64, &0_u64, &false,
+    );
+
+    // Attempt refund before hold period expires (at exactly t=1000, hold period = 500s)
+    env.ledger().set_timestamp(1400);
+    let result = client.try_refund_escrow(&customer, &escrow_id);
+    assert!(result.is_err(), "refund should fail before hold period has elapsed");
+}
+
+#[test]
+fn refund_after_hold_period_transfers_correct_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+
+    let token_client = token::Client::new(&env, &token);
+    let amount = 750_i128;
+
+    // Create escrow at t=2000 with hold period of 300s
+    env.ledger().set_timestamp(2000);
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &amount, &token, &0_u64, &300_u64, &0_u64, &false,
+    );
+
+    let balance_before = token_client.balance(&customer);
+
+    // Advance past hold period: 2000 + 300 = 2300
+    env.ledger().set_timestamp(2301);
+    client.refund_escrow(&customer, &escrow_id);
+
+    let balance_after = token_client.balance(&customer);
+    assert_eq!(
+        balance_after - balance_before,
+        amount,
+        "customer should receive exactly the escrowed amount"
+    );
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3105,7 +3105,14 @@ impl EscrowContract {
             return Err(Error::Basic(BasicError::Unauthorized));
         }
         match escrow.status {
-            EscrowStatus::Locked | EscrowStatus::Disputed => {
+            EscrowStatus::Locked => {
+                let current_time = env.ledger().timestamp();
+                if current_time < escrow.created_at + escrow.min_hold_period {
+                    return Err(Error::Escrow(EscrowError::ReleaseOnHoldPeriod));
+                }
+                escrow.status = EscrowStatus::Resolved;
+            }
+            EscrowStatus::Disputed => {
                 escrow.status = EscrowStatus::Resolved;
             }
             EscrowStatus::Released | EscrowStatus::Resolved | EscrowStatus::Cancelled => {
@@ -9136,6 +9143,9 @@ mod bulk_evidence_test;
 //
 #[cfg(test)]
 mod observer_test;
+//
+#[cfg(test)]
+mod hold_period_test;
 //
 // mod health_check_test;
 //

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -6898,3 +6898,6 @@ mod test_merchant_eligibility;
 
 #[cfg(test)]
 mod test_customer_tier_policy;
+
+#[cfg(test)]
+mod test_voucher_expiry;

--- a/contracts/refund/src/test_voucher_expiry.rs
+++ b/contracts/refund/src/test_voucher_expiry.rs
@@ -1,0 +1,122 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+fn setup(env: &Env) -> (RefundContractClient, Address) {
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    (client, admin)
+}
+
+fn create_refund_and_issue_voucher(
+    env: &Env,
+    client: &RefundContractClient,
+    admin: &Address,
+    expiry_seconds: u64,
+) -> (u64, u64) {
+    let merchant = Address::generate(env);
+    let customer = Address::generate(env);
+    let token = Address::generate(env);
+    let amount = 1000_i128;
+    let payment_id = 1_u64;
+    let reason = String::from_str(env, "defective product");
+
+    let refund_id = client.request_refund(
+        &merchant,
+        &payment_id,
+        &customer,
+        &amount,
+        &amount,
+        &token,
+        &reason,
+        &RefundReasonCode::ProductDefect,
+        &env.ledger().timestamp(),
+    );
+
+    let voucher_id = client.issue_refund_voucher(admin, &refund_id, &expiry_seconds);
+    (refund_id, voucher_id)
+}
+
+#[test]
+fn test_redeem_voucher_before_expiry_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    // Issue a voucher expiring 1000s from now
+    env.ledger().set_timestamp(1000);
+    let (_, voucher_id) = create_refund_and_issue_voucher(&env, &client, &admin, 1000);
+
+    // Redeem before expiry (at t=1500, expires at t=2000)
+    env.ledger().set_timestamp(1500);
+    let result = client.try_redeem_refund_voucher(
+        &client.get_voucher(&voucher_id).unwrap().customer,
+        &voucher_id,
+        &1_u64,
+    );
+    assert!(result.is_ok(), "redeeming a valid unexpired voucher should succeed");
+}
+
+#[test]
+fn test_redeem_expired_voucher_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    // Issue a voucher expiring 500s from t=1000 → expires at t=1500
+    env.ledger().set_timestamp(1000);
+    let (_, voucher_id) = create_refund_and_issue_voucher(&env, &client, &admin, 500);
+
+    // Advance past expiry
+    env.ledger().set_timestamp(1501);
+    let result = client.try_redeem_refund_voucher(
+        &client.get_voucher(&voucher_id).unwrap().customer,
+        &voucher_id,
+        &1_u64,
+    );
+    assert!(result.is_err(), "redeeming an expired voucher should fail");
+}
+
+#[test]
+fn test_redeem_voucher_at_exact_expiry_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    // Issue a voucher expiring 300s from t=1000 → expires at t=1300
+    env.ledger().set_timestamp(1000);
+    let (_, voucher_id) = create_refund_and_issue_voucher(&env, &client, &admin, 300);
+
+    // At exactly the expiry timestamp the voucher is expired (> check uses >)
+    env.ledger().set_timestamp(1300);
+    let result = client.try_redeem_refund_voucher(
+        &client.get_voucher(&voucher_id).unwrap().customer,
+        &voucher_id,
+        &1_u64,
+    );
+    // timestamp(1300) > expires_at(1300) is false, so it should succeed at exactly the boundary
+    assert!(result.is_ok(), "voucher should still be valid at exactly the expiry timestamp");
+}
+
+#[test]
+fn test_already_redeemed_voucher_cannot_be_redeemed_again() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    env.ledger().set_timestamp(1000);
+    let (_, voucher_id) = create_refund_and_issue_voucher(&env, &client, &admin, 1000);
+
+    let customer = client.get_voucher(&voucher_id).unwrap().customer;
+
+    // First redemption should succeed
+    client.redeem_refund_voucher(&customer, &voucher_id, &1_u64);
+
+    // Second redemption must fail
+    let result = client.try_redeem_refund_voucher(&customer, &voucher_id, &1_u64);
+    assert!(result.is_err(), "a voucher can only be redeemed once");
+}


### PR DESCRIPTION

Body:


## Summary

closes #358 [Test + Fix]** — Added three tests verifying escrow hold-period auto-refund behaviour, and fixed the logic gap that made them possible: `refund_escrow` previously had no hold-period guard, allowing customers to refund a locked escrow immediately. Now `refund_escrow` returns `ReleaseOnHoldPeriod` for `Locked` escrows until `created_at + min_hold_period` has elapsed (matching the existing guard in `release_escrow`).

closes #371 [Test]** — Added four tests covering voucher expiry in `redeem_refund_voucher`. The expiry check (`timestamp > expires_at`) was already in place; these tests lock in the behaviour with passing/failing/boundary and double-redeem cases.
closes #359
## Changes

| File | Change |
|------|--------|
| `contracts/escrow/src/lib.rs` | Guard added to `refund_escrow` for `Locked` status — rejects refund before hold period elapses |
| `contracts/escrow/src/hold_period_test.rs` | New: `escrow_refundable_after_hold_period_elapsed`, `escrow_not_refundable_before_hold_period_elapsed`, `refund_after_hold_period_transfers_correct_amount` |
| `contracts/escrow/src/expiry_test.rs` | Bug fix: `release_escrow` was called with wrong arity in `test_extend_expiry_released_escrow_fails` |
| `contracts/refund/src/test_voucher_expiry.rs` | New: `test_redeem_voucher_before_expiry_succeeds`, `test_redeem_expired_voucher_fails`, `test_redeem_voucher_at_exact_expiry_fails`, `test_already_redeemed_voucher_cannot_be_redeemed_again` |
| `contracts/refund/src/lib.rs` | Registers `test_voucher_expiry` module |

## Test plan

- [ ] `cargo test -p escrow hold_period` — all 3 new tests pass
- [ ] `cargo test -p escrow expiry` — existing expiry tests still pass (arity fix included)
- [ ] `cargo test -p refund test_voucher` — 4 voucher expiry tests pass once pre-existing compile errors in unrelated refund test files are resolved