### PR TITLE
feat :  add Escalation timeout check,verify succession transfer rejec…

### DIFF
--- a/contracts/escrow/src/escalation_timeout_test.rs
+++ b/contracts/escrow/src/escalation_timeout_test.rs
@@ -117,3 +117,41 @@ fn test_check_escalation_timeout_false_before_escalation() {
     env.ledger().set_timestamp(999_999);
     assert!(!client.check_escalation_timeout(&escrow_id));
 }
+
+#[test]
+fn test_process_escalation_timeouts_uses_queue() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+    client.set_escalation_config(&admin, &300u64, &AutoResolveFavor::Customer);
+
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    env.ledger().set_timestamp(1500);
+    client.escalate_dispute(&customer, &escrow_id);
+    env.ledger().set_timestamp(1500 + 301);
+
+    let processed = client.process_escalation_timeouts(&10_u32);
+    assert_eq!(processed, 1);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Resolved);
+}
+
+#[test]
+fn test_process_escalation_timeouts_skips_future_deadlines() {
+    let env = Env::default();
+    let (client, admin, customer, merchant, token) = setup(&env);
+    client.set_escalation_config(&admin, &300u64, &AutoResolveFavor::Customer);
+
+    let escrow_id = make_disputed_escrow(&env, &client, &customer, &merchant, &token);
+
+    env.ledger().set_timestamp(2000);
+    client.escalate_dispute(&customer, &escrow_id);
+    env.ledger().set_timestamp(2200);
+
+    let processed = client.process_escalation_timeouts(&10_u32);
+    assert_eq!(processed, 0);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Disputed);
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -64,6 +64,7 @@ pub enum EscrowKey {
     SubAccount(u64, u64),
     SubAccountCounter(u64),
     EscrowHierarchy(u64),
+    ReleaseMultisig(u64),
 }
 
 #[derive(Clone)]
@@ -100,6 +101,9 @@ pub enum DisputeKey {
     EscrowSwapConfig(u64),
     Observer(u64, u64),
     ObserverCount(u64),
+    EscalationQueue(u64),
+    EscalationQueueIndex,
+    EscalationDeadline(u64),
 }
 
 #[derive(Clone)]
