### PR TITLE
Add observer guards, schema versioning, sub-account fee override, and clawback delay minimum

### DIFF
--- a/contracts/escrow/src/clawback_test.rs
+++ b/contracts/escrow/src/clawback_test.rs
@@ -44,7 +44,6 @@ fn test_initiate_clawback_success() {
 }
 
 #[test]
-#[should_panic]
 fn test_initiate_clawback_too_short_delay() {
     let env = Env::default();
     let contract_id = env.register(EscrowContract, ());
@@ -70,9 +69,13 @@ fn test_initiate_clawback_too_short_delay() {
     );
 
     let reason_hash = BytesN::from_array(&env, &[1_u8; 32]);
-    let delay = 86399_u64; // just under 24h
+    let delay = 0_u64;
 
-    client.initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+    let result = client.try_initiate_clawback(&admin, &escrow_id, &reason_hash, &delay);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Escrow(EscrowError::ClawbackDelayTooShort)))
+    );
 }
 
 #[test]

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -34,6 +34,7 @@ pub enum ConfigKey {
     InsuranceConfig,
     TimeLockConfig,
     AdminClawbackEscrow(u64),
+    SchemaVersion,
 }
 
 #[derive(Clone)]
@@ -129,6 +130,7 @@ pub enum BasicError {
     InvalidMerkleProof = 109,
     RootAlreadyCommitted = 110,
     InvalidBps = 111,
+    SchemaAlreadyAtTarget = 112,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -162,6 +164,7 @@ pub enum EscrowError {
     NewExpiryNotAfterCurrent = 224,
     RenewalPeriodTooShort = 225,
     RenewalPeriodTooLong = 226,
+    ClawbackDelayTooShort = 227,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -223,10 +226,10 @@ impl TryFrom<soroban_sdk::Error> for Error {
             if code >= 300 && code <= 314 {
                 return Ok(Error::Action(unsafe { core::mem::transmute(code) }));
             }
-            if code >= 200 && code <= 221 {
+            if code >= 200 && code <= 227 {
                 return Ok(Error::Escrow(unsafe { core::mem::transmute(code) }));
             }
-            if code >= 100 && code <= 111 {
+            if code >= 100 && code <= 112 {
                 return Ok(Error::Basic(unsafe { core::mem::transmute(code) }));
             }
         }
@@ -914,6 +917,7 @@ pub struct EscrowSubAccount {
     pub amount: i128,
     pub released: bool,
     pub release_condition: Option<String>,
+    pub fee_bps_override: Option<i128>,
 }
 
 #[derive(Clone)]
@@ -1509,6 +1513,10 @@ fn sum_approved_weight(env: &Env, escrow_id: u64, participants: &Vec<Participant
     total
 }
 
+const INITIAL_SCHEMA_VERSION: u32 = 1;
+const MIGRATION_TARGET_SCHEMA_VERSION: u32 = 2;
+const MIN_CLAWBACK_DELAY: u64 = 86_400;
+
 #[contract]
 pub struct EscrowContract;
 
@@ -1531,7 +1539,18 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::Config(ConfigKey::AdminMultiSig), &config);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::SchemaVersion),
+            &INITIAL_SCHEMA_VERSION,
+        );
         AdminAdded { admin }.publish(&env);
+    }
+
+    pub fn get_schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::SchemaVersion))
+            .unwrap_or(INITIAL_SCHEMA_VERSION)
     }
 
     pub fn set_escrow_fee_config(
@@ -2028,8 +2047,8 @@ impl EscrowContract {
             return Err(Error::Basic(BasicError::NotAnAdmin));
         }
 
-        if delay_seconds < 86400 {
-            panic!("delay_seconds must be at least 86400");
+        if delay_seconds < MIN_CLAWBACK_DELAY {
+            return Err(Error::Escrow(EscrowError::ClawbackDelayTooShort));
         }
 
         if !env
@@ -2893,17 +2912,16 @@ impl EscrowContract {
     ) -> Result<(), Error> {
         admin.require_auth();
 
+        let config = Self::get_multisig_config(env.clone());
+        if !config.admins.contains(&admin) {
+            return Err(Error::Basic(BasicError::NotAnAdmin));
+        }
+
         // Check if this is being called from execute_queued_action
 
-        if let Some(config) = env
-            .storage()
-            .instance()
-            .get::<DataKey, MultiSigConfig>(&DataKey::Config(ConfigKey::AdminMultiSig))
-        {
-            if config.admins.contains(&admin) && early_release {
-                // Admin force release requires time-lock
-                return Err(Error::Basic(BasicError::Unauthorized));
-            }
+        if config.admins.contains(&admin) && early_release {
+            // Admin force release requires time-lock
+            return Err(Error::Basic(BasicError::Unauthorized));
         }
 
         Self::internal_release_escrow(env, admin, escrow_id, early_release, None)
@@ -6606,6 +6624,10 @@ impl EscrowContract {
             return Err(Error::Basic(BasicError::NotAnAdmin));
         }
 
+        if Self::get_schema_version(env.clone()) >= MIGRATION_TARGET_SCHEMA_VERSION {
+            return Err(Error::Basic(BasicError::SchemaAlreadyAtTarget));
+        }
+
         if let Some(status) = env
             .storage()
             .instance()
@@ -6776,6 +6798,10 @@ impl EscrowContract {
         env.storage().instance().set(
             &DataKey::Dispute(DisputeKey::EscrowMigrationStatus),
             &status,
+        );
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::SchemaVersion),
+            &MIGRATION_TARGET_SCHEMA_VERSION,
         );
 
         Ok(())
@@ -8627,12 +8653,17 @@ impl EscrowContract {
         EscrowHealth::Healthy
     }
 
+    fn effective_sub_account_fee_bps(sub: &EscrowSubAccount, parent_fee_bps: i128) -> i128 {
+        sub.fee_bps_override.unwrap_or(parent_fee_bps)
+    }
+
     pub fn create_sub_account(
         env: Env,
         merchant: Address,
         escrow_id: u64,
         label_hash: BytesN<32>,
         amount: i128,
+        fee_bps_override: Option<i128>,
     ) -> Result<u64, Error> {
         merchant.require_auth();
 
@@ -8668,6 +8699,7 @@ impl EscrowContract {
             amount,
             released: false,
             release_condition: None,
+            fee_bps_override,
         };
 
         env.storage().instance().set(
@@ -8680,6 +8712,39 @@ impl EscrowContract {
         );
 
         Ok(sub_id)
+    }
+
+    pub fn set_sub_account_fee_override(
+        env: Env,
+        merchant: Address,
+        escrow_id: u64,
+        sub_id: u64,
+        fee_bps_override: Option<i128>,
+    ) -> Result<(), Error> {
+        merchant.require_auth();
+
+        let escrow = EscrowContract::get_escrow(&env, escrow_id);
+        if merchant != escrow.merchant {
+            return Err(Error::Basic(BasicError::Unauthorized));
+        }
+
+        let mut sub: EscrowSubAccount = env
+            .storage()
+            .instance()
+            .get(&DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)))
+            .ok_or(Error::Escrow(EscrowError::SubAccountNotFound))?;
+
+        if sub.released {
+            return Err(Error::Escrow(EscrowError::SubAccountAlreadyReleased));
+        }
+
+        sub.fee_bps_override = fee_bps_override;
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::SubAccount(escrow_id, sub_id)),
+            &sub,
+        );
+
+        Ok(())
     }
 
     pub fn fund_sub_account(
@@ -8753,11 +8818,25 @@ impl EscrowContract {
             return Err(Error::Escrow(EscrowError::SubAccountAlreadyReleased));
         }
 
+        let fee_bps = Self::effective_sub_account_fee_bps(&sub, escrow.fee_bps);
+        let fee_amount = (sub.amount * fee_bps) / 10000;
+        let merchant_amount = sub.amount - fee_amount;
+
+        if fee_amount > 0 {
+            let fee_config = Self::get_escrow_fee_config(env.clone());
+            EscrowContract::transfer_if_token_contract(
+                &env,
+                &escrow.token,
+                &fee_config.fee_recipient,
+                fee_amount,
+            )?;
+        }
+
         EscrowContract::transfer_if_token_contract(
             &env,
             &escrow.token,
             &escrow.merchant,
-            sub.amount,
+            merchant_amount,
         )?;
 
         sub.released = true;
@@ -9145,7 +9224,8 @@ mod expiry_test;
 //
 #[cfg(test)]
 mod bulk_evidence_test;
-// mod migration_test;
+#[cfg(test)]
+mod migration_test;
 //
 // #[cfg(test)]
 // mod multi_party_rollback_test;

--- a/contracts/escrow/src/migration_test.rs
+++ b/contracts/escrow/src/migration_test.rs
@@ -3,7 +3,7 @@
 use crate::*;
 use soroban_sdk::testutils::Ledger;
 use crate::*;
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{testutils::Address as _, vec, Address, BytesN, Env};
 
 fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address) {
     env.mock_all_auths();
@@ -15,6 +15,129 @@ fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address, Address
     let merchant = Address::generate(env);
     let token = Address::generate(env);
     (client, admin, customer, merchant, token)
+}
+
+// ── SCHEMA VERSION ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_schema_version_initialized_to_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _customer, _merchant, _token) = setup(&env);
+
+    assert_eq!(client.get_schema_version(), 1);
+}
+
+#[test]
+fn test_schema_version_increments_after_migration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    client.begin_migration(&admin);
+    client.migrate_escrow(&admin, &1);
+    client.complete_migration(&admin);
+
+    assert_eq!(client.get_schema_version(), 2);
+}
+
+#[test]
+fn test_begin_migration_rejects_when_schema_already_at_target() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    client.create_escrow(&customer, &merchant, &500_i128, &token, &1000_u64, &0_u64, &0_u64, &false);
+    client.begin_migration(&admin);
+    client.migrate_escrow(&admin, &1);
+    client.complete_migration(&admin);
+
+    let result = client.try_begin_migration(&admin);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Basic(BasicError::SchemaAlreadyAtTarget)))
+    );
+}
+
+#[test]
+fn test_initiate_clawback_rejects_zero_delay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
+    );
+    let reason_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+    let result = client.try_initiate_clawback(&admin, &escrow_id, &reason_hash, &0_u64);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Escrow(EscrowError::ClawbackDelayTooShort)))
+    );
+}
+
+#[test]
+fn test_sub_account_fee_bps_override() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    client.set_escrow_fee_config(
+        &admin,
+        &EscrowFeeConfig {
+            fee_bps: 500,
+            fee_recipient: admin.clone(),
+            enabled: true,
+        },
+    );
+
+    let escrow_id = client.create_escrow(
+        &customer, &merchant, &1000_i128, &token, &1000_u64, &0_u64, &0_u64, &false,
+    );
+    let label = BytesN::from_array(&env, &[1u8; 32]);
+
+    let fee_free_id = client.create_sub_account(&merchant, &escrow_id, &label, &200, &Some(0));
+    let premium_id = client.create_sub_account(
+        &merchant,
+        &escrow_id,
+        &BytesN::from_array(&env, &[2u8; 32]),
+        &300,
+        &Some(1000),
+    );
+    let inherited_id = client.create_sub_account(
+        &merchant,
+        &escrow_id,
+        &BytesN::from_array(&env, &[3u8; 32]),
+        &100,
+        &None,
+    );
+
+    assert_eq!(
+        client.get_sub_account(&escrow_id, &fee_free_id).unwrap().fee_bps_override,
+        Some(0)
+    );
+    assert_eq!(
+        client.get_sub_account(&escrow_id, &premium_id).unwrap().fee_bps_override,
+        Some(1000)
+    );
+    assert!(
+        client
+            .get_sub_account(&escrow_id, &inherited_id)
+            .unwrap()
+            .fee_bps_override
+            .is_none()
+    );
+
+    client.set_sub_account_fee_override(&merchant, &escrow_id, &inherited_id, &Some(250));
+    assert_eq!(
+        client
+            .get_sub_account(&escrow_id, &inherited_id)
+            .unwrap()
+            .fee_bps_override,
+        Some(250)
+    );
 }
 
 // ── MIGRATION FLOW ────────────────────────────────────────────────────────────

