### PR TITLE
feat: subscription index, token allowlist, refund appeal window, and arbitrator conflict guard

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -43,6 +43,7 @@ pub enum ConfigKey {
     GlobalMerchantCount,
     PauseStateKey,
     MinSplitAmount,
+    AllowedTokens,
 }
 
 #[derive(Clone)]
@@ -170,6 +171,7 @@ pub enum PaymentError {
     BillingOverflow = 221,
     InvalidLineItem = 222,
     InvalidScheduleTime = 223,
+    TokenNotAllowed = 224,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -291,7 +293,7 @@ impl TryFrom<soroban_sdk::Error> for Error {
             if code >= 300 && code <= 316 {
                 return Ok(Error::Subscription(unsafe { core::mem::transmute(code) }));
             }
-            if code >= 200 && code <= 223 {
+            if code >= 200 && code <= 224 {
                 return Ok(Error::Payment(unsafe { core::mem::transmute(code) }));
             }
             if code >= 100 && code <= 125 {
@@ -359,6 +361,9 @@ pub enum MerchantDataKey {
     VerificationTierLimit(MerchantVerificationLevel),
     MerchantPaymentsPage(Address, u64),
     MerchantPaused(Address),
+    MerchantActiveSubscriptions(Address, u64),
+    MerchantActiveSubscriptionCount(Address),
+    ActiveSubscriptionIndex(u64),
 }
 
 // State and proposal data keys
@@ -2460,6 +2465,10 @@ impl PaymentContract {
         expiration_duration: u64,
         metadata: String,
     ) -> Result<u64, Error> {
+        if !PaymentContract::is_token_allowed(env, &token) {
+            return Err(Error::Payment(PaymentError::TokenNotAllowed));
+        }
+
         // Validate currency
         if !PaymentContract::is_valid_currency(&currency) {
             return Err(Error::Basic(BasicError::InvalidCurrency));
@@ -4410,6 +4419,240 @@ impl PaymentContract {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    pub fn add_allowed_token(env: Env, admin: Address, token: Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::MultiSigConfig))
+            .ok_or(Error::Basic(BasicError::MultiSigNotInitialized))?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Basic(BasicError::Unauthorized));
+        }
+
+        let mut tokens: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::AllowedTokens))
+            .unwrap_or_else(|| Vec::new(&env));
+        if !tokens.contains(&token) {
+            tokens.push_back(token);
+            env.storage()
+                .instance()
+                .set(&DataKey::Config(ConfigKey::AllowedTokens), &tokens);
+        }
+
+        Ok(())
+    }
+
+    pub fn remove_allowed_token(env: Env, admin: Address, token: Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::MultiSigConfig))
+            .ok_or(Error::Basic(BasicError::MultiSigNotInitialized))?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Basic(BasicError::Unauthorized));
+        }
+
+        let tokens: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::AllowedTokens))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut updated = Vec::new(&env);
+        for entry in tokens.iter() {
+            if entry != token {
+                updated.push_back(entry);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Config(ConfigKey::AllowedTokens), &updated);
+
+        Ok(())
+    }
+
+    pub fn get_allowed_tokens(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::AllowedTokens))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    fn is_token_allowed(env: &Env, token: &Address) -> bool {
+        let tokens: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::AllowedTokens))
+            .unwrap_or_else(|| Vec::new(env));
+        tokens.contains(token)
+    }
+
+    const ACTIVE_SUBSCRIPTION_PAGE_SIZE: u64 = 100;
+
+    fn merchant_active_subscription_count(env: &Env, merchant: &Address) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Merchant(
+                MerchantDataKey::MerchantActiveSubscriptionCount(merchant.clone()),
+            ))
+            .unwrap_or(0)
+    }
+
+    fn set_active_subscription_at(
+        env: &Env,
+        merchant: &Address,
+        flat_index: u64,
+        subscription_id: u64,
+    ) {
+        let page_num = flat_index / Self::ACTIVE_SUBSCRIPTION_PAGE_SIZE;
+        let page_offset = flat_index % Self::ACTIVE_SUBSCRIPTION_PAGE_SIZE;
+        let mut page: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptions(
+                merchant.clone(),
+                page_num,
+            )))
+            .unwrap_or_else(|| Vec::new(env));
+
+        let page_offset_u32 = page_offset as u32;
+        while page.len() <= page_offset_u32 {
+            page.push_back(0);
+        }
+        page.set(page_offset_u32, subscription_id);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptions(
+                merchant.clone(),
+                page_num,
+            )),
+            &page,
+        );
+    }
+
+    fn active_subscription_at(env: &Env, merchant: &Address, flat_index: u64) -> Option<u64> {
+        let page_num = flat_index / Self::ACTIVE_SUBSCRIPTION_PAGE_SIZE;
+        let page_offset = flat_index % Self::ACTIVE_SUBSCRIPTION_PAGE_SIZE;
+        let page: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptions(
+                merchant.clone(),
+                page_num,
+            )))?;
+        let page_offset_u32 = page_offset as u32;
+        if page_offset_u32 < page.len() {
+            Some(page.get(page_offset_u32).unwrap())
+        } else {
+            None
+        }
+    }
+
+    fn remove_active_subscription_page_entry(env: &Env, merchant: &Address, flat_index: u64) {
+        let page_num = flat_index / Self::ACTIVE_SUBSCRIPTION_PAGE_SIZE;
+        let page_offset = flat_index % Self::ACTIVE_SUBSCRIPTION_PAGE_SIZE;
+        let page_offset_u32 = page_offset as u32;
+        let mut page: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptions(
+                merchant.clone(),
+                page_num,
+            )))
+            .unwrap_or_else(|| Vec::new(env));
+
+        if page_offset_u32 < page.len() {
+            let mut rebuilt = Vec::new(env);
+            for i in 0..page.len() {
+                if i != page_offset_u32 {
+                    rebuilt.push_back(page.get(i).unwrap());
+                }
+            }
+            if rebuilt.is_empty() {
+                env.storage().instance().remove(&DataKey::Merchant(
+                    MerchantDataKey::MerchantActiveSubscriptions(merchant.clone(), page_num),
+                ));
+            } else {
+                env.storage().instance().set(
+                    &DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptions(
+                        merchant.clone(),
+                        page_num,
+                    )),
+                    &rebuilt,
+                );
+            }
+        }
+    }
+
+    fn add_to_merchant_active_subscriptions(env: &Env, merchant: &Address, subscription_id: u64) {
+        let count = Self::merchant_active_subscription_count(env, merchant);
+        Self::set_active_subscription_at(env, merchant, count, subscription_id);
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::ActiveSubscriptionIndex(subscription_id)),
+            &count,
+        );
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptionCount(
+                merchant.clone(),
+            )),
+            &(count + 1),
+        );
+    }
+
+    fn remove_from_merchant_active_subscriptions(
+        env: &Env,
+        merchant: &Address,
+        subscription_id: u64,
+    ) {
+        let count = Self::merchant_active_subscription_count(env, merchant);
+        if count == 0 {
+            return;
+        }
+
+        let index: u64 = match env.storage().instance().get(&DataKey::Merchant(
+            MerchantDataKey::ActiveSubscriptionIndex(subscription_id),
+        )) {
+            Some(i) => i,
+            None => return,
+        };
+        let last_index = count - 1;
+
+        if index != last_index {
+            if let Some(last_id) = Self::active_subscription_at(env, merchant, last_index) {
+                Self::set_active_subscription_at(env, merchant, index, last_id);
+                env.storage().instance().set(
+                    &DataKey::Merchant(MerchantDataKey::ActiveSubscriptionIndex(last_id)),
+                    &index,
+                );
+            }
+        }
+
+        Self::remove_active_subscription_page_entry(env, merchant, last_index);
+        env.storage().instance().remove(&DataKey::Merchant(
+            MerchantDataKey::ActiveSubscriptionIndex(subscription_id),
+        ));
+        env.storage().instance().set(
+            &DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptionCount(
+                merchant.clone(),
+            )),
+            &last_index,
+        );
+    }
+
+    /// Returns active subscription IDs for a merchant (100 per page).
+    pub fn get_merchant_subscriptions(env: Env, merchant: Address, page: u64) -> Vec<u64> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Merchant(MerchantDataKey::MerchantActiveSubscriptions(
+                merchant, page,
+            )))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
     fn is_valid_currency(currency: &Currency) -> bool {
         matches!(
             currency,
@@ -4638,6 +4881,8 @@ impl PaymentContract {
             &DataKey::Merchant(MerchantDataKey::SubscriptionCount(merchant.clone())),
             &(m_count + 1),
         );
+
+        Self::add_to_merchant_active_subscriptions(&env, &merchant, sub_id);
 
         (SubscriptionCreated {
             subscription_id: sub_id,
@@ -5197,6 +5442,8 @@ impl PaymentContract {
             &DataKey::Subscription(SubscriptionKey::Data(subscription_id)),
             &sub,
         );
+
+        Self::remove_from_merchant_active_subscriptions(&env, &sub.merchant, subscription_id);
 
         // Emit TrialCancelled if cancelled during trial
         let now = env.ledger().timestamp();

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -69,6 +69,7 @@ pub enum DataKey {
     CustomerTier(Address),
     CustomerTierPolicy(Address, u32),
     StrictTierPolicy(Address),
+    AppealWindowSeconds,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -169,6 +170,7 @@ pub enum RefundStatus {
     Approved,
     Rejected,
     Processed,
+    PendingAppeal,
 }
 
 // Issue #397: canonical reason codes, enforced by the type system on Refund and
@@ -604,6 +606,8 @@ pub struct Refund {
     pub approved_at: Option<u64>,
     pub rejected_at: Option<u64>,
     pub processed_at: Option<u64>,
+    pub rejected_by: Option<Address>,
+    pub appeal_deadline: Option<u64>,
     // Issue #199: TTL expiry
     pub expires_at: Option<u64>,
 }
@@ -1223,6 +1227,9 @@ impl RefundContract {
         Self::set_inherit_from_parent_inner(&env, &admin, false);
         Self::set_requires_admin_approval_inner(&env, &admin, true);
         Self::set_auto_approve_below_inner(&env, &admin, 0);
+        env.storage()
+            .instance()
+            .set(&DataKey::AppealWindowSeconds, &604800u64);
     }
 
     pub fn request_refund(
@@ -1296,46 +1303,99 @@ impl RefundContract {
         // Require admin authentication
         admin.require_auth();
 
-        // Retrieve refund from storage
+        Self::begin_refund_rejection(&env, admin, refund_id, rejection_reason)
+    }
+
+    pub fn finalize_denial(env: Env, refund_id: u64) -> Result<(), Error> {
         let mut refund: Refund = env
             .storage()
             .instance()
             .get(&DataKey::Refund(refund_id))
             .ok_or(Error::RefundNotFound)?;
 
-        // Check refund status is Requested
-        if refund.status != RefundStatus::Requested {
+        if refund.status != RefundStatus::PendingAppeal {
+            return Err(Error::RefundNotRejected);
+        }
+
+        let appeal_deadline = refund
+            .appeal_deadline
+            .ok_or(Error::RefundNotRejected)?;
+        let now = env.ledger().timestamp();
+        if now < appeal_deadline {
             return Err(Error::InvalidStatus);
         }
 
-        Self::remove_from_status_index(&env, RefundStatus::Requested, refund_id)?;
+        Self::remove_from_status_index(&env, RefundStatus::PendingAppeal, refund_id)?;
 
-        // Update refund status to Rejected
         refund.status = RefundStatus::Rejected;
-        // Issue #147: Set rejected_at timestamp
-        refund.rejected_at = Some(env.ledger().timestamp());
-
-        // Store updated refund back to storage
+        refund.rejected_at = Some(now);
         env.storage()
             .instance()
             .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(&env, RefundStatus::Rejected, refund_id);
-        env.storage().instance().set(
-            &SystemKey::RefundRejectedAt(refund_id),
-            &env.ledger().timestamp(),
-        );
+        env.storage()
+            .instance()
+            .set(&SystemKey::RefundRejectedAt(refund_id), &now);
 
-        // Emit RefundRejected event
+        let rejected_by = refund
+            .rejected_by
+            .clone()
+            .unwrap_or(env.current_contract_address());
+
         (RefundRejected {
             refund_id,
-            rejected_by: admin,
-            rejected_at: env.ledger().timestamp(),
-            rejection_reason,
+            rejected_by,
+            rejected_at: now,
+            rejection_reason: soroban_sdk::String::from_str(&env, "appeal window expired"),
         })
         .publish(&env);
 
-        // Issue #144: Invoke notification hooks
         Self::invoke_hooks(&env, RefundEventType::Rejected, refund_id);
+
+        Ok(())
+    }
+
+    fn begin_refund_rejection(
+        env: &Env,
+        admin: Address,
+        refund_id: u64,
+        rejection_reason: String,
+    ) -> Result<(), Error> {
+        let mut refund: Refund = env
+            .storage()
+            .instance()
+            .get(&DataKey::Refund(refund_id))
+            .ok_or(Error::RefundNotFound)?;
+
+        if refund.status != RefundStatus::Requested {
+            return Err(Error::InvalidStatus);
+        }
+
+        Self::remove_from_status_index(env, RefundStatus::Requested, refund_id)?;
+
+        let appeal_window: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AppealWindowSeconds)
+            .unwrap_or(604800);
+        let now = env.ledger().timestamp();
+
+        refund.status = RefundStatus::PendingAppeal;
+        refund.rejected_by = Some(admin.clone());
+        refund.appeal_deadline = Some(now.saturating_add(appeal_window));
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Refund(refund_id), &refund);
+        Self::add_to_status_index(env, RefundStatus::PendingAppeal, refund_id);
+
+        (RefundRejected {
+            refund_id,
+            rejected_by: admin,
+            rejected_at: now,
+            rejection_reason,
+        })
+        .publish(env);
 
         Ok(())
     }
@@ -1357,7 +1417,9 @@ impl RefundContract {
         if refund.customer != customer {
             return Err(Error::Unauthorized);
         }
-        if refund.status != RefundStatus::Rejected {
+        if refund.status != RefundStatus::Rejected
+            && refund.status != RefundStatus::PendingAppeal
+        {
             return Err(Error::RefundNotRejected);
         }
         if env
@@ -1368,14 +1430,28 @@ impl RefundContract {
             return Err(Error::AppealAlreadyFiled);
         }
 
-        let rejected_at: u64 = env
-            .storage()
-            .instance()
-            .get(&SystemKey::RefundRejectedAt(refund_id))
-            .ok_or(Error::RefundNotRejected)?;
         let now = env.ledger().timestamp();
-        if now > rejected_at.saturating_add(72 * 60 * 60) {
-            return Err(Error::AppealWindowExpired);
+        if refund.status == RefundStatus::PendingAppeal {
+            let appeal_deadline = refund
+                .appeal_deadline
+                .ok_or(Error::RefundNotRejected)?;
+            if now > appeal_deadline {
+                return Err(Error::AppealWindowExpired);
+            }
+        } else {
+            let rejected_at: u64 = env
+                .storage()
+                .instance()
+                .get(&SystemKey::RefundRejectedAt(refund_id))
+                .ok_or(Error::RefundNotRejected)?;
+            let appeal_window: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AppealWindowSeconds)
+                .unwrap_or(604800);
+            if now > rejected_at.saturating_add(appeal_window) {
+                return Err(Error::AppealWindowExpired);
+            }
         }
 
         let counter: u64 = env
@@ -1459,11 +1535,14 @@ impl RefundContract {
                 .instance()
                 .get(&DataKey::Refund(appeal.refund_id))
                 .ok_or(Error::RefundNotFound)?;
-            if refund.status != RefundStatus::Rejected {
+            if refund.status != RefundStatus::Rejected
+                && refund.status != RefundStatus::PendingAppeal
+            {
                 return Err(Error::RefundNotRejected);
             }
 
-            Self::remove_from_status_index(&env, RefundStatus::Rejected, refund.id)?;
+            let prior_status = refund.status.clone();
+            Self::remove_from_status_index(&env, prior_status, refund.id)?;
             refund.status = RefundStatus::Approved;
             env.storage()
                 .instance()
@@ -1818,6 +1897,63 @@ impl RefundContract {
             &ArbitrationKey::ArbitratorReputation(arbitrator),
             &reputation,
         );
+
+        Ok(())
+    }
+
+    pub fn assign_arbitrator(
+        env: Env,
+        admin: Address,
+        case_id: u64,
+        arbitrator: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut case: ArbitrationCase = env
+            .storage()
+            .instance()
+            .get(&ArbitrationKey::ArbitrationCase(case_id))
+            .ok_or(Error::RefundNotFound)?;
+        if case.status != ArbitrationStatus::Open {
+            return Err(Error::InvalidStatus);
+        }
+
+        let refund: Refund = env
+            .storage()
+            .instance()
+            .get(&DataKey::Refund(case.refund_id))
+            .ok_or(Error::RefundNotFound)?;
+
+        if let Some(denied_by) = refund.rejected_by.clone() {
+            if arbitrator == denied_by {
+                // denied_by cannot arbitrate their own denial decision
+                return Err(Error::Unauthorized);
+            }
+        }
+
+        let arbitrators: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&ArbitrationKey::ArbitratorList)
+            .unwrap_or(Vec::new(&env));
+        if !arbitrators.contains(&arbitrator) {
+            return Err(Error::NotArbitrator);
+        }
+
+        if !case.arbitrators.contains(&arbitrator) {
+            case.arbitrators.push_back(arbitrator);
+            env.storage()
+                .instance()
+                .set(&ArbitrationKey::ArbitrationCase(case_id), &case);
+        }
 
         Ok(())
     }
@@ -3036,6 +3172,10 @@ impl RefundContract {
                             pending_count += 1;
                             pending_amount += refund.amount;
                         }
+                        RefundStatus::PendingAppeal => {
+                            pending_count += 1;
+                            pending_amount += refund.amount;
+                        }
                     }
                 }
             }
@@ -4242,6 +4382,8 @@ impl RefundContract {
             },
             rejected_at: None,
             processed_at: None,
+            rejected_by: None,
+            appeal_deadline: None,
             // Issue #199: TTL expiry
             expires_at: ttl_expires_at,
         };
@@ -5873,34 +6015,12 @@ impl RefundContract {
 
         for refund_id in refund_ids.iter() {
             let result = (|| -> Result<(), Error> {
-                let mut refund: Refund = env
-                    .storage()
-                    .instance()
-                    .get(&DataKey::Refund(refund_id))
-                    .ok_or(Error::RefundNotFound)?;
-                if refund.status != RefundStatus::Requested {
-                    return Err(Error::InvalidStatus);
-                }
-                Self::remove_from_status_index(&env, RefundStatus::Requested, refund_id)?;
-                refund.status = RefundStatus::Rejected;
-                refund.rejected_at = Some(env.ledger().timestamp());
-                env.storage()
-                    .instance()
-                    .set(&DataKey::Refund(refund_id), &refund);
-                Self::add_to_status_index(&env, RefundStatus::Rejected, refund_id);
-                env.storage().instance().set(
-                    &SystemKey::RefundRejectedAt(refund_id),
-                    &env.ledger().timestamp(),
-                );
-                (RefundRejected {
+                Self::begin_refund_rejection(
+                    &env,
+                    admin.clone(),
                     refund_id,
-                    rejected_by: admin.clone(),
-                    rejected_at: env.ledger().timestamp(),
-                    rejection_reason: soroban_sdk::String::from_str(&env, "batch rejection"),
-                })
-                .publish(&env);
-                Self::invoke_hooks(&env, RefundEventType::Rejected, refund_id);
-                Ok(())
+                    soroban_sdk::String::from_str(&env, "batch rejection"),
+                )
             })();
             match result {
                 Ok(()) => succeeded.push_back(refund_id),


### PR DESCRIPTION
closes #369 
closes #384
closes #387 
closes #395

## Summary

This PR closes four security and enhancement gaps across the payment and refund contracts:

### 1. Merchant active subscription index (payment)
**Problem:** There was no way to list active subscriptions for a merchant. Callers had to know subscription IDs upfront and call `get_subscription()` on each one — impractical for dashboards.

**Solution:**
- Added a paginated `MerchantActiveSubscriptions` index (100 IDs per page), maintained automatically on `create_subscription()` and `cancel_subscription()`
- Exposed `get_merchant_subscriptions(merchant, page)` for efficient dashboard queries

### 2. Arbitrator conflict-of-interest guard (refund)
**Problem:** The admin who denied a refund could also be assigned as arbitrator on the same case, creating a conflict of interest with no independent oversight.

**Solution:**
- Record `rejected_by` on the `Refund` when a denial is initiated
- Added `assign_arbitrator(admin, case_id, arbitrator)` which rejects the assignment when `arbitrator == rejected_by`

### 3. Payment token allowlist (payment)
**Problem:** `create_payment()` accepted any contract address as `token`, allowing malicious SEP-41-compatible contracts to run arbitrary logic during transfers.

**Solution:**
- Added admin-managed `AllowedTokens` storage (`add_allowed_token` / `remove_allowed_token`)
- `create_payment()` validates the token is in the allowlist before proceeding (`TokenNotAllowed` otherwise)

### 4. Refund appeal window (refund)
**Problem:** A denied refund was immediately final with no on-chain recourse period, unlike industry standards (typically 7–14 days).

**Solution:**
- Added `AppealWindowSeconds` config (default `604800` = 7 days), set at `initialize()`
- Denials now transition to `PendingAppeal` with an `appeal_deadline` instead of immediately to `Rejected`
- Added `finalize_denial(refund_id)` — callable after the deadline to finalize the denial
- Updated `file_appeal()` and `resolve_appeal()` to work during the `PendingAppeal` window

## Files changed
- `contracts/payment/src/lib.rs`
- `contracts/refund/src/lib.rs`

## Test plan
- [ ] Create subscription → verify ID appears in `get_merchant_subscriptions(merchant, 0)`
- [ ] Cancel subscription → verify ID is removed from active index
- [ ] `create_payment()` with unlisted token → expect `TokenNotAllowed`
- [ ] Admin adds token → `create_payment()` succeeds
- [ ] `reject_refund()` → refund status is `PendingAppeal` with `appeal_deadline` set
- [ ] `finalize_denial()` before deadline → fails (`InvalidStatus`)
- [ ] Advance ledger past deadline → `finalize_denial()` → status becomes `Rejected`
- [ ] `assign_arbitrator()` with `arbitrator == rejected_by` → fails (`Unauthorized`)
- [ ] `assign_arbitrator()` with a different registered arbitrator → succeeds
- [ ] Customer files appeal during `PendingAppeal` window → succeeds
- [ ] Admin upholds appeal during `PendingAppeal` → refund approved and processed

## Notes
- Pre-existing compile issues in the repo (`payments` duplicate `FeatureError` discriminant `530`; `refund` `Error` enum `LengthExceedsMax`) were not addressed per scope — these changes are logically complete on top of the existing codebase.