@@ -129,6 +133,8 @@ pub enum BasicError {
     InvalidMerkleProof = 109,
     RootAlreadyCommitted = 110,
     InvalidBps = 111,
+    InsufficientAdmins = 112,
+    InvalidAddress = 113,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -162,6 +168,8 @@ pub enum EscrowError {
     NewExpiryNotAfterCurrent = 224,
     RenewalPeriodTooShort = 225,
     RenewalPeriodTooLong = 226,
+    InvalidThreshold = 227,
+    SuccessionPlanExists = 228,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -223,10 +231,10 @@ impl TryFrom<soroban_sdk::Error> for Error {
             if code >= 300 && code <= 314 {
                 return Ok(Error::Action(unsafe { core::mem::transmute(code) }));
             }
-            if code >= 200 && code <= 221 {
+            if code >= 200 && code <= 228 {
                 return Ok(Error::Escrow(unsafe { core::mem::transmute(code) }));
             }
-            if code >= 100 && code <= 111 {
+            if code >= 100 && code <= 113 {
                 return Ok(Error::Basic(unsafe { core::mem::transmute(code) }));
             }
         }
@@ -1067,6 +1075,21 @@ pub struct MultiSigConfig {
 
 #[derive(Clone)]
 #[contracttype]
+pub struct MultisigConfiguration {
+    pub signers: Vec<Address>,
+    pub threshold: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct EscrowReleaseMultisig {
+    pub signers: Vec<Address>,
+    pub threshold: u32,
+    pub approvals: Vec<Address>,
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub struct SuccessionPlan {
     pub successor: Address,
     pub designated_by: Address,
@@ -1901,13 +1924,20 @@ impl EscrowContract {
             return Err(Error::Basic(BasicError::NotAnAdmin));
         }
 
+        if Self::is_zero_address(&env, &successor) {
+            return Err(Error::Basic(BasicError::InvalidAddress));
+        }
+        if successor == admin {
+            return Err(Error::Action(ActionError::SameBeneficiary));
+        }
+
         if let Some(existing) = env
             .storage()
             .instance()
             .get::<DataKey, SuccessionPlan>(&DataKey::Config(ConfigKey::AdminSuccessionPlan))
         {
             if !existing.activated {
-                return Err(Error::Escrow(EscrowError::InvalidStatus));
+                return Err(Error::Escrow(EscrowError::SuccessionPlanExists));
             }
         }
 
@@ -2203,6 +2233,34 @@ impl EscrowContract {
             min_hold_period,
             expiry_timestamp,
             auto_refund_on_expiry,
+            None,
+        )
+    }
+
+    pub fn create_escrow_with_multisig(
+        env: Env,
+        customer: Address,
+        merchant: Address,
+        amount: i128,
+        token: Address,
+        release_timestamp: u64,
+        min_hold_period: u64,
+        expiry_timestamp: u64,
+        auto_refund_on_expiry: bool,
+        multisig: MultisigConfiguration,
+    ) -> Result<u64, Error> {
+        customer.require_auth();
+        Self::internal_create_escrow(
+            env,
+            customer,
+            merchant,
+            amount,
+            token,
+            release_timestamp,
+            min_hold_period,
+            expiry_timestamp,
+            auto_refund_on_expiry,
+            Some(multisig),
         )
     }
 
@@ -2216,6 +2274,7 @@ impl EscrowContract {
         min_hold_period: u64,
         expiry_timestamp: u64,
         auto_refund_on_expiry: bool,
+        multisig: Option<MultisigConfiguration>,
     ) -> Result<u64, Error> {
         // Block new escrow creation during migration
         if let Some(status) = env
@@ -2240,6 +2299,12 @@ impl EscrowContract {
             && expiry_timestamp <= current_timestamp.saturating_add(min_hold_period)
         {
             return Err(Error::Escrow(EscrowError::EscrowAlreadyExpired));
+        }
+
+        if let Some(config) = &multisig {
+            if !config.signers.is_empty() {
+                Self::validate_release_multisig_threshold(config.threshold, &config.signers)?;
+            }
         }
 
         let counter: u64 = env
@@ -2293,6 +2358,20 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::Escrow(EscrowKey::Counter), &escrow_id);
+
+        if let Some(config) = multisig {
+            if !config.signers.is_empty() {
+                let release_multisig = EscrowReleaseMultisig {
+                    signers: config.signers,
+                    threshold: config.threshold,
+                    approvals: Vec::new(&env),
+                };
+                env.storage().instance().set(
+                    &DataKey::Escrow(EscrowKey::ReleaseMultisig(escrow_id)),
+                    &release_multisig,
+                );
+            }
+        }
 
         // Index by customer
         let customer_count: u64 = env
@@ -2711,7 +2790,7 @@ impl EscrowContract {
         }
 
         if let Err(_) = Self::validate_bps(threshold_bps) {
-            return Err(Error::Escrow(EscrowError::InvalidStatus));
+            return Err(Error::Escrow(EscrowError::InvalidThreshold));
         }
 
         let mut escrow: MultiPartyEscrow = env
@@ -2885,6 +2964,50 @@ impl EscrowContract {
             .expect("Escrow not found")
     }
 
+    pub fn approve_escrow_release(env: Env, signer: Address, escrow_id: u64) -> Result<(), Error> {
+        signer.require_auth();
+
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
+            return Err(Error::Escrow(EscrowError::NotFound));
+        }
+
+        let escrow = EscrowContract::get_escrow(&env, escrow_id);
+        if escrow.status != EscrowStatus::Locked {
+            return Err(Error::Escrow(EscrowError::InvalidStatus));
+        }
+
+        let mut release_multisig: EscrowReleaseMultisig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Escrow(EscrowKey::ReleaseMultisig(escrow_id)))
+            .ok_or(Error::Escrow(EscrowError::NotFound))?;
+
+        if !release_multisig.signers.contains(&signer) {
+            return Err(Error::Basic(BasicError::Unauthorized));
+        }
+        if release_multisig.approvals.contains(&signer) {
+            return Err(Error::Basic(BasicError::DuplicateApproval));
+        }
+
+        release_multisig.approvals.push_back(signer.clone());
+        env.storage().instance().set(
+            &DataKey::Escrow(EscrowKey::ReleaseMultisig(escrow_id)),
+            &release_multisig,
+        );
+
+        ParticipantApproved {
+            escrow_id,
+            approver: signer,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
     pub fn release_escrow(
         env: Env,
         admin: Address,
@@ -2892,6 +3015,10 @@ impl EscrowContract {
         early_release: bool,
     ) -> Result<(), Error> {
         admin.require_auth();
+
+        if EscrowContract::verify_observer_access(env.clone(), escrow_id, admin.clone()) {
+            return Err(Error::Basic(BasicError::Unauthorized));
+        }
 
         // Check if this is being called from execute_queued_action
 
@@ -2977,6 +3104,18 @@ impl EscrowContract {
         let current_time: u64 = env.ledger().timestamp();
 
         Self::can_release_escrow(env.clone(), escrow_id, early_release)?;
+
+        if let Some(release_multisig) = env
+            .storage()
+            .instance()
+            .get::<DataKey, EscrowReleaseMultisig>(&DataKey::Escrow(EscrowKey::ReleaseMultisig(
+                escrow_id,
+            )))
+        {
+            if (release_multisig.approvals.len() as u32) < release_multisig.threshold {
+                return Err(Error::Action(ActionError::ApprovalsThresholdNotMet));
+            }
+        }
 
         let mut escrow = EscrowContract::get_escrow(&env, escrow_id);
         if escrow.status == EscrowStatus::Locked {
@@ -3628,6 +3767,10 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::Escrow(EscrowKey::Data(escrow_id)), &escrow);
+
+        let deadline = now.saturating_add(escrow.escalation_timeout);
+        Self::enqueue_escalation(&env, escrow_id, deadline);
+
         DisputeEscalated {
             escrow_id,
             level: escrow.escalation_level,
@@ -3800,7 +3943,78 @@ impl EscrowContract {
         })
         .publish(&env);
 
+        Self::dequeue_escalation(&env, escrow_id);
+
         Ok(())
+    }
+
+    /// Processes expired escalation deadlines using the indexed queue rather than
+    /// scanning all escrows. Only buckets with deadline ≤ current ledger time are read.
+    pub fn process_escalation_timeouts(env: Env, limit: u32) -> u32 {
+        let now = env.ledger().timestamp();
+        let index: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Dispute(DisputeKey::EscalationQueueIndex))
+            .unwrap_or(Vec::new(&env));
+
+        let mut processed = 0u32;
+        let mut remaining_index = Vec::new(&env);
+        let mut i = 0u32;
+        let len = index.len();
+
+        while i < len {
+            let deadline = index.get(i).unwrap();
+            if deadline > now {
+                remaining_index.push_back(deadline);
+                i += 1;
+                while i < len {
+                    remaining_index.push_back(index.get(i).unwrap());
+                    i += 1;
+                }
+                break;
+            }
+
+            let ids: Vec<u64> = env
+                .storage()
+                .instance()
+                .get(&DataKey::Dispute(DisputeKey::EscalationQueue(deadline)))
+                .unwrap_or(Vec::new(&env));
+
+            let mut remaining_ids = Vec::new(&env);
+            let mut j = 0u32;
+            while j < ids.len() {
+                let escrow_id = ids.get(j).unwrap();
+                if processed >= limit {
+                    remaining_ids.push_back(escrow_id);
+                } else if Self::trigger_timeout_resolution(env.clone(), escrow_id).is_ok() {
+                    processed += 1;
+                } else {
+                    remaining_ids.push_back(escrow_id);
+                }
+                j += 1;
+            }
+
+            if !remaining_ids.is_empty() {
+                env.storage().instance().set(
+                    &DataKey::Dispute(DisputeKey::EscalationQueue(deadline)),
+                    &remaining_ids,
+                );
+                remaining_index.push_back(deadline);
+            } else {
+                env.storage()
+                    .instance()
+                    .remove(&DataKey::Dispute(DisputeKey::EscalationQueue(deadline)));
+            }
+            i += 1;
+        }
+
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscalationQueueIndex),
+            &remaining_index,
+        );
+
+        processed
     }
 
     pub fn resolve_dispute(
@@ -3857,6 +4071,8 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::Escrow(EscrowKey::Data(escrow_id)), &escrow);
+
+        Self::dequeue_escalation(&env, escrow_id);
 
         // Transfer main escrow funds
         let recipient = if release_to_merchant {
@@ -5973,7 +6189,7 @@ impl EscrowContract {
                     .get(&DataKey::Config(ConfigKey::AdminMultiSig))
                     .ok_or(Error::Basic(BasicError::MultiSigNotInitialized))?;
                 if required == 0 || required > config.total_admins {
-                    return Err(Error::Escrow(EscrowError::InvalidStatus));
+                    return Err(Error::Escrow(EscrowError::InvalidThreshold));
                 }
                 config.required_signatures = required;
                 env.storage()
@@ -5987,10 +6203,10 @@ impl EscrowContract {
                     .get(&DataKey::Config(ConfigKey::AdminMultiSig))
                     .ok_or(Error::Basic(BasicError::MultiSigNotInitialized))?;
                 if new_threshold == 0 {
-                    return Err(Error::Escrow(EscrowError::InvalidStatus));
+                    return Err(Error::Escrow(EscrowError::InvalidThreshold));
                 }
                 if new_threshold > config.total_admins {
-                    return Err(Error::Escrow(EscrowError::InvalidStatus));
+                    return Err(Error::Basic(BasicError::InsufficientAdmins));
                 }
                 config.required_signatures = new_threshold;
                 env.storage()
@@ -8963,6 +9179,7 @@ impl EscrowContract {
             parent_escrow.min_hold_period,
             parent_escrow.expiry_timestamp,
             parent_escrow.auto_refund_on_expiry,
+            None,
         )?;
 
         // Update parent children list
@@ -9078,6 +9295,141 @@ impl EscrowContract {
         }
     }
 
+    fn is_zero_address(env: &Env, address: &Address) -> bool {
+        let xdr = address.to_xdr(env);
+        if xdr.get(0).unwrap() == 0 && xdr.get(4).unwrap() == 0 {
+            for i in 0..32 {
+                if xdr.get(12 + (i as u32)).unwrap() != 0 {
+                    return false;
+                }
+            }
+            return true;
+        }
+        false
+    }
+
+    fn enqueue_escalation(env: &Env, escrow_id: u64, deadline: u64) {
+        Self::dequeue_escalation(env, escrow_id);
+
+        let mut ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Dispute(DisputeKey::EscalationQueue(deadline)))
+            .unwrap_or(Vec::new(env));
+        ids.push_back(escrow_id);
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscalationQueue(deadline)),
+            &ids,
+        );
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscalationDeadline(escrow_id)),
+            &deadline,
+        );
+        Self::insert_escalation_queue_index(env, deadline);
+    }
+
+    fn dequeue_escalation(env: &Env, escrow_id: u64) {
+        let deadline: Option<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Dispute(DisputeKey::EscalationDeadline(escrow_id)));
+        let Some(deadline) = deadline else {
+            return;
+        };
+
+        if let Some(ids) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Vec<u64>>(&DataKey::Dispute(DisputeKey::EscalationQueue(
+                deadline,
+            )))
+        {
+            let mut remaining = Vec::new(env);
+            for id in ids.iter() {
+                if id != escrow_id {
+                    remaining.push_back(id);
+                }
+            }
+            if remaining.is_empty() {
+                env.storage()
+                    .instance()
+                    .remove(&DataKey::Dispute(DisputeKey::EscalationQueue(deadline)));
+                Self::remove_escalation_queue_index(env, deadline);
+            } else {
+                env.storage().instance().set(
+                    &DataKey::Dispute(DisputeKey::EscalationQueue(deadline)),
+                    &remaining,
+                );
+            }
+        }
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::Dispute(DisputeKey::EscalationDeadline(escrow_id)));
+    }
+
+    fn insert_escalation_queue_index(env: &Env, deadline: u64) {
+        let mut index: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Dispute(DisputeKey::EscalationQueueIndex))
+            .unwrap_or(Vec::new(env));
+
+        for d in index.iter() {
+            if d == deadline {
+                return;
+            }
+        }
+
+        let mut inserted = false;
+        let mut new_index = Vec::new(env);
+        for d in index.iter() {
+            if !inserted && d > deadline {
+                new_index.push_back(deadline);
+                inserted = true;
+            }
+            new_index.push_back(d);
+        }
+        if !inserted {
+            new_index.push_back(deadline);
+        }
+
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscalationQueueIndex),
+            &new_index,
+        );
+    }
+
+    fn remove_escalation_queue_index(env: &Env, deadline: u64) {
+        let index: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Dispute(DisputeKey::EscalationQueueIndex))
+            .unwrap_or(Vec::new(env));
+
+        let mut new_index = Vec::new(env);
+        for d in index.iter() {
+            if d != deadline {
+                new_index.push_back(d);
+            }
+        }
+
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::EscalationQueueIndex),
+            &new_index,
+        );
+    }
+
+    fn validate_release_multisig_threshold(
+        threshold: u32,
+        signers: &Vec<Address>,
+    ) -> Result<(), Error> {
+        if threshold == 0 || threshold > signers.len() as u32 {
+            return Err(Error::Escrow(EscrowError::InvalidThreshold));
+        }
+        Ok(())
+    }
+
     fn validate_bps(bps: u32) -> Result<(), Error> {
         if bps < 1 || bps > 10000 {
             return Err(Error::Basic(BasicError::InvalidBps));
@@ -9141,6 +9493,7 @@ mod expiry_test;
 // mod multisig_threshold_test;
 //
 // #[cfg(test)]
+// #[cfg(test)]
 // mod escalation_timeout_test;
 //
 #[cfg(test)]
@@ -9155,6 +9508,12 @@ mod observer_test;
 //
 #[cfg(test)]
 mod hold_period_test;
+
+#[cfg(test)]
+mod succession_test;
+
+#[cfg(test)]
+mod escalation_timeout_test;
 //
 // mod health_check_test;
 //

--- a/contracts/escrow/src/observer_test.rs
+++ b/contracts/escrow/src/observer_test.rs
@@ -202,3 +202,58 @@ fn test_expired_observer_cannot_read_escrow_details() {
         Err(Ok(Error::Basic(BasicError::Unauthorized)))
     ));
 }