--- a/contracts/escrow/src/observer_test.rs
+++ b/contracts/escrow/src/observer_test.rs
@@ -156,6 +156,47 @@ fn test_merchant_can_read_escrow_details() {
 
 // An active observer can read escrow details (no panic means access granted)
 #[test]
+fn observer_can_read_escrow_state() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let observer = Address::generate(&env);
+    let escrow_id = create_escrow(&client, &customer, &merchant, &token);
+
+    client.add_observer(&customer, &escrow_id, &observer, &3600_u64);
+
+    let escrow = client.get_escrow_details(&observer, &escrow_id);
+    assert_eq!(escrow.id, escrow_id);
+    assert_eq!(escrow.customer, customer);
+}
+
+#[test]
+fn observer_cannot_release_escrow() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let observer = Address::generate(&env);
+    let escrow_id = create_escrow(&client, &customer, &merchant, &token);
+
+    client.add_observer(&customer, &escrow_id, &observer, &3600_u64);
+
+    let result = client.try_release_escrow(&observer, &escrow_id, &false);
+    assert_eq!(result, Err(Ok(Error::Basic(BasicError::NotAnAdmin))));
+}
+
+#[test]
+fn observer_cannot_open_dispute() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let observer = Address::generate(&env);
+    let escrow_id = create_escrow(&client, &customer, &merchant, &token);
+
+    client.add_observer(&customer, &escrow_id, &observer, &3600_u64);
+
+    let result = client.try_dispute_escrow(&observer, &escrow_id);
+    assert_eq!(result, Err(Ok(Error::Basic(BasicError::Unauthorized))));
+}
+
+// An active observer can read escrow details (no panic means access granted)
+#[test]
 fn test_observer_can_read_escrow_details() {
     let env = Env::default();
     let (client, _admin, customer, _merchant, token) = setup(&env);

--- a/contracts/escrow/src/test_sub_account.rs
+++ b/contracts/escrow/src/test_sub_account.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, token, Address, BytesN, Env};
 
 fn setup(env: &Env) -> (EscrowContractClient<'_>, Address, Address, Address, Address) {
     let contract_id = env.register(EscrowContract, ());
@@ -21,7 +21,7 @@ fn make_escrow(
     token: &Address,
     amount: i128,
 ) -> u64 {
-    client.create_escrow(customer, merchant, &amount, token, &9999999_u64, &0_u64)
+    client.create_escrow(customer, merchant, &amount, token, &9999999_u64, &0_u64, &0_u64, &false)
 }
 
 fn label(env: &Env) -> BytesN<32> {
@@ -35,7 +35,7 @@ fn test_create_sub_account() {
 
     let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
 
-    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &400);
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &400, &None);
     assert_eq!(sub_id, 1);
 
     let sub = client.get_sub_account(&escrow_id, &sub_id).unwrap();
@@ -49,7 +49,7 @@ fn test_funding_sub_account() {
     let (client, _, customer, merchant, token) = setup(&env);
 
     let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
-    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &200);
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &200, &None);
 
     client.fund_sub_account(&merchant, &escrow_id, &sub_id, &300);
 
