### PR TITLE
feat :  add admin path, add notification hook address

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -228,6 +228,8 @@ pub enum Error {
     HookNotFound = 41,
     MaxHooksPerEventReached = 42,
     HookNotOwnedBySubscriber = 43,
+    // Issue #373: Invalid notification hook subscriber address
+    InvalidHookAddress = 58,
     // Issue #148: Customer eligibility errors
     CustomerBlockedFromRefund = 44,
     EligibilityEntryNotFound = 45,
@@ -844,6 +846,8 @@ pub struct CustomerRefundRateLimit {
     pub request_count: u32,
     pub max_requests_per_window: u32,
     pub window_seconds: u64,
+    /// When true, per-customer limits are not refreshed from global config on window reset.
+    pub custom_override: bool,
 }
 
 #[derive(Clone)]
@@ -851,6 +855,10 @@ pub struct CustomerRefundRateLimit {
 pub struct GlobalRefundRateLimit {
     pub max_requests_per_window: u32,
     pub window_seconds: u64,
+    /// Config applied to windows that start at or after `next_config_effective_at`.
+    pub next_max_requests_per_window: u32,
+    pub next_window_seconds: u64,
+    pub next_config_effective_at: u64,
 }
 
 /// Configuration for platform fee deduction on refund processing
@@ -1186,6 +1194,16 @@ pub struct RefundCooldownEnforced {
     pub last_refund_at: u64,
     pub cooldown_seconds: u64,
     pub available_at: u64,
+}
+
+/// Event emitted when the global refund rate limit config is updated
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitUpdated {
+    pub admin: Address,
+    pub new_window_seconds: u64,
+    pub new_max_refunds: u32,
+    pub effective_at: u64,
 }
 
 #[contract]
@@ -1738,10 +1756,12 @@ impl RefundContract {
                 request_count: 0,
                 max_requests_per_window: max_per_window,
                 window_seconds,
+                custom_override: true,
             });
 
         limit.max_requests_per_window = max_per_window;
         limit.window_seconds = window_seconds;
+        limit.custom_override = true;
 
         env.storage()
             .instance()
@@ -1759,6 +1779,7 @@ impl RefundContract {
                 request_count: 0,
                 max_requests_per_window: 0,
                 window_seconds: 0,
+                custom_override: false,
             })
     }
 