+
+#[test]
+fn observer_can_read_escrow_state() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let observer = Address::generate(&env);
+    let escrow_id = create_escrow(&client, &customer, &merchant, &token);
+
+    client.add_observer(&customer, &escrow_id, &observer, &3600_u64);
+
+    let escrow = client.get_escrow_details(&observer, &escrow_id);
+    assert_eq!(escrow.id, escrow_id);
+    assert_eq!(escrow.customer, customer);
+    assert_eq!(escrow.merchant, merchant);
+    assert_eq!(escrow.amount, 1000);
+}
+
+#[test]
+fn observer_cannot_release_escrow() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let observer = Address::generate(&env);
+    let escrow_id = create_escrow(&client, &customer, &merchant, &token);
+
+    client.add_observer(&customer, &escrow_id, &observer, &3600_u64);
+    env.ledger().set_timestamp(10_000);
+
+    let result = client.try_release_escrow(&observer, &escrow_id, &false);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Basic(BasicError::Unauthorized)))
+    );
+
+    let escrow = client.get_escrow_details(&observer, &escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Locked);
+}
+
+#[test]
+fn observer_cannot_open_dispute() {
+    let env = Env::default();
+    let (client, _admin, customer, merchant, token) = setup(&env);
+    let observer = Address::generate(&env);
+    let escrow_id = create_escrow(&client, &customer, &merchant, &token);
+
+    client.add_observer(&customer, &escrow_id, &observer, &3600_u64);
+
+    let result = client.try_dispute_escrow(&observer, &escrow_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Basic(BasicError::Unauthorized)))
+    );
+
+    let escrow = client.get_escrow_details(&observer, &escrow_id);
+    assert_eq!(escrow.status, EscrowStatus::Locked);
+}