@@ -67,7 +67,7 @@ fn test_release_sub_account() {
     token_admin.mint(&customer, &1000);
 
     let escrow_id = make_escrow(&client, &customer, &merchant, &token_id, 1000);
-    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &500);
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &500, &None);
 
     client.release_sub_account(&admin, &escrow_id, &sub_id);
 
@@ -85,7 +85,7 @@ fn test_double_release_rejected() {
     token_admin.mint(&customer, &1000);
 
     let escrow_id = make_escrow(&client, &customer, &merchant, &token_id, 1000);
-    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &500);
+    let sub_id = client.create_sub_account(&merchant, &escrow_id, &label(&env), &500, &None);
 
     client.release_sub_account(&admin, &escrow_id, &sub_id);
 
@@ -101,7 +101,7 @@ fn test_funding_exceeds_escrow_rejected() {
     let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
 
     // Try to allocate more than the escrow holds
-    let result = client.try_create_sub_account(&merchant, &escrow_id, &label(&env), &1001);
+    let result = client.try_create_sub_account(&merchant, &escrow_id, &label(&env), &1001, &None);
     assert_eq!(result, Err(Ok(Error::Escrow(EscrowError::SubAccountFundingExceedsEscrow))));
 }
 
@@ -112,7 +112,7 @@ fn test_parent_guard_blocks_release_with_unreleased_sub_accounts() {
     env.ledger().set_timestamp(1000);
 
     let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
-    client.create_sub_account(&merchant, &escrow_id, &label(&env), &500);
+    client.create_sub_account(&merchant, &escrow_id, &label(&env), &500, &None);
 
     // Parent release should fail because sub-account is not yet released
     let result = client.try_release_escrow(&admin, &escrow_id, &true);
@@ -125,11 +125,87 @@ fn test_list_sub_accounts() {
     let (client, _, customer, merchant, token) = setup(&env);
 
     let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
-    client.create_sub_account(&merchant, &escrow_id, &label(&env), &200);
-    client.create_sub_account(&merchant, &escrow_id, &BytesN::from_array(&env, &[2u8; 32]), &300);
+    client.create_sub_account(&merchant, &escrow_id, &label(&env), &200, &None);
+    client.create_sub_account(
+        &merchant,
+        &escrow_id,
+        &BytesN::from_array(&env, &[2u8; 32]),
+        &300,
+        &None,
+    );
 
     let subs = client.list_sub_accounts(&escrow_id);
     assert_eq!(subs.len(), 2);
     assert_eq!(subs.get(0).unwrap().amount, 200);
     assert_eq!(subs.get(1).unwrap().amount, 300);
+}
+
+#[test]
+fn test_sub_account_fee_bps_override() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+
+    client.set_escrow_fee_config(
+        &admin,
+        &EscrowFeeConfig {
+            fee_bps: 500,
+            fee_recipient: admin.clone(),
+            enabled: true,
+        },
+    );
+
+    let escrow_id = make_escrow(&client, &customer, &merchant, &token, 1000);
+
+    let fee_free_id = client.create_sub_account(
+        &merchant,
+        &escrow_id,
+        &label(&env),
+        &200,
+        &Some(0),
+    );
+    let premium_id = client.create_sub_account(
+        &merchant,
+        &escrow_id,
+        &BytesN::from_array(&env, &[2u8; 32]),
+        &300,
+        &Some(1000),
+    );
+    let inherited_id = client.create_sub_account(
+        &merchant,
+        &escrow_id,
+        &BytesN::from_array(&env, &[3u8; 32]),
+        &100,
+        &None,
+    );
+
+    assert_eq!(
+        client
+            .get_sub_account(&escrow_id, &fee_free_id)
+            .unwrap()
+            .fee_bps_override,
+        Some(0)
+    );
+    assert_eq!(
+        client
+            .get_sub_account(&escrow_id, &premium_id)
+            .unwrap()
+            .fee_bps_override,
+        Some(1000)
+    );
+    assert!(
+        client
+            .get_sub_account(&escrow_id, &inherited_id)
+            .unwrap()
+            .fee_bps_override
+            .is_none()
+    );
+
+    client.set_sub_account_fee_override(&merchant, &escrow_id, &inherited_id, &Some(250));
+    assert_eq!(
+        client
+            .get_sub_account(&escrow_id, &inherited_id)
+            .unwrap()
+            .fee_bps_override,
+        Some(250)
+    );
 }