@@ -1770,15 +1791,79 @@ impl RefundContract {
     ) -> Result<(), Error> {
         admin.require_auth();
 
+        if max_per_window == 0 || window_seconds == 0 {
+            return Err(Error::InvalidAmount);
+        }
+
         let limit = GlobalRefundRateLimit {
             max_requests_per_window: max_per_window,
             window_seconds,
+            next_max_requests_per_window: max_per_window,
+            next_window_seconds: window_seconds,
+            next_config_effective_at: 0,
         };
 
         env.storage()
             .instance()
             .set(&DataKey::GlobalRefundRateLimit, &limit);
         Ok(())
+    }
+
+    /// Update the global refund rate limit without disrupting in-progress windows.
+    /// New parameters apply only to windows that start at or after the update timestamp;
+    /// the current window's request count and duration are preserved.
+    pub fn update_rate_limit(
+        env: Env,
+        admin: Address,
+        new_window_seconds: u64,
+        new_max_refunds: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+
+        if new_max_refunds == 0 || new_window_seconds == 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let now = env.ledger().timestamp();
+        let updated = match env
+            .storage()
+            .instance()
+            .get::<DataKey, GlobalRefundRateLimit>(&DataKey::GlobalRefundRateLimit)
+        {
+            Some(mut existing) => {
+                existing.next_max_requests_per_window = new_max_refunds;
+                existing.next_window_seconds = new_window_seconds;
+                existing.next_config_effective_at = now;
+                existing
+            }
+            None => GlobalRefundRateLimit {
+                max_requests_per_window: new_max_refunds,
+                window_seconds: new_window_seconds,
+                next_max_requests_per_window: new_max_refunds,
+                next_window_seconds: new_window_seconds,
+                next_config_effective_at: 0,
+            },
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::GlobalRefundRateLimit, &updated);
+
+        (RateLimitUpdated {
+            admin,
+            new_window_seconds,
+            new_max_refunds,
+            effective_at: now,
+        })
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_global_refund_rate_limit(env: Env) -> Option<GlobalRefundRateLimit> {
+        env.storage()
+            .instance()
+            .get(&DataKey::GlobalRefundRateLimit)
     }
 
     pub fn register_arbitrator(env: Env, admin: Address, arbitrator: Address) -> Result<(), Error> {
@@ -3972,7 +4057,7 @@ impl RefundContract {
         admin.require_auth();
         let limit = Self::get_batch_refund_limit(env.clone());
         if refund_ids.len() > limit {
-            // Return single error result indicating batch too large
+            // Batch-level validation failure: reject the entire batch without processing.
             let mut results = Vec::new(&env);
             results.push_back(BatchRefundResult {
                 refund_id: 0,
@@ -3983,6 +4068,8 @@ impl RefundContract {
             return results;
         }
 
+        // Per-item failures are isolated; valid items are processed and invalid items
+        // return an error entry in the results vector without blocking other items.
         let mut results = Vec::new(&env);
         for refund_id in refund_ids.iter() {
             let result = Self::approve_refund_internal(&env, admin.clone(), refund_id);
@@ -4022,6 +4109,7 @@ impl RefundContract {
         admin.require_auth();
         let limit = Self::get_batch_refund_limit(env.clone());
         if refund_ids.len() > limit {
+            // Batch-level validation failure: reject the entire batch without processing.
             let mut results = Vec::new(&env);
             results.push_back(BatchRefundResult {
                 refund_id: 0,
@@ -4032,6 +4120,8 @@ impl RefundContract {
             return results;
         }
 
+        // Per-item failures are isolated; valid items are processed and invalid items
+        // return an error entry in the results vector without blocking other items.
         let mut results = Vec::new(&env);
         for refund_id in refund_ids.iter() {
             let amount = env
@@ -4901,6 +4991,17 @@ impl RefundContract {
         }
     }
 
+    fn effective_global_rate_limit(global: &GlobalRefundRateLimit, now: u64) -> (u32, u64) {
+        if global.next_config_effective_at > 0 && now >= global.next_config_effective_at {
+            (
+                global.next_max_requests_per_window,
+                global.next_window_seconds,
+            )
+        } else {
+            (global.max_requests_per_window, global.window_seconds)
+        }
+    }
+
     fn check_and_update_customer_refund_rate_limit(
         env: &Env,
         customer: Address,
@@ -4918,23 +5019,32 @@ impl RefundContract {
         if global_limit_opt.is_none() && customer_limit_opt.is_none() {
             return Ok(());
         }
+        let now = env.ledger().timestamp();
         let mut limit = match customer_limit_opt {
             Some(l) => l,
             None => {
-                let g = global_limit_opt.unwrap();
+                let g = global_limit_opt.as_ref().unwrap();
+                let (max_requests, window_seconds) = Self::effective_global_rate_limit(g, now);
                 CustomerRefundRateLimit {
                     customer: customer.clone(),
-                    window_start: env.ledger().timestamp(),
+                    window_start: now,
                     request_count: 0,
-                    max_requests_per_window: g.max_requests_per_window,
-                    window_seconds: g.window_seconds,
+                    max_requests_per_window: max_requests,
+                    window_seconds,
+                    custom_override: false,
                 }
             }
         };
-        let now = env.ledger().timestamp();
         if now >= limit.window_start + limit.window_seconds {
             limit.window_start = now;
             limit.request_count = 0;
+            if !limit.custom_override {
+                if let Some(ref g) = global_limit_opt {
+                    let (max_requests, window_seconds) = Self::effective_global_rate_limit(g, now);
+                    limit.max_requests_per_window = max_requests;
+                    limit.window_seconds = window_seconds;
+                }
+            }
         }
         if limit.request_count >= limit.max_requests_per_window {
             return Err(Error::RefundRateLimitExceeded);
@@ -5387,6 +5497,18 @@ impl RefundContract {
     // Issue #144: Notification hook functions
     const MAX_HOOKS_PER_EVENT: u32 = 10;
 
+    /// Verify the subscriber address is a reachable contract that implements `ping()`.
+    fn validate_notification_hook_subscriber(env: &Env, subscriber: &Address) -> Result<(), Error> {
+        match env.try_invoke_contract::<(), soroban_sdk::InvokeError>(
+            subscriber,
+            &Symbol::new(env, "ping"),
+            ().into_val(env),
+        ) {
+            Ok(Ok(_)) => Ok(()),
+            _ => Err(Error::InvalidHookAddress),
+        }
+    }
+
     /// Register a notification hook for specific refund events
     pub fn register_notification_hook(
         env: Env,
@@ -5399,6 +5521,8 @@ impl RefundContract {
         if events.is_empty() {
             return Err(Error::InvalidAmount); // Reusing error for invalid input
         }
+
+        Self::validate_notification_hook_subscriber(&env, &subscriber)?;
 
         // Check max hooks per event type
         for event_type in events.iter() {

--- a/contracts/refund/src/test_batch.rs
+++ b/contracts/refund/src/test_batch.rs
@@ -33,6 +33,175 @@ fn make_refund(
     )
 }
 
+fn refund_status(client: &RefundContractClient, refund_id: u64) -> RefundStatus {
+    client.get_refund(&refund_id).status
+}
+
+// ── Required batch_refund() semantics tests ─────────────────────────────────
+// approve_refund_batch / process_refund_batch implement partial-success mode:
+// per-item validation failures are skipped while valid items continue.
+// Batch-level validation failures (e.g. oversized batch) abort the entire call.
+
+#[test]
+fn batch_with_all_valid_items_completes_successfully() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    let r1 = make_refund(&client, &env, &merchant, 1);
+    let r2 = make_refund(&client, &env, &merchant, 2);
+    let r3 = make_refund(&client, &env, &merchant, 3);
+
+    let mut approve_ids = Vec::new(&env);
+    approve_ids.push_back(r1);
+    approve_ids.push_back(r2);
+    approve_ids.push_back(r3);
+
+    let approve_results = client.approve_refund_batch(&admin, &approve_ids);
+    assert_eq!(approve_results.len(), 3);
+    for i in 0..3 {
+        let result = approve_results.get(i).unwrap();
+        assert!(result.success);
+        assert_eq!(result.error_code, 0);
+        assert_eq!(refund_status(&client, result.refund_id), RefundStatus::Approved);
+    }
+
+    let mut process_ids = Vec::new(&env);
+    process_ids.push_back(r1);
+    process_ids.push_back(r2);
+    process_ids.push_back(r3);
+
+    let process_results = client.process_refund_batch(&admin, &process_ids);
+    assert_eq!(process_results.len(), 3);
+    for i in 0..3 {
+        let result = process_results.get(i).unwrap();
+        assert!(result.success);
+        assert_eq!(result.error_code, 0);
+        assert_eq!(result.amount_refunded, 500i128);
+        assert_eq!(refund_status(&client, result.refund_id), RefundStatus::Processed);
+    }
+}
+
+#[test]
+fn batch_processes_valid_items_and_skips_invalid() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    let r1 = make_refund(&client, &env, &merchant, 1);
+    let r2 = make_refund(&client, &env, &merchant, 2);
+    let r3 = make_refund(&client, &env, &merchant, 3);
+    let missing_id = 9999u64;
+
+    // Pre-approve r2 so a later approve attempt fails with InvalidStatus.
+    client.approve_refund(&admin, &r2);
+
+    let mut approve_ids = Vec::new(&env);
+    approve_ids.push_back(r1);
+    approve_ids.push_back(missing_id);
+    approve_ids.push_back(r2);
+    approve_ids.push_back(r3);
+
+    let approve_results = client.approve_refund_batch(&admin, &approve_ids);
+    assert_eq!(approve_results.len(), 4);
+    assert!(approve_results.get(0).unwrap().success);
+    assert!(!approve_results.get(1).unwrap().success);
+    assert_eq!(
+        approve_results.get(1).unwrap().error_code,
+        Error::RefundNotFound as u32
+    );
+    assert!(!approve_results.get(2).unwrap().success);
+    assert_eq!(
+        approve_results.get(2).unwrap().error_code,
+        Error::InvalidStatus as u32
+    );
+    assert!(approve_results.get(3).unwrap().success);
+
+    assert_eq!(refund_status(&client, r1), RefundStatus::Approved);
+    assert_eq!(refund_status(&client, r2), RefundStatus::Approved);
+    assert_eq!(refund_status(&client, r3), RefundStatus::Approved);
+
+    // Pre-process r1 so batch processing hits an already-processed item.
+    client.process_refund(&admin, &r1);
+
+    let mut process_ids = Vec::new(&env);
+    process_ids.push_back(r1);
+    process_ids.push_back(missing_id);
+    process_ids.push_back(r2);
+    process_ids.push_back(r3);
+
+    let process_results = client.process_refund_batch(&admin, &process_ids);
+    assert_eq!(process_results.len(), 4);
+    assert!(!process_results.get(0).unwrap().success);
+    assert_eq!(
+        process_results.get(0).unwrap().error_code,
+        Error::InvalidStatus as u32
+    );
+    assert!(!process_results.get(1).unwrap().success);
+    assert_eq!(
+        process_results.get(1).unwrap().error_code,
+        Error::RefundNotFound as u32
+    );
+    assert!(process_results.get(2).unwrap().success);
+    assert!(process_results.get(3).unwrap().success);
+
+    assert_eq!(refund_status(&client, r1), RefundStatus::Processed);
+    assert_eq!(refund_status(&client, r2), RefundStatus::Processed);
+    assert_eq!(refund_status(&client, r3), RefundStatus::Processed);
+}
+
+#[test]
+fn batch_aborts_all_on_single_validation_failure() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let merchant = Address::generate(&env);
+
+    client.set_batch_refund_limit(&admin, &2u32);
+
+    let r1 = make_refund(&client, &env, &merchant, 1);
+    let r2 = make_refund(&client, &env, &merchant, 2);
+    let r3 = make_refund(&client, &env, &merchant, 3);
+
+    let mut approve_ids = Vec::new(&env);
+    approve_ids.push_back(r1);
+    approve_ids.push_back(r2);
+    approve_ids.push_back(r3);
+
+    let approve_results = client.approve_refund_batch(&admin, &approve_ids);
+    assert_eq!(approve_results.len(), 1);
+    assert!(!approve_results.get(0).unwrap().success);
+    assert_eq!(
+        approve_results.get(0).unwrap().error_code,
+        Error::BatchRefundTooLarge as u32
+    );
+
+    // Batch-level rejection must not mutate any refund in the batch.
+    assert_eq!(refund_status(&client, r1), RefundStatus::Requested);
+    assert_eq!(refund_status(&client, r2), RefundStatus::Requested);
+    assert_eq!(refund_status(&client, r3), RefundStatus::Requested);
+
+    // Approve two items individually, then attempt an oversized process batch.
+    client.approve_refund(&admin, &r1);
+    client.approve_refund(&admin, &r2);
+
+    let mut process_ids = Vec::new(&env);
+    process_ids.push_back(r1);
+    process_ids.push_back(r2);
+    process_ids.push_back(r3);
+
+    let process_results = client.process_refund_batch(&admin, &process_ids);
+    assert_eq!(process_results.len(), 1);
+    assert!(!process_results.get(0).unwrap().success);
+    assert_eq!(
+        process_results.get(0).unwrap().error_code,
+        Error::BatchRefundTooLarge as u32
+    );
+
+    assert_eq!(refund_status(&client, r1), RefundStatus::Approved);
+    assert_eq!(refund_status(&client, r2), RefundStatus::Approved);
+    assert_eq!(refund_status(&client, r3), RefundStatus::Requested);
+}
+
 // Default batch limit is 20
 #[test]
 fn test_default_batch_limit() {

--- a/contracts/refund/src/test_notification_hooks.rs
+++ b/contracts/refund/src/test_notification_hooks.rs
@@ -13,6 +13,8 @@ pub struct MockSubscriber;
 
 #[contractimpl]
 impl MockSubscriber {
+    pub fn ping(_env: Env) {}
+
     pub fn on_refund_event(_env: Env, _event_type: RefundEventType, _refund_id: u64) {
         // Mock implementation - does nothing but doesn't fail
     }
@@ -24,9 +26,20 @@ pub struct FailingSubscriber;
 
 #[contractimpl]
 impl FailingSubscriber {
+    pub fn ping(_env: Env) {}
+
     pub fn on_refund_event(_env: Env, _event_type: RefundEventType, _refund_id: u64) {
         panic!("Intentional failure");
     }
+}
+
+// Hook contract missing ping() — registration must be rejected
+#[contract]
+pub struct SubscriberWithoutPing;
+
+#[contractimpl]
+impl SubscriberWithoutPing {
+    pub fn on_refund_event(_env: Env, _event_type: RefundEventType, _refund_id: u64) {}
 }
 
 fn setup_test_env<'a>() -> (Env, RefundContractClient<'a>, Address, Address) {
@@ -37,11 +50,15 @@ fn setup_test_env<'a>() -> (Env, RefundContractClient<'a>, Address, Address) {
     let client = RefundContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    let subscriber = Address::generate(&env);
+    let subscriber = env.register_contract(None, MockSubscriber);
 
     client.initialize(&admin);
 
     (env, client, admin, subscriber)
+}
+
+fn register_mock_subscriber(env: &Env) -> Address {
+    env.register_contract(None, MockSubscriber)
 }
 
 #[test]
@@ -68,8 +85,8 @@ fn test_register_notification_hook() {
 fn test_register_multiple_hooks() {
     let (env, client, _admin, _subscriber) = setup_test_env();
 
-    let subscriber1 = Address::generate(&env);
-    let subscriber2 = Address::generate(&env);
+    let subscriber1 = register_mock_subscriber(&env);
+    let subscriber2 = register_mock_subscriber(&env);
 
     let mut events1 = Vec::new(&env);
     events1.push_back(RefundEventType::Requested);
@@ -97,7 +114,7 @@ fn test_max_hooks_per_event() {
 
     // Register 10 hooks (max limit)
     for i in 0..10 {
-        let subscriber = Address::generate(&env);
+        let subscriber = register_mock_subscriber(&env);
         let mut events = Vec::new(&env);
         events.push_back(RefundEventType::Requested);
 
@@ -106,7 +123,7 @@ fn test_max_hooks_per_event() {
     }
 
     // Try to register 11th hook - should fail
-    let subscriber11 = Address::generate(&env);
+    let subscriber11 = register_mock_subscriber(&env);
     let mut events = Vec::new(&env);
     events.push_back(RefundEventType::Requested);
 
@@ -141,7 +158,7 @@ fn test_deregister_hook_not_owner() {
     let hook_id = client.register_notification_hook(&subscriber, &events);
 
     // Try to deregister with different address
-    let other_subscriber = Address::generate(&env);
+    let other_subscriber = register_mock_subscriber(&env);
     let result = client.try_deregister_hook(&other_subscriber, &hook_id);
     assert_eq!(result, Err(Ok(Error::HookNotOwnedBySubscriber)));
 }
@@ -376,6 +393,30 @@ fn test_multiple_hooks_same_event() {
     );
 
     assert_eq!(refund_id, 1);
+}
+
+#[test]
+fn test_register_notification_hook_invalid_address() {
+    let (env, client, _admin, _subscriber) = setup_test_env();
+
+    let invalid_subscriber = Address::generate(&env);
+    let mut events = Vec::new(&env);
+    events.push_back(RefundEventType::Requested);
+
+    let result = client.try_register_notification_hook(&invalid_subscriber, &events);
+    assert_eq!(result, Err(Ok(Error::InvalidHookAddress)));
+}
+
+#[test]
+fn test_register_notification_hook_missing_ping() {
+    let (env, client, _admin, _subscriber) = setup_test_env();
+
+    let subscriber = env.register_contract(None, SubscriberWithoutPing);
+    let mut events = Vec::new(&env);
+    events.push_back(RefundEventType::Requested);
+
+    let result = client.try_register_notification_hook(&subscriber, &events);
+    assert_eq!(result, Err(Ok(Error::InvalidHookAddress)));
 }
 
 #[test]

--- a/contracts/refund/src/test_rate_limit.rs
+++ b/contracts/refund/src/test_rate_limit.rs
@@ -153,3 +153,181 @@ fn test_rate_limit_window_reset() {
         &0,
     );
 }
+
+#[test]
+fn test_update_rate_limit_preserves_current_window_count() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let reason = String::from_str(&env, "Preserve count");
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client.set_global_refund_rate_limit(&admin, &3, &86400);
+
+    for i in 1..=2 {
+        client.request_refund(
+            &merchant,
+            &(i as u64),
+            &customer,
+            &100,
+            &100,
+            &token,
+            &reason,
+            &RefundReasonCode::Other,
+            &0,
+        );
+    }
+
+    // Tighten limits mid-window; in-progress window keeps prior max and count.
+    client.update_rate_limit(&admin, &3600, &1);
+
+    let status = client.get_customer_rate_limit_status(&customer);
+    assert_eq!(status.request_count, 2);
+    assert_eq!(status.max_requests_per_window, 3);
+    assert_eq!(status.window_seconds, 86400);
+
+    client.request_refund(
+        &merchant,
+        &3,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0,
+    );
+
+    let res = client.try_request_refund(
+        &merchant,
+        &4,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_update_rate_limit_applies_after_window_reset() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let reason = String::from_str(&env, "Deferred apply");
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client.set_global_refund_rate_limit(&admin, &3, &86400);
+
+    for i in 1..=2 {
+        client.request_refund(
+            &merchant,
+            &(i as u64),
+            &customer,
+            &100,
+            &100,
+            &token,
+            &reason,
+            &RefundReasonCode::Other,
+            &0,
+        );
+    }
+
+    env.ledger().set_timestamp(100);
+    client.update_rate_limit(&admin, &3600, &1);
+
+    // Still inside the original 24h window; old limits apply.
+    client.request_refund(
+        &merchant,
+        &3,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0,
+    );
+
+    let res = client.try_request_refund(
+        &merchant,
+        &4,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0,
+    );
+    assert!(res.is_err());
+
+    // After the original window expires, the updated config takes effect.
+    env.ledger().set_timestamp(86401);
+
+    client.request_refund(
+        &merchant,
+        &5,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0,
+    );
+
+    let status = client.get_customer_rate_limit_status(&customer);
+    assert_eq!(status.request_count, 1);
+    assert_eq!(status.max_requests_per_window, 1);
+    assert_eq!(status.window_seconds, 3600);
+
+    let res = client.try_request_refund(
+        &merchant,
+        &6,
+        &customer,
+        &100,
+        &100,
+        &token,
+        &reason,
+        &RefundReasonCode::Other,
+        &0,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_update_rate_limit_rejects_invalid_params() {
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    assert_eq!(
+        client.try_update_rate_limit(&admin, &0, &5),
+        Err(Ok(Error::InvalidAmount))
+    );
+    assert_eq!(
+        client.try_update_rate_limit(&admin, &3600, &0),
+        Err(Ok(Error::InvalidAmount))
+    );
+}


### PR DESCRIPTION
closes #373
closes #374
closes #377
closes #379

##Summary
Notification Hook Validation
Problem: register_notification_hook() accepted any address without verifying it was a reachable contract. Invalid hook addresses caused silent notification failures while refund state still changed.