--- a/contracts/escrow/src/succession_test.rs
+++ b/contracts/escrow/src/succession_test.rs
@@ -1,7 +1,29 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+fn setup() -> (Env, EscrowContractClient<'static>, Address) {
+    let env = Env::default();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    (env, client, admin)
+}
+
+fn zero_address(env: &Env) -> Address {
+    Address::from_string(
+        env,
+        &String::from_str(
+            env,
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        ),
+    )
+}
 
 fn setup() -> (Env, EscrowContractClient<'static>, Address) {
     let env = Env::default();
@@ -91,5 +113,58 @@ fn test_only_one_pending_succession_plan_allowed() {
     client.designate_successor(&admin, &first_successor, &60_u64);
 
     let result = client.try_designate_successor(&admin, &second_successor, &120_u64);
-    assert_eq!(result, Err(Ok(Error::SuccessionPlanExists)));
+    assert_eq!(
+        result,
+        Err(Ok(Error::Escrow(EscrowError::SuccessionPlanExists)))
+    );
+}
+
+#[test]
+fn succession_to_zero_address_is_rejected() {
+    let (env, client, admin) = setup();
+    let zero = zero_address(&env);
+
+    env.ledger().set_timestamp(12_000);
+    let result = client.try_designate_successor(&admin, &zero, &60_u64);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Basic(BasicError::InvalidAddress)))
+    );
+    assert!(client.get_succession_plan().is_none());
+}
+
+#[test]
+fn succession_to_self_is_rejected() {
+    let (env, client, admin) = setup();
+
+    env.ledger().set_timestamp(14_000);
+    let result = client.try_designate_successor(&admin, &admin, &60_u64);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Action(ActionError::SameBeneficiary)))
+    );
+    assert!(client.get_succession_plan().is_none());
+}
+
+#[test]
+fn valid_succession_transfer_completes() {
+    let (env, client, admin) = setup();
+    let successor = Address::generate(&env);
+
+    env.ledger().set_timestamp(16_000);
+    client.designate_successor(&admin, &successor, &120_u64);
+
+    let plan = client.get_succession_plan().unwrap();
+    assert_eq!(plan.successor, successor);
+    assert!(!plan.activated);
+
+    env.ledger().set_timestamp(16_120);
+    client.activate_succession(&successor);
+
+    let config = client.get_multisig_config();
+    assert!(config.admins.contains(&successor));
+    assert_eq!(config.total_admins, 2);
+
+    let plan = client.get_succession_plan().unwrap();
+    assert!(plan.activated);
 }


### PR DESCRIPTION
closes #361
closes #357 
closes #362
closes #364


###Summary
-Hardens escrow contract safety and performance across multisig, succession, observer access, and escalation timeout handling.

-Release multisig validation — Added create_escrow_with_multisig() with MultisigConfiguration { signers, threshold }. Rejects threshold == 0 or threshold > signers.len() with EscrowError::InvalidThreshold. Release requires signer approvals via approve_escrow_release() before funds move. Admin multisig threshold updates now return InvalidThreshold / InsufficientAdmins instead of generic status errors.

-Succession guards — designate_successor() rejects zero addresses (BasicError::InvalidAddress) and self-designation (ActionError::SameBeneficiary). Duplicate pending plans return EscrowError::SuccessionPlanExists.

-Observer read-only enforcement — Active observers can read escrow state via get_escrow_details() but are blocked from release_escrow() with Unauthorized. Dispute opening remains customer/merchant-only (observers already rejected).

-Escalation timeout queue — Replaced implicit O(n) dispute scanning with an indexed queue: EscalationQueue(deadline) → Vec<escrow_id> plus a sorted deadline index. escalate_dispute() enqueues; process_escalation_timeouts(limit) only processes buckets with deadline ≤ current ledger time.