--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -43,6 +43,7 @@ pub enum ConfigKey {
     GlobalMerchantCount,
     PauseStateKey,
     MinSplitAmount,
+    SchemaVersion,
 }
 
 #[derive(Clone)]
@@ -140,6 +141,7 @@ pub enum BasicError {
     TierLimitsNotConfigured = 123,
     InvalidInterval = 124,
     InvalidBps = 125,
+    SchemaAlreadyAtTarget = 126,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1785,6 +1787,7 @@ const MAX_TRIAL_DURATION: u64 = 90 * SECONDS_PER_DAY; // 90 days max trial
 // Fee tier volume thresholds (raw token units)
 const PREMIUM_VOLUME_THRESHOLD: i128 = 10_000;
 const ENTERPRISE_VOLUME_THRESHOLD: i128 = 100_000;
+const INITIAL_SCHEMA_VERSION: u32 = 1;
 
 #[contractimpl]
 impl PaymentContract {
@@ -1809,7 +1812,41 @@ impl PaymentContract {
         env.storage()
             .instance()
             .set(&DataKey::Config(ConfigKey::Admin), &admin);
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::SchemaVersion),
+            &INITIAL_SCHEMA_VERSION,
+        );
         (AdminAdded { admin }).publish(&env);
+    }
+
+    pub fn get_schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::SchemaVersion))
+            .unwrap_or(INITIAL_SCHEMA_VERSION)
+    }
+
+    pub fn migrate_schema(env: Env, admin: Address, target_version: u32) -> Result<(), Error> {
+        admin.require_auth();
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config(ConfigKey::MultiSigConfig))
+            .ok_or(Error::Basic(BasicError::MultiSigNotInitialized))?;
+        if !config.admins.contains(&admin) {
+            return Err(Error::Basic(BasicError::NotAnAdmin));
+        }
+
+        let current = Self::get_schema_version(env.clone());
+        if current >= target_version {
+            return Err(Error::Basic(BasicError::SchemaAlreadyAtTarget));
+        }
+
+        env.storage().instance().set(
+            &DataKey::Config(ConfigKey::SchemaVersion),
+            &target_version,
+        );
+        Ok(())
     }
 
     pub fn set_merchant_verification_level(
@@ -10538,3 +10575,6 @@ mod test_payment_forward;
 
 #[cfg(test)]
 mod test_scheduled_payment;
+
+#[cfg(test)]
+mod schema_version_test;

--- a/contracts/payment/src/schema_version_test.rs
+++ b/contracts/payment/src/schema_version_test.rs
@@ -1,0 +1,35 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test_schema_version_initialized_to_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    assert_eq!(client.get_schema_version(), 1);
+}
+
+#[test]
+fn test_migrate_schema_rejects_already_at_target() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.migrate_schema(&admin, &2);
+    assert_eq!(client.get_schema_version(), 2);
+
+    let result = client.try_migrate_schema(&admin, &2);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Basic(BasicError::SchemaAlreadyAtTarget)))
+    );
+}

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -135,6 +135,7 @@ pub enum SystemKey {
     // Per-customer refund cooldown
     CustomerRefundCooldown(Address),
     RefundCooldownConfig,
+    SchemaVersion,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -245,6 +246,7 @@ pub enum Error {
     CaseAlreadyEscalated = 56,
     // Issue #370: Customer tier policy errors
     TierPolicyNotFound = 57,
+    SchemaAlreadyAtTarget = 58,
 }
 
 #[contractevent]
@@ -1194,12 +1196,17 @@ pub struct RefundContract;
 #[contractimpl]
 impl RefundContract {
     const BATCH_DECISION_LIMIT: u32 = 50;
+    const INITIAL_SCHEMA_VERSION: u32 = 1;
 
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Already initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(
+            &SystemKey::SchemaVersion,
+            &Self::INITIAL_SCHEMA_VERSION,
+        );
 
         // Set default refund policy (30 days, 100% refund)
         let mut default_tiers = Vec::new(&env);
@@ -1223,6 +1230,35 @@ impl RefundContract {
         Self::set_inherit_from_parent_inner(&env, &admin, false);
         Self::set_requires_admin_approval_inner(&env, &admin, true);
         Self::set_auto_approve_below_inner(&env, &admin, 0);
+    }
+
+    pub fn get_schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&SystemKey::SchemaVersion)
+            .unwrap_or(Self::INITIAL_SCHEMA_VERSION)
+    }
+
+    pub fn migrate_schema(env: Env, admin: Address, target_version: u32) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let current = Self::get_schema_version(env.clone());
+        if current >= target_version {
+            return Err(Error::SchemaAlreadyAtTarget);
+        }
+
+        env.storage()
+            .instance()
+            .set(&SystemKey::SchemaVersion, &target_version);
+        Ok(())
     }
 
     pub fn request_refund(
@@ -6905,3 +6941,6 @@ mod test_customer_tier_policy;
 
 #[cfg(test)]
 mod test_voucher_expiry;
+
+#[cfg(test)]
+mod schema_version_test;

--- a/contracts/refund/src/schema_version_test.rs
+++ b/contracts/refund/src/schema_version_test.rs
@@ -1,0 +1,32 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test_schema_version_initialized_to_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    assert_eq!(client.get_schema_version(), 1);
+}
+
+#[test]
+fn test_migrate_schema_rejects_already_at_target() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.migrate_schema(&admin, &2);
+    assert_eq!(client.get_schema_version(), 2);
+
+    let result = client.try_migrate_schema(&admin, &2);
+    assert_eq!(result, Err(Ok(Error::SchemaAlreadyAtTarget)));
+}


### PR DESCRIPTION
closes #362
closes #366 
closes #383 
closes #390

## Summary

This PR closes four escrow architecture/security/test gaps across the FacilPay contracts:

1. **Observer read-only enforcement (tests)** — Verifies that an active observer can read escrow state via `get_escrow_details()` but is rejected when calling `release_escrow()` (`NotAnAdmin`) or `dispute_escrow()` (`Unauthorized`). `release_escrow` now requires the caller to be a multisig admin.

2. **Contract storage schema versioning** — Adds `DataKey::SchemaVersion` (stored as `u32`, initialized to `1`) in escrow, payment, and refund contracts. Exposes `get_schema_version()`. Escrow migration is gated: `begin_migration` rejects when schema is already at the target version (`SchemaAlreadyAtTarget`); `complete_migration` bumps the version to `2`. Payment and refund expose `migrate_schema(admin, target_version)` with the same already-at-target guard.

3. **Sub-account fee override** — Adds `fee_bps_override: Option<i128>` to `EscrowSubAccount`. `create_sub_account` accepts an optional override; `set_sub_account_fee_override` allows updating it post-creation. On `release_sub_account`, the effective fee uses the override when set, otherwise inherits the parent escrow's `fee_bps`.

4. **Clawback minimum delay** — Enforces `MIN_CLAWBACK_DELAY = 86_400` (24 hours) in `initiate_clawback()`. Delays below this return `EscrowError::ClawbackDelayTooShort` instead of panicking.

## Changes by contract

### Escrow (`contracts/escrow/src/lib.rs`)
- `ConfigKey::SchemaVersion`, `BasicError::SchemaAlreadyAtTarget`, `EscrowError::ClawbackDelayTooShort`
- `get_schema_version()`, schema gating in migration flow
- `EscrowSubAccount.fee_bps_override`, `set_sub_account_fee_override()`, fee-aware `release_sub_account`
- Admin-only check on `release_escrow`
- Extended `Error::try_from` code ranges for new error codes

### Payment (`contracts/payment/src/lib.rs`)
- `ConfigKey::SchemaVersion`, `BasicError::SchemaAlreadyAtTarget`
- `get_schema_version()`, `migrate_schema()`

### Refund (`contracts/refund/src/lib.rs`)
- `SystemKey::SchemaVersion`, `Error::SchemaAlreadyAtTarget`
- `get_schema_version()`, `migrate_schema()`

## Tests added

| Test | File |
|------|------|
| `observer_can_read_escrow_state` | `observer_test.rs` |
| `observer_cannot_release_escrow` | `observer_test.rs` |
| `observer_cannot_open_dispute` | `observer_test.rs` |
| `test_schema_version_*`, `test_initiate_clawback_rejects_zero_delay`, `test_sub_account_fee_bps_override` | `migration_test.rs` |
| `test_schema_version_initialized_to_one`, `test_migrate_schema_rejects_already_at_target` | `payment/refund schema_version_test.rs` |

## Test plan

- [x] `cargo test --lib observer_` in escrow (15 passed)
- [x] `cargo test --lib migration_test` in escrow (16 passed)
- [x] `cargo check` in escrow (passes)
- [ ] Payment/refund schema tests — blocked by pre-existing compile errors in those crates (not introduced by this PR)

## Security / behavior notes

- Observers remain read-only; they cannot release funds or open disputes.
- Clawback can no longer be initiated with a zero or sub-24-hour delay, preventing same-ledger fund seizure.
- Sub-accounts can be fee-free (`override = 0`) or premium-rated without restructuring the escrow hierarchy.
- Schema version markers give future migrations an auditable baseline.