### PR TITLE
Add rustdoc comments to all public functions in payment contract

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -258,6 +258,11 @@ pub enum Error {
 }
 
 impl Error {
+    /// Converts this error variant to its raw `u32` discriminant for Soroban's
+    /// `InvokeError` compatibility.
+    ///
+    /// # Returns
+    /// The `u32` discriminant corresponding to this error variant.
     pub fn to_u32(&self) -> u32 {
         match self {
             Error::Basic(e) => *e as u32,
@@ -1796,6 +1801,13 @@ const INITIAL_SCHEMA_VERSION: u32 = 1;
 
 #[contractimpl]
 impl PaymentContract {
+    /// Initializes the payment contract with a single admin and default multisig config.
+    ///
+    /// # Arguments
+    /// * `admin` - The initial admin address
+    ///
+    /// # Panics
+    /// Panics if the contract has already been initialized.
     pub fn initialize(env: Env, admin: Address) {
         if env
             .storage()
@@ -1824,6 +1836,10 @@ impl PaymentContract {
         (AdminAdded { admin }).publish(&env);
     }
 
+    /// Returns the current schema version of the contract storage.
+    ///
+    /// # Returns
+    /// The current schema version as a `u32`.
     pub fn get_schema_version(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -1831,6 +1847,15 @@ impl PaymentContract {
             .unwrap_or(INITIAL_SCHEMA_VERSION)
     }
 
+    /// Migrates the contract storage schema to a target version.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing the migration (must be in the multisig admin list)
+    /// * `target_version` - The schema version to migrate to
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the caller is not an admin, the target version
+    /// is not greater than the current version, or multisig is not initialized.
     pub fn migrate_schema(env: Env, admin: Address, target_version: u32) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -1854,6 +1879,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Sets the verification level for a specific merchant.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this change (must be in the multisig admin list)
+    /// * `merchant` - The merchant whose verification level is being set
+    /// * `level` - The new verification level to assign
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the caller is not an admin or multisig is not initialized.
     pub fn set_merchant_verification_level(
         env: Env,
         admin: Address,
@@ -1878,6 +1912,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves the verification level for a given merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address to query
+    ///
+    /// # Returns
+    /// The merchant's verification level, defaulting to `Unverified` if not set.
     pub fn get_merchant_verification_level(
         env: Env,
         merchant: Address,
@@ -1890,6 +1931,14 @@ impl PaymentContract {
             .unwrap_or(MerchantVerificationLevel::Unverified)
     }
 
+    /// Configures the transaction limits for a specific verification tier.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this change (must be in the multisig admin list)
+    /// * `limits` - The tier limits to store, including the tier level and its associated limits
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the caller is not an admin or multisig is not initialized.
     pub fn set_verification_tier_limits(
         env: Env,
         admin: Address,
@@ -1913,6 +1962,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves the transaction limits configured for a given verification tier.
+    ///
+    /// # Arguments
+    /// * `level` - The verification tier level to query
+    ///
+    /// # Returns
+    /// `Some(VerificationTierLimits)` if configured for the tier, or `None` otherwise.
     pub fn get_tier_limits(
         env: Env,
         level: MerchantVerificationLevel,
@@ -1924,6 +1980,13 @@ impl PaymentContract {
             )))
     }
 
+    /// Returns the current multisig configuration.
+    ///
+    /// # Returns
+    /// The `MultiSigConfig` containing admin list, required signatures, and proposal TTL.
+    ///
+    /// # Panics
+    /// Panics if the multisig configuration has not been initialized.
     pub fn get_multisig_config(env: Env) -> MultiSigConfig {
         env.storage()
             .instance()
@@ -1931,6 +1994,17 @@ impl PaymentContract {
             .expect("MultiSig not initialized")
     }
 
+    /// Proposes a new admin action for multisig approval.
+    ///
+    /// # Arguments
+    /// * `proposer` - The admin proposing the action (must be in the multisig admin list)
+    /// * `action_type` - The type of action being proposed
+    /// * `target` - The target address for the action
+    /// * `data` - Arbitrary data payload for the action
+    ///
+    /// # Returns
+    /// `Ok(proposal_id)` on success, or an error if the proposer is not an admin
+    /// or multisig is not initialized.
     pub fn propose_action(
         env: Env,
         proposer: Address,
@@ -1995,6 +2069,16 @@ impl PaymentContract {
         Ok(proposal_id)
     }
 
+    /// Approves a pending admin proposal.
+    ///
+    /// # Arguments
+    /// * `approver` - The admin approving the proposal (must be in the multisig admin list)
+    /// * `proposal_id` - The ID of the proposal to approve
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the approver is not an admin, the proposal
+    /// is not found, has already been executed/rejected, is expired, or was already approved
+    /// by this admin.
     pub fn approve_action(env: Env, approver: Address, proposal_id: String) -> Result<(), Error> {
         approver.require_auth();
 
@@ -2046,6 +2130,14 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Executes a fully approved admin proposal.
+    ///
+    /// # Arguments
+    /// * `proposal_id` - The ID of the proposal to execute
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the proposal is not found, has already been
+    /// executed/rejected, is expired, or has not reached the required signature threshold.
     pub fn execute_action(env: Env, proposal_id: String) -> Result<(), Error> {
         let config: MultiSigConfig = env
             .storage()
@@ -2086,6 +2178,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Rejects a pending admin proposal, preventing its execution.
+    ///
+    /// # Arguments
+    /// * `rejecter` - The admin rejecting the proposal (must be in the multisig admin list)
+    /// * `proposal_id` - The ID of the proposal to reject
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the rejecter is not an admin, the proposal
+    /// is not found, or has already been executed/rejected.
     pub fn reject_action(env: Env, rejecter: Address, proposal_id: String) -> Result<(), Error> {
         rejecter.require_auth();
 
@@ -2126,6 +2227,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Adds a new admin to the multisig configuration.
+    ///
+    /// # Arguments
+    /// * `caller` - The existing admin adding the new admin (must be in the multisig admin list)
+    /// * `new_admin` - The address of the new admin to add
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the caller is not an admin or multisig is not initialized.
+    /// No-op if the address is already an admin.
     pub fn add_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), Error> {
         caller.require_auth();
 
@@ -2151,6 +2261,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Removes an admin from the multisig configuration.
+    ///
+    /// # Arguments
+    /// * `caller` - The existing admin performing the removal (must be in the multisig admin list)
+    /// * `admin` - The address of the admin to remove
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the caller is not an admin, the target is not
+    /// an admin, removing them would leave fewer admins than required signatures, or multisig
+    /// is not initialized.
     pub fn remove_admin(env: Env, caller: Address, admin: Address) -> Result<(), Error> {
         caller.require_auth();
 
@@ -2189,6 +2309,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Updates the required number of admin signatures for multisig proposals.
+    ///
+    /// # Arguments
+    /// * `caller` - The admin updating the requirement (must be in the multisig admin list)
+    /// * `required` - The new number of required signatures (must be > 0 and <= total admins)
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the caller is not an admin, the required count
+    /// is invalid, or multisig is not initialized.
     pub fn update_required_signatures(
         env: Env,
         caller: Address,
@@ -2218,6 +2347,21 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Creates a new payment from a customer to a merchant.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer making the payment (must authorize)
+    /// * `merchant` - The merchant receiving the payment
+    /// * `amount` - The payment amount in base token units
+    /// * `token` - The SPL token address for the payment
+    /// * `currency` - The fiat currency associated with the payment
+    /// * `expiration_duration` - Seconds until the payment expires (0 for no expiration)
+    /// * `metadata` - Arbitrary metadata string for the payment
+    ///
+    /// # Returns
+    /// `Ok(payment_id)` on success, or an error if the token is not allowed, currency is
+    /// invalid, metadata is too large, the customer is flagged, rate limits are exceeded,
+    /// or the contract is paused.
     pub fn create_payment(
         env: Env,
         customer: Address,
@@ -2242,6 +2386,18 @@ impl PaymentContract {
         )
     }
 
+    /// Schedules a future payment by escrowing tokens until the scheduled time.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer scheduling the payment (must authorize)
+    /// * `merchant` - The merchant who will receive the payment
+    /// * `token` - The SPL token address for the payment
+    /// * `amount` - The payment amount in base token units
+    /// * `scheduled_at` - The ledger timestamp at which the payment should be executed
+    ///
+    /// # Returns
+    /// `Ok(payment_id)` on success, or an error if the amount is non-positive, the scheduled
+    /// time is in the past, or the contract is paused.
     pub fn schedule_payment(
         env: Env,
         customer: Address,
@@ -2300,6 +2456,15 @@ impl PaymentContract {
         Ok(payment_id)
     }
 
+    /// Executes a previously scheduled payment once its scheduled time has passed.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the scheduled payment to execute
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payment is not found, has been cancelled,
+    /// was already executed, is not yet due, the customer is flagged, spend limits are
+    /// exceeded, or the contract is paused.
     pub fn execute_scheduled_payment(env: Env, payment_id: u64) -> Result<(), Error> {
         Self::require_not_paused(&env, "execute_scheduled_payment")?;
         let mut scheduled: ScheduledPayment = env
@@ -2334,6 +2499,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Cancels a scheduled payment and refunds the escrowed tokens to the customer.
+    ///
+    /// # Arguments
+    /// * `caller` - The customer who scheduled the payment, or an admin (must authorize)
+    /// * `payment_id` - The ID of the scheduled payment to cancel
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payment is not found, has already been
+    /// executed or cancelled, the caller is unauthorized, or the contract is paused.
     pub fn cancel_scheduled_payment(
         env: Env,
         caller: Address,
@@ -2374,6 +2548,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves the details of a scheduled payment.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the scheduled payment to retrieve
+    ///
+    /// # Returns
+    /// `Ok(ScheduledPayment)` on success, or `Error::Payment(NotFound)` if not found.
     pub fn get_scheduled_payment(env: Env, payment_id: u64) -> Result<ScheduledPayment, Error> {
         env.storage()
             .instance()
@@ -2412,6 +2593,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Configures a merchant's payout schedule for accumulating payments before settlement.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant configuring the payout schedule (must authorize)
+    /// * `frequency` - How often payouts should occur (Immediate, Daily, Weekly, Monthly)
+    /// * `token` - The SPL token address to accumulate for payouts
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
     pub fn set_payout_schedule(
         env: Env,
         merchant: Address,
@@ -2440,6 +2630,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves the payout schedule configuration for a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address to query
+    ///
+    /// # Returns
+    /// `Some(PayoutSchedule)` if configured, or `None` otherwise.
     pub fn get_payout_schedule(env: Env, merchant: Address) -> Option<PayoutSchedule> {
         env.storage()
             .instance()
@@ -2448,6 +2645,14 @@ impl PaymentContract {
             )))
     }
 
+    /// Triggers an accumulated payout for a merchant, transferring held funds.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant requesting the payout (must authorize)
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payout schedule is not found, the payout
+    /// period has not elapsed, or there is nothing to settle.
     pub fn trigger_scheduled_payout(env: Env, merchant: Address) -> Result<(), Error> {
         merchant.require_auth();
         let mut schedule: PayoutSchedule = env
@@ -2482,6 +2687,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the accumulated token balance for a merchant's payout schedule.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address to query
+    ///
+    /// # Returns
+    /// The accumulated balance in base token units, or 0 if no payout schedule exists.
     pub fn get_accumulated_balance(env: Env, merchant: Address) -> i128 {
         env.storage()
             .instance()
@@ -2827,6 +3039,16 @@ impl PaymentContract {
         Ok(payment_id)
     }
 
+    /// Retrieves a payment by its ID.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to retrieve
+    ///
+    /// # Returns
+    /// The `Payment` record.
+    ///
+    /// # Panics
+    /// Panics if the payment is not found.
     pub fn get_payment(env: &Env, payment_id: u64) -> Payment {
         env.storage()
             .instance()
@@ -2847,6 +3069,23 @@ impl PaymentContract {
         }
     }
 
+    /// Creates a payment backed by an escrow contract for dispute protection.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer making the payment
+    /// * `merchant` - The merchant receiving the payment
+    /// * `amount` - The payment amount in base token units
+    /// * `token` - The SPL token address for the payment
+    /// * `currency` - The fiat currency associated with the payment
+    /// * `escrow_contract` - The address of the escrow contract to hold funds
+    /// * `release_timestamp` - The timestamp when funds can be released from escrow
+    /// * `min_hold_period` - Minimum time funds must remain in escrow
+    /// * `metadata` - Arbitrary metadata string for the payment
+    /// * `auto_release_on_complete` - Whether to auto-release escrow when payment completes
+    ///
+    /// # Returns
+    /// `Ok((payment_id, escrow_id))` on success, or an error if the underlying payment
+    /// creation fails, the escrow contract invocation fails, or the token transfer fails.
     pub fn create_escrowed_payment(
         env: Env,
         customer: Address,
@@ -2908,6 +3147,15 @@ impl PaymentContract {
         Ok((payment_id, escrow_id))
     }
 
+    /// Completes an escrowed payment by releasing funds from the escrow contract.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing the completion (must be in the multisig admin list)
+    /// * `payment_id` - The ID of the escrowed payment to complete
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized, the payment is not
+    /// found, is not in Pending status, has an unresolved dispute, or the escrow release fails.
     pub fn complete_escrowed_payment(
         env: Env,
         admin: Address,
@@ -2966,6 +3214,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Cancels an escrowed payment and refunds the escrowed funds to the customer.
+    ///
+    /// # Arguments
+    /// * `caller` - The customer or merchant who authorized this payment (must authorize)
+    /// * `payment_id` - The ID of the escrowed payment to cancel
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payment is not found, is not in Pending
+    /// status, the caller is not the customer or merchant, has an unresolved dispute,
+    /// or the escrow refund fails.
     pub fn cancel_escrowed_payment(
         env: Env,
         caller: Address,
@@ -3011,6 +3269,17 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Raises a dispute on an escrowed payment, freezing the escrow funds.
+    ///
+    /// # Arguments
+    /// * `caller` - The customer or merchant raising the dispute (must authorize)
+    /// * `payment_id` - The ID of the escrowed payment to dispute
+    /// * `reason` - A text description of the dispute reason
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payment is not found, is not in Pending
+    /// status, the caller is not the customer or merchant, there is already an unresolved
+    /// dispute, or the escrow dispute invocation fails.
     pub fn dispute_escrowed_payment(
         env: Env,
         caller: Address,
@@ -3072,6 +3341,17 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Resolves an escrowed payment dispute by ruling in favor of the customer or merchant.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin resolving the dispute (must be in the multisig admin list)
+    /// * `payment_id` - The ID of the escrowed payment with the dispute
+    /// * `favor_customer` - If true, funds are returned to the customer; otherwise, released to merchant
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized, the payment is not
+    /// found, the dispute is already resolved, the payment is not in Pending status,
+    /// or the escrow resolution fails.
     pub fn resolve_escrowed_payment_dispute(
         env: Env,
         admin: Address,
@@ -3142,6 +3422,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves the escrowed payment bridge record for a given payment.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to look up
+    ///
+    /// # Returns
+    /// `Ok(EscrowedPayment)` on success, or an error if the escrow mapping is not found.
     pub fn get_escrowed_payment(env: Env, payment_id: u64) -> Result<EscrowedPayment, Error> {
         env.storage()
             .instance()
@@ -3149,6 +3436,13 @@ impl PaymentContract {
             .ok_or(Error::Feature(FeatureError::EscrowMappingNotFound))
     }
 
+    /// Retrieves the dispute record for an escrowed payment, if one exists.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to check for disputes
+    ///
+    /// # Returns
+    /// `Some(EscrowedPaymentDispute)` if a dispute record exists, or `None` otherwise.
     pub fn get_escrowed_payment_dispute(
         env: Env,
         payment_id: u64,
@@ -3178,6 +3472,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Updates the notes field on a payment.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant who owns the payment (must authorize)
+    /// * `payment_id` - The ID of the payment to update
+    /// * `notes` - The new notes text to set on the payment
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the notes are too large, the payment is not
+    /// found, or the caller is not the payment's merchant.
     pub fn update_payment_notes(
         env: Env,
         merchant: Address,
@@ -3218,6 +3522,14 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Checks whether a payment has expired based on its expiration timestamp.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to check
+    ///
+    /// # Returns
+    /// `true` if the payment exists, has a non-zero expiration, and the current time
+    /// exceeds the expiration; `false` otherwise.
     pub fn is_payment_expired(env: &Env, payment_id: u64) -> bool {
         if !env
             .storage()
@@ -3230,6 +3542,14 @@ impl PaymentContract {
         payment.expires_at > 0 && env.ledger().timestamp() > payment.expires_at
     }
 
+    /// Expires a payment that has passed its expiration time, refunding the customer.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to expire
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payment is not found, is not in Pending
+    /// status, has no expiration set, or has not yet expired.
     pub fn expire_payment(env: Env, payment_id: u64) -> Result<(), Error> {
         // Retrieve payment from storage
         if !env
@@ -3300,6 +3620,19 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Completes a pending payment, transferring funds from the customer to the merchant.
+    ///
+    /// If the payment exceeds the large payment threshold, a multisig proposal is
+    /// automatically created instead of completing immediately.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing the completion (must be in the multisig admin list)
+    /// * `payment_id` - The ID of the payment to complete
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized, the payment is not
+    /// found, is not in Pending status, is expired, or the multisig threshold is not met.
+    /// Returns `ProposalError::RequiresMultiSig` if a multisig proposal was auto-created.
     pub fn complete_payment(env: Env, admin: Address, payment_id: u64) -> Result<(), Error> {
         Self::require_not_paused(&env, "complete_payment")?;
         admin.require_auth();
@@ -3604,6 +3937,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Configures automatic payment forwarding for a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant setting up forwarding (must authorize)
+    /// * `forward_to` - The address to forward a portion of payments to
+    /// * `forward_bps` - The percentage to forward in basis points (1-10000)
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the forward_bps is invalid, a forwarding loop
+    /// is detected, or the contract is paused.
     pub fn set_payment_forward(
         env: Env,
         merchant: Address,
@@ -3660,6 +4003,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Removes the payment forwarding configuration for a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant removing forwarding (must authorize)
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if no forwarding config exists or the contract is paused.
     pub fn remove_payment_forward(env: Env, merchant: Address) -> Result<(), Error> {
         Self::require_not_paused(&env, "remove_payment_forward")?;
         merchant.require_auth();
@@ -3690,6 +4040,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves the payment forwarding configuration for a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address to query
+    ///
+    /// # Returns
+    /// `Ok(PaymentForwardConfig)` if configured, or an error if no config is found.
     pub fn get_forward_config(env: Env, merchant: Address) -> Result<PaymentForwardConfig, Error> {
         env.storage()
             .instance()
@@ -3699,6 +4056,16 @@ impl PaymentContract {
             .ok_or(Error::Feature(FeatureError::ForwardConfigNotFound))
     }
 
+    /// Configures the loyalty points program settings.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this change (must be in the multisig admin list)
+    /// * `config` - The loyalty configuration including points per unit, redemption rate,
+    ///   and expiry duration
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized, the config values
+    /// are invalid (zero points_per_unit or zero expiry_seconds), or the contract is paused.
     pub fn configure_loyalty(env: Env, admin: Address, config: LoyaltyConfig) -> Result<(), Error> {
         Self::require_not_paused(&env, "configure_loyalty")?;
         admin.require_auth();
@@ -3722,6 +4089,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the loyalty points balance for a customer.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address to query
+    ///
+    /// # Returns
+    /// `Some(CustomerLoyaltyBalance)` if the customer has a loyalty balance, or `None` otherwise.
     pub fn get_loyalty_balance(env: Env, customer: Address) -> Option<CustomerLoyaltyBalance> {
         env.storage()
             .instance()
@@ -3730,6 +4104,18 @@ impl PaymentContract {
             )))
     }
 
+    /// Redeems loyalty points as a discount on a specific payment.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer redeeming points (must authorize)
+    /// * `points` - The number of loyalty points to redeem
+    /// * `payment_id` - The payment to apply the discount to
+    ///
+    /// # Returns
+    /// `Ok(discount_amount)` on success, where `discount_amount` is the token amount
+    /// to deduct from the payment (capped at 50% of the payment amount), or an error
+    /// if loyalty is not configured, points are insufficient or expired, the payment is
+    /// not found, or the caller is not the payment's customer.
     pub fn redeem_points(
         env: Env,
         customer: Address,
@@ -3841,7 +4227,17 @@ impl PaymentContract {
         );
     }
 
-    // Partial payment functions (#112)
+    /// Pays an installment toward a pending payment.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer making the installment payment (must authorize)
+    /// * `payment_id` - The ID of the payment to pay toward
+    /// * `amount` - The installment amount in base token units
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the amount is non-positive, the payment is expired
+    /// or not in Pending status, the installment exceeds the outstanding balance, or the
+    /// contract is paused. Automatically finalizes the payment if fully paid.
     pub fn pay_installment(
         env: Env,
         customer: Address,
@@ -3944,6 +4340,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the full installment payment history for a given payment.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to retrieve installment history for
+    ///
+    /// # Returns
+    /// A `Vec<PartialPaymentRecord>` of all installments made toward the payment.
     pub fn get_installment_history(env: Env, payment_id: u64) -> Vec<PartialPaymentRecord> {
         let installment_counter: u32 = env
             .storage()
@@ -3968,6 +4371,14 @@ impl PaymentContract {
         history
     }
 
+    /// Returns the outstanding balance remaining on a payment.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to check
+    ///
+    /// # Returns
+    /// The remaining amount in base token units. Returns the full payment amount if no
+    /// partial payments have been made.
     pub fn get_outstanding_balance(env: Env, payment_id: u64) -> i128 {
         // First check if we have an outstanding balance stored
         if let Some(balance) =
@@ -4014,6 +4425,14 @@ impl PaymentContract {
         outstanding
     }
 
+    /// Finalizes a payment that has been fully paid through installments.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to finalize
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payment is not in Pending status or
+    /// the outstanding balance is not zero.
     pub fn finalize_installment_payment(env: Env, payment_id: u64) -> Result<(), Error> {
         let mut payment = PaymentContract::get_payment(&env, payment_id);
 
@@ -4068,6 +4487,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Refunds a pending payment in full, returning funds to the customer.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing the refund (must be in the multisig admin list)
+    /// * `payment_id` - The ID of the payment to refund
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized, the payment is not
+    /// found, is expired, is not in Pending status, or the contract is paused.
     pub fn refund_payment(env: Env, admin: Address, payment_id: u64) -> Result<(), Error> {
         Self::require_not_paused(&env, "refund_payment")?;
         admin.require_auth();
@@ -4196,6 +4624,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Refunds a partial amount of a pending or partially-refunded payment.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing the refund (must be in the multisig admin list)
+    /// * `payment_id` - The ID of the payment to partially refund
+    /// * `refund_amount` - The amount to refund in base token units
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized, the payment is not
+    /// found, is expired, is not in a refundable status, or the refund exceeds the payment amount.
     pub fn partial_refund(
         env: Env,
         admin: Address,
@@ -4259,6 +4697,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Cancels a pending payment.
+    ///
+    /// # Arguments
+    /// * `caller` - The customer or merchant who authorized the payment (must authorize)
+    /// * `payment_id` - The ID of the payment to cancel
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the payment is not found, is not in Pending
+    /// status, or the caller is not the customer or merchant.
     pub fn cancel_payment(env: Env, caller: Address, payment_id: u64) -> Result<(), Error> {
         Self::require_not_paused(&env, "cancel_payment")?;
         caller.require_auth();
@@ -4360,6 +4807,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns a paginated list of payments made by a customer.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address to query
+    /// * `limit` - Maximum number of payments to return
+    /// * `offset` - The number of payments to skip (for pagination)
+    ///
+    /// # Returns
+    /// A `Vec<Payment>` containing the requested page of payments.
     pub fn get_payments_by_customer(
         env: Env,
         customer: Address,
@@ -4400,6 +4856,13 @@ impl PaymentContract {
         payments
     }
 
+    /// Returns the total number of payments made by a customer.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address to query
+    ///
+    /// # Returns
+    /// The total payment count for the customer, or 0 if none.
     pub fn get_payment_count_by_customer(env: Env, customer: Address) -> u64 {
         env.storage()
             .instance()
@@ -4407,6 +4870,15 @@ impl PaymentContract {
             .unwrap_or(0)
     }
 
+    /// Returns a paginated list of payments received by a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address to query
+    /// * `limit` - Maximum number of payments to return
+    /// * `offset` - The number of payments to skip (for pagination)
+    ///
+    /// # Returns
+    /// A `Vec<Payment>` containing the requested page of payments.
     pub fn get_payments_by_merchant(
         env: Env,
         merchant: Address,
@@ -4447,6 +4919,13 @@ impl PaymentContract {
         payments
     }
 
+    /// Returns the total number of payments received by a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address to query
+    ///
+    /// # Returns
+    /// The total payment count for the merchant, or 0 if none.
     pub fn get_payment_count_by_merchant(env: Env, merchant: Address) -> u64 {
         env.storage()
             .instance()
@@ -4464,6 +4943,14 @@ impl PaymentContract {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    /// Adds a token to the list of allowed tokens for payments.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this change (must be in the multisig admin list)
+    /// * `token` - The SPL token address to add to the allowed list
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized or multisig is not initialized.
     pub fn add_allowed_token(env: Env, admin: Address, token: Address) -> Result<(), Error> {
         admin.require_auth();
 
@@ -4491,6 +4978,14 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Removes a token from the list of allowed tokens for payments.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this change (must be in the multisig admin list)
+    /// * `token` - The SPL token address to remove from the allowed list
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if the admin is unauthorized or multisig is not initialized.
     pub fn remove_allowed_token(env: Env, admin: Address, token: Address) -> Result<(), Error> {
         admin.require_auth();
 
@@ -4521,6 +5016,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the list of allowed payment tokens.
+    ///
+    /// If no tokens have been configured, returns an empty list, which means all tokens are permitted.
+    ///
+    /// # Returns
+    /// A vector of token addresses that have been explicitly allowed by an admin.
+    /// Returns the list of all allowed tokens for payments.
+    ///
+    /// # Returns
+    /// A `Vec<Address>` of allowed token addresses. Returns an empty vector if none are configured.
     pub fn get_allowed_tokens(env: Env) -> Vec<Address> {
         env.storage()
             .instance()
@@ -4709,6 +5214,17 @@ impl PaymentContract {
         )
     }
 
+    /// Sets the manual conversion rate for a given currency.
+    ///
+    /// This rate is used when oracle-based rate fetching is disabled or unavailable.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `currency` - The fiat currency to set a conversion rate for.
+    /// * `rate` - The conversion rate in base units (e.g., 1_0000000 = 1:1).
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized or the currency is invalid.
     pub fn set_conversion_rate(
         env: Env,
         admin: Address,
@@ -4738,6 +5254,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the stored conversion rate for a given currency.
+    ///
+    /// Defaults to `1_0000000` (1:1) if no rate has been set.
+    ///
+    /// # Arguments
+    /// * `currency` - The fiat currency to query the conversion rate for.
+    ///
+    /// # Returns
+    /// The conversion rate in base units.
     pub fn get_conversion_rate(env: Env, currency: Currency) -> i128 {
         env.storage()
             .instance()
@@ -4745,6 +5270,18 @@ impl PaymentContract {
             .unwrap_or(1_0000000)
     }
 
+    /// Configures the oracle-based price feed for a given currency.
+    ///
+    /// When enabled, the contract will fetch live conversion rates from the oracle
+    /// contract instead of using the manual conversion rate.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `config` - The oracle rate configuration including oracle address, price feed ID,
+    ///   staleness threshold, and currency.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized.
     pub fn set_oracle_rate_config(
         env: Env,
         admin: Address,
@@ -4766,12 +5303,34 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the oracle rate configuration for a given currency.
+    ///
+    /// # Arguments
+    /// * `currency` - The fiat currency to query the oracle config for.
+    ///
+    /// # Returns
+    /// `Some(OracleRateConfig)` if configured, `None` otherwise.
     pub fn get_oracle_rate_config(env: Env, currency: Currency) -> Option<OracleRateConfig> {
         env.storage()
             .instance()
             .get(&DataKey::Feature(FeatureKey::OracleRateConfig(currency)))
     }
 
+    /// Fetches a fresh conversion rate from the oracle and stores it.
+    ///
+    /// If the oracle is disabled for this currency, returns the stored manual rate.
+    /// If the oracle feed data is stale (older than `max_staleness_seconds`), returns an error.
+    ///
+    /// # Arguments
+    /// * `currency` - The fiat currency to refresh the conversion rate for.
+    ///
+    /// # Returns
+    /// The updated conversion rate on success.
+    ///
+    /// # Errors
+    /// - `OracleNotConfigured` if no oracle config exists for the currency.
+    /// - `OracleCallFailed` if the oracle contract call fails.
+    /// - `OracleFeedStale` if the fetched data exceeds the staleness threshold.
     pub fn refresh_conversion_rate(env: Env, currency: Currency) -> Result<i128, Error> {
         let cfg: OracleRateConfig = env
             .storage()
@@ -5256,6 +5815,25 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Creates a new metered (usage-based) subscription.
+    ///
+    /// The merchant authorises creation. Usage is reported separately via `report_usage`
+    /// and billed via `execute_metered_billing`.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant creating the subscription.
+    /// * `customer` - The customer being subscribed.
+    /// * `price_per_unit` - The cost per usage unit in token base units.
+    /// * `unit_name` - A human-readable name for the usage unit (e.g., "API calls").
+    /// * `token` - The payment token address.
+    /// * `billing_cap` - Optional maximum billable amount per billing cycle.
+    /// * `max_units_per_period` - Optional maximum number of units that can be accumulated per period.
+    ///
+    /// # Returns
+    /// The metered subscription ID on success.
+    ///
+    /// # Errors
+    /// - `Unauthorized` if the caller is not the merchant.
     pub fn create_metered_subscription(
         env: Env,
         merchant: Address,
@@ -5302,6 +5880,22 @@ impl PaymentContract {
         Ok(sub_id)
     }
 
+    /// Reports usage units for a metered subscription.
+    ///
+    /// The reported units are accumulated until the next billing cycle.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant authorizing the usage report (must own the subscription).
+    /// * `subscription_id` - The metered subscription to report usage for.
+    /// * `units` - The number of usage units to add to the accumulator.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - `MeteredNotFound` if the subscription does not exist.
+    /// - `Unauthorized` if the caller is not the subscription's merchant.
+    /// - `UsageCapExceeded` if adding the units would exceed `max_units_per_period`.
     pub fn report_usage(
         env: Env,
         merchant: Address,
@@ -5345,6 +5939,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the current usage state of a metered subscription.
+    ///
+    /// # Arguments
+    /// * `subscription_id` - The metered subscription to query.
+    ///
+    /// # Returns
+    /// The `MeteredSubscription` containing accumulated units, billing cap, and other usage data.
+    ///
+    /// # Panics
+    /// Panics if the metered subscription is not found.
     pub fn get_current_usage(env: Env, subscription_id: u64) -> MeteredSubscription {
         env.storage()
             .instance()
@@ -5354,6 +5958,21 @@ impl PaymentContract {
             .expect("MeteredSubscription not found")
     }
 
+    /// Sets or updates the billing cap for a metered subscription.
+    ///
+    /// The billing cap limits the maximum amount that can be charged per billing cycle.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant authorizing the update (must own the subscription).
+    /// * `subscription_id` - The metered subscription to update.
+    /// * `cap` - The new billing cap amount in token base units.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - `MeteredNotFound` if the subscription does not exist.
+    /// - `Unauthorized` if the caller is not the subscription's merchant.
     pub fn set_billing_cap(
         env: Env,
         merchant: Address,
@@ -5384,6 +6003,20 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Executes a billing cycle for a metered subscription.
+    ///
+    /// Calculates the total charge from accumulated units × price per unit (capped by `billing_cap` if set),
+    /// transfers the amount from the customer to the merchant, and resets the usage accumulator.
+    ///
+    /// # Arguments
+    /// * `subscription_id` - The metered subscription to bill.
+    ///
+    /// # Returns
+    /// The total amount charged on success, or `0` if no usage was accumulated.
+    ///
+    /// # Errors
+    /// - `MeteredNotFound` if the subscription does not exist.
+    /// - `BillingOverflow` if the multiplication of units × price overflows.
     pub fn execute_metered_billing(env: Env, subscription_id: u64) -> Result<i128, Error> {
         let mut sub: MeteredSubscription = env
             .storage()
@@ -6153,6 +6786,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Checks whether an address has been flagged by an admin.
+    ///
+    /// Flagged addresses are blocked from creating payments unless explicitly allowlisted.
+    ///
+    /// # Arguments
+    /// * `address` - The address to check.
+    ///
+    /// # Returns
+    /// `true` if the address is flagged, `false` otherwise.
     pub fn is_address_flagged(env: Env, address: Address) -> bool {
         let rate_limit: AddressRateLimit = env
             .storage()
@@ -6171,12 +6813,29 @@ impl PaymentContract {
         rate_limit.flagged
     }
 
+    /// Returns the reason an address was flagged, if any.
+    ///
+    /// # Arguments
+    /// * `address` - The address to query.
+    ///
+    /// # Returns
+    /// `Some(reason)` if the address is flagged and a reason was recorded, `None` otherwise.
     pub fn get_flag_reason(env: Env, address: Address) -> Option<String> {
         env.storage()
             .instance()
             .get(&DataKey::Customer(CustomerDataKey::FlagReason(address)))
     }
 
+    /// Adds an address to the allowlist, bypassing the flagged-address block.
+    ///
+    /// Allowlisted addresses can create payments even if they have been flagged.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `address` - The address to allowlist.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized.
     pub fn add_to_allowlist(env: Env, admin: Address, address: Address) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -6194,6 +6853,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Removes an address from the allowlist.
+    ///
+    /// Once removed, a flagged address will again be blocked from creating payments.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `address` - The address to remove from the allowlist.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized.
     pub fn remove_from_allowlist(env: Env, admin: Address, address: Address) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -6313,6 +6982,18 @@ impl PaymentContract {
             .unwrap_or(false)
     }
 
+    /// Sets a custom rate limit configuration for a specific merchant.
+    ///
+    /// Overrides the global rate limit for this merchant. Use `reset_merchant_rate_limit`
+    /// to revert to global defaults.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `merchant` - The merchant to configure the rate limit for.
+    /// * `config` - The merchant-specific rate limit configuration.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized.
     pub fn set_merchant_rate_limit(
         env: Env,
         admin: Address,
@@ -6335,12 +7016,27 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the custom rate limit configuration for a merchant, if set.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant to query.
+    ///
+    /// # Returns
+    /// `Some(MerchantRateLimit)` if a custom config exists, `None` if the merchant uses global defaults.
     pub fn get_merchant_rate_limit(env: Env, merchant: Address) -> Option<MerchantRateLimit> {
         env.storage()
             .instance()
             .get(&DataKey::Feature(FeatureKey::MerchantRateLimit(merchant)))
     }
 
+    /// Removes the custom rate limit for a merchant, reverting to global defaults.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `merchant` - The merchant whose rate limit config should be removed.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized.
     pub fn reset_merchant_rate_limit(
         env: Env,
         admin: Address,
@@ -6361,6 +7057,18 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Checks whether a payment of the given amount would pass the merchant's rate limit.
+    ///
+    /// Considers the merchant's verification tier limits, custom merchant limits,
+    /// and the global rate limit config. Does **not** update any counters — use
+    /// this as a read-only pre-check.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant to check rate limits for.
+    /// * `amount` - The proposed payment amount.
+    ///
+    /// # Returns
+    /// `true` if the payment is allowed, `false` if it would exceed a rate limit.
     pub fn check_rate_limit(env: Env, merchant: Address, amount: i128) -> bool {
         let level = Self::get_merchant_verification_level(env.clone(), merchant.clone());
         let tier_limits_opt = Self::get_tier_limits(env.clone(), level);
@@ -7046,6 +7754,19 @@ impl PaymentContract {
 
     // ── FEE WAIVER FUNCTIONS ───────────────────────────────────────────────────
 
+    /// Grants a fee waiver to a merchant, reducing their platform fee by the specified BPS.
+    ///
+    /// The waiver applies to all future payments until it expires or is revoked.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `merchant` - The merchant to grant the waiver to.
+    /// * `waiver_bps` - The fee reduction in basis points (0–10000, where 10000 = 100% waiver).
+    /// * `valid_until` - The ledger timestamp at which the waiver expires.
+    /// * `reason` - A human-readable reason for granting the waiver.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized or the BPS value is invalid.
     pub fn grant_fee_waiver(
         env: Env,
         admin: Address,
@@ -7094,6 +7815,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Revokes an active fee waiver for a merchant.
+    ///
+    /// After revocation, the merchant reverts to their standard fee tier.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `merchant` - The merchant whose waiver should be revoked.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized or no waiver exists.
     pub fn revoke_fee_waiver(env: Env, admin: Address, merchant: Address) -> Result<(), Error> {
         admin.require_auth();
 
@@ -7132,6 +7863,15 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the active fee waiver for a merchant, if any.
+    ///
+    /// Automatically removes and returns `None` if the waiver has expired.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant to query.
+    ///
+    /// # Returns
+    /// `Some(FeeWaiver)` if a valid waiver exists, `None` otherwise.
     pub fn get_fee_waiver(env: Env, merchant: Address) -> Option<FeeWaiver> {
         let waiver: Option<FeeWaiver> =
             env.storage()
@@ -7160,6 +7900,15 @@ impl PaymentContract {
         }
     }
 
+    /// Computes the effective fee rate for a merchant after applying tier discount and waiver.
+    ///
+    /// Returns 0 if no fee config exists or fees are inactive.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant to compute the effective fee for.
+    ///
+    /// # Returns
+    /// The effective fee in basis points.
     pub fn get_effective_fee_bps(env: Env, merchant: Address) -> u32 {
         // Get base fee configuration
         let config: Option<FeeConfig> = env
@@ -7190,6 +7939,17 @@ impl PaymentContract {
 
     // ── FEE REBATE FUNCTIONS ──────────────────────────────────────────────────
 
+    /// Configures the fee rebate program for merchants.
+    ///
+    /// When active, merchants accrue a rebate on fees paid above a volume threshold,
+    /// which they can later claim via `claim_fee_rebate`.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing this operation (must be a multisig admin).
+    /// * `config` - The rebate configuration including BPS, threshold volume, and period.
+    ///
+    /// # Returns
+    /// `Ok(())` on success, or an error if unauthorized.
     pub fn configure_fee_rebate(
         env: Env,
         admin: Address,
@@ -7210,12 +7970,33 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the current rebate accrual state for a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant to query.
+    ///
+    /// # Returns
+    /// `Some(MerchantRebateAccrual)` if accrual data exists, `None` otherwise.
     pub fn get_rebate_accrual(env: Env, merchant: Address) -> Option<MerchantRebateAccrual> {
         env.storage()
             .instance()
             .get(&DataKey::Merchant(MerchantDataKey::RebateAccrual(merchant)))
     }
 
+    /// Claims the accrued fee rebate for a merchant.
+    ///
+    /// Transfers the rebate amount from accumulated fees to the merchant and resets the accrual.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant claiming the rebate.
+    ///
+    /// # Returns
+    /// The rebate amount transferred on success.
+    ///
+    /// # Errors
+    /// - `RebateConfigNotFound` if the rebate program is not configured or inactive.
+    /// - `RebateThresholdNotMet` if no accrual data exists for the merchant.
+    /// - `RebateAlreadyClaimed` if the accrued rebate is zero (already claimed).
     pub fn claim_fee_rebate(env: Env, merchant: Address) -> Result<i128, Error> {
         merchant.require_auth();
 
@@ -7338,6 +8119,20 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Creates multiple payments in a single transaction.
+    ///
+    /// Each unique customer in the batch must authorize the transaction. Individual
+    /// payment failures do not revert the entire batch — results are returned per entry.
+    ///
+    /// # Arguments
+    /// * `entries` - A vector of `BatchPaymentEntry` structs describing each payment.
+    ///
+    /// # Returns
+    /// A vector of `BatchResult` indicating success/failure for each entry.
+    ///
+    /// # Errors
+    /// - `InvalidBatchSize` if the batch is empty or exceeds 50 entries.
+    /// - `ContractPaused` if the contract is paused.
     pub fn create_batch_payment(
         env: Env,
         entries: Vec<BatchPaymentEntry>,
@@ -7389,6 +8184,22 @@ impl PaymentContract {
         Ok(results)
     }
 
+    /// Completes multiple payments in a single transaction.
+    ///
+    /// Only admin (multisig) users may call this. Each payment is individually
+    /// completed — failures do not revert the batch.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin authorizing the batch completion.
+    /// * `payment_ids` - A vector of payment IDs to complete.
+    ///
+    /// # Returns
+    /// A vector of `BatchResult` indicating success/failure for each payment.
+    ///
+    /// # Errors
+    /// - `InvalidBatchSize` if the batch is empty or exceeds 50 entries.
+    /// - `Unauthorized` if the caller is not a multisig admin.
+    /// - `ContractPaused` if the contract is paused.
     pub fn complete_batch_payment(
         env: Env,
         admin: Address,
@@ -7434,6 +8245,21 @@ impl PaymentContract {
         Ok(results)
     }
 
+    /// Cancels multiple payments in a single transaction.
+    ///
+    /// The caller must be authorized for each payment (customer, merchant, or admin).
+    /// Individual cancellation failures do not revert the batch.
+    ///
+    /// # Arguments
+    /// * `caller` - The address authorizing the cancellations.
+    /// * `payment_ids` - A vector of payment IDs to cancel.
+    ///
+    /// # Returns
+    /// A vector of `BatchResult` indicating success/failure for each payment.
+    ///
+    /// # Errors
+    /// - `InvalidBatchSize` if the batch is empty or exceeds 50 entries.
+    /// - `ContractPaused` if the contract is paused.
     pub fn cancel_batch_payment(
         env: Env,
         caller: Address,
@@ -7470,6 +8296,22 @@ impl PaymentContract {
         Ok(results)
     }
 
+    /// Creates a batch of payments atomically with aggregated transfers.
+    ///
+    /// Validates each entry (currency, metadata, sanctions, rate limits, spend limits),
+    /// creates payment records, and executes token transfers. Transfers to merchants
+    /// are aggregated by token/merchant pair for gas efficiency.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address initiating the batch (must be a multi-sig admin).
+    /// * `entries` - Vector of `BatchPaymentEntry` items to process.
+    ///
+    /// # Returns
+    /// A vector of `BatchResult` indicating success/failure and payment ID for each entry.
+    ///
+    /// # Errors
+    /// Returns an error if the contract is paused, admin is unauthorized,
+    /// or the batch size exceeds the configured maximum.
     pub fn create_payment_batch_optimized(
         env: Env,
         admin: Address,
@@ -7769,6 +8611,15 @@ impl PaymentContract {
         Ok(results)
     }
 
+    /// Estimates the gas cost for executing a batch payment operation.
+    ///
+    /// Uses a rough heuristic based on entry count and unique token/merchant groups.
+    ///
+    /// # Arguments
+    /// * `entries` - The batch payment entries to estimate gas for.
+    ///
+    /// # Returns
+    /// Estimated gas units as a `u32`.
     pub fn get_batch_gas_estimate(env: Env, entries: Vec<BatchPaymentEntry>) -> u32 {
         // Estimate based on number of entries and groups
         let mut groups: Vec<(Address, Address)> = Vec::new(&env);
@@ -7788,6 +8639,26 @@ impl PaymentContract {
         1000 + (entries.len() as u32) * 500 + (groups.len() as u32) * 300
     }
 
+    /// Creates a conditional payment that is only completed when a specified condition is met.
+    ///
+    /// The payment is created in `Pending` status and stored with its condition.
+    /// The condition can be time-based, oracle-based, or cross-contract state-based.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer initiating the payment (must authorize).
+    /// * `merchant` - The merchant receiving the payment.
+    /// * `amount` - Payment amount in base token units.
+    /// * `token` - Address of the token contract.
+    /// * `currency` - Currency enum for the payment.
+    /// * `expiration_duration` - Seconds until the payment expires (0 for no expiration).
+    /// * `metadata` - Optional descriptive metadata string.
+    /// * `condition` - The `ConditionType` that must be satisfied to complete payment.
+    ///
+    /// # Returns
+    /// The payment ID on success.
+    ///
+    /// # Errors
+    /// Returns an error if the base payment creation fails.
     pub fn create_conditional_payment(
         env: Env,
         customer: Address,
@@ -7843,6 +8714,21 @@ impl PaymentContract {
         Ok(payment_id)
     }
 
+    /// Evaluates the condition of a conditional payment and caches the result.
+    ///
+    /// For time-based conditions, compares the current ledger timestamp against
+    /// the target. For cross-contract conditions, invokes the target contract
+    /// to retrieve its state hash. Oracle conditions are not yet supported.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the conditional payment to evaluate.
+    ///
+    /// # Returns
+    /// `true` if the condition is met, `false` otherwise.
+    ///
+    /// # Errors
+    /// Returns an error if the conditional payment is not found or if
+    /// oracle/cross-contract evaluation fails.
     pub fn evaluate_condition(env: Env, payment_id: u64) -> Result<bool, Error> {
         let mut conditional_payment: ConditionalPayment = env
             .storage()
@@ -7898,6 +8784,21 @@ impl PaymentContract {
         Ok(condition_met)
     }
 
+    /// Completes a conditional payment after evaluating its condition.
+    ///
+    /// Only an admin can call this function. The payment must be in `Pending` status,
+    /// not expired, and the condition must evaluate to `true`.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `payment_id` - The ID of the conditional payment to complete.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the admin is unauthorized, payment not found,
+    /// already processed, expired, or condition not met.
     pub fn complete_conditional_payment(
         env: Env,
         admin: Address,
@@ -7956,6 +8857,21 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Executes a conditional payment if its condition is met.
+    ///
+    /// Unlike `complete_conditional_payment`, this can be called by anyone.
+    /// It evaluates the condition and completes the payment atomically.
+    /// If already completed, it returns `Ok(())` silently.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the conditional payment.
+    ///
+    /// # Returns
+    /// `Ok(())` on success or if already completed.
+    ///
+    /// # Errors
+    /// Returns an error if the payment is not found, not in pending status,
+    /// or the condition is not met.
     pub fn execute_if_condition_met(env: Env, payment_id: u64) -> Result<(), Error> {
         if !env
             .storage()
@@ -7981,6 +8897,16 @@ impl PaymentContract {
         PaymentContract::do_complete_payment(&env, payment_id)
     }
 
+    /// Retrieves the conditional payment record for a given payment ID.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the conditional payment.
+    ///
+    /// # Returns
+    /// The `ConditionalPayment` record.
+    ///
+    /// # Errors
+    /// Returns `PaymentError::NotFound` if no conditional payment exists.
     pub fn get_conditional_payment(env: Env, payment_id: u64) -> Result<ConditionalPayment, Error> {
         env.storage()
             .instance()
@@ -7992,6 +8918,11 @@ impl PaymentContract {
 
     // ── ANALYTICS FUNCTIONS ────────────────────────────────────────────────
 
+    /// Returns the global payment analytics for the entire platform.
+    ///
+    /// # Returns
+    /// A `PaymentAnalytics` struct with aggregate counts and volume totals.
+    /// Returns zeroed defaults if no analytics data has been recorded.
     pub fn get_payment_analytics(env: Env) -> PaymentAnalytics {
         env.storage()
             .instance()
@@ -8008,6 +8939,14 @@ impl PaymentContract {
             })
     }
 
+    /// Returns analytics data for a specific merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address to query analytics for.
+    ///
+    /// # Returns
+    /// A `MerchantAnalytics` struct with per-merchant payment counts and volume.
+    /// Returns zeroed defaults if no analytics data exists for this merchant.
     pub fn get_merchant_analytics(env: Env, merchant: Address) -> MerchantAnalytics {
         env.storage()
             .instance()
@@ -8022,10 +8961,24 @@ impl PaymentContract {
             })
     }
 
+    /// Returns the total transaction volume for a specific merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address.
+    ///
+    /// # Returns
+    /// Total volume as `i128`.
     pub fn get_merchant_total_volume(env: Env, merchant: Address) -> i128 {
         PaymentContract::get_merchant_analytics(env, merchant).total_volume
     }
 
+    /// Returns analytics data for a specific customer.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address to query analytics for.
+    ///
+    /// # Returns
+    /// A `CustomerAnalytics` struct with payment counts, volume, and behavioral metrics.
     pub fn get_customer_analytics(env: Env, customer: Address) -> CustomerAnalytics {
         env.storage()
             .instance()
@@ -8033,6 +8986,15 @@ impl PaymentContract {
             .unwrap_or(PaymentContract::default_customer_analytics())
     }
 
+    /// Returns the top merchants by volume for a given customer, up to the specified limit.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address.
+    /// * `limit` - Maximum number of merchants to return.
+    ///
+    /// # Returns
+    /// A vector of `(Address, i128)` tuples representing (merchant, total_volume),
+    /// sorted by descending volume.
     pub fn get_customer_top_merchants(
         env: Env,
         customer: Address,
@@ -8096,6 +9058,14 @@ impl PaymentContract {
         result
     }
 
+    /// Returns the total spending volume for a customer in a specific month.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address.
+    /// * `month_timestamp` - Unix timestamp representing the start of the month.
+    ///
+    /// # Returns
+    /// Volume as `i128` for the specified month. Returns 0 if no data exists.
     pub fn get_customer_monthly_volume(env: Env, customer: Address, month_timestamp: u64) -> i128 {
         env.storage()
             .instance()
@@ -8106,6 +9076,18 @@ impl PaymentContract {
             .unwrap_or(0)
     }
 
+    /// Returns hourly analytics buckets for a merchant within a time range.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address.
+    /// * `from` - Start timestamp (inclusive).
+    /// * `to` - End timestamp (exclusive).
+    ///
+    /// # Returns
+    /// A vector of `AnalyticsBucket` for each hour that has recorded data.
+    ///
+    /// # Errors
+    /// Returns an error if `from >= to`.
     pub fn get_merchant_analytics_range(
         env: Env,
         merchant: Address,
@@ -8132,6 +9114,13 @@ impl PaymentContract {
         Ok(out)
     }
 
+    /// Returns the platform-wide daily analytics bucket for a given day.
+    ///
+    /// # Arguments
+    /// * `day_timestamp` - Any timestamp within the target day.
+    ///
+    /// # Returns
+    /// An `AnalyticsBucket` with aggregated daily metrics (payments, volume, refunds, failures).
     pub fn get_platform_analytics_daily(env: Env, day_timestamp: u64) -> AnalyticsBucket {
         let day_start = PaymentContract::day_bucket_start(day_timestamp);
         env.storage()
@@ -8149,6 +9138,14 @@ impl PaymentContract {
             })
     }
 
+    /// Returns the top merchants across the platform by total volume.
+    ///
+    /// # Arguments
+    /// * `limit` - Maximum number of merchants to return.
+    ///
+    /// # Returns
+    /// A vector of `(Address, i128)` tuples representing (merchant, total_volume),
+    /// sorted by descending volume.
     pub fn get_top_merchants_by_volume(env: Env, limit: u32) -> Vec<(Address, i128)> {
         let count: u64 = env
             .storage()
@@ -8287,6 +9284,20 @@ impl PaymentContract {
 
     // ── PAUSE FUNCTIONS ────────────────────────────────────────────────────
 
+    /// Pauses the entire contract, blocking all guarded functions.
+    ///
+    /// Only callable by a multi-sig admin. Records the pause event
+    /// in the pause history for audit purposes.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `reason` - Human-readable reason for pausing.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an authorized admin.
     pub fn pause_contract(env: Env, admin: Address, reason: String) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -8350,6 +9361,19 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Unpauses the entire contract, re-enabling all guarded functions.
+    ///
+    /// Only callable by a multi-sig admin. Records the unpause event
+    /// in the pause history for audit purposes.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an authorized admin.
     pub fn unpause_contract(env: Env, admin: Address) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -8400,6 +9424,21 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Pauses a specific function, preventing it from being called.
+    ///
+    /// Only callable by a multi-sig admin. The operation is idempotent;
+    /// pausing an already-paused function is a no-op.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `function_name` - The name of the function to pause.
+    /// * `reason` - Human-readable reason for the pause.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an authorized admin.
     pub fn pause_function(
         env: Env,
         admin: Address,
@@ -8470,6 +9509,20 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Unpauses a specific function, allowing it to be called again.
+    ///
+    /// Only callable by a multi-sig admin. Records the unpause event
+    /// in the pause history.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `function_name` - The name of the function to unpause.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an authorized admin.
     pub fn unpause_function(env: Env, admin: Address, function_name: String) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -8561,6 +9614,11 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the current global pause state of the contract.
+    ///
+    /// # Returns
+    /// A `PauseState` struct indicating whether the contract is globally paused,
+    /// which individual functions are paused, and who/when it was paused.
     pub fn get_pause_state(env: Env) -> PauseState {
         env.storage()
             .instance()
@@ -8574,6 +9632,16 @@ impl PaymentContract {
             })
     }
 
+    /// Checks whether a specific function is currently paused.
+    ///
+    /// Returns `true` if the contract is globally paused or if the given
+    /// function name is in the paused functions list.
+    ///
+    /// # Arguments
+    /// * `function_name` - The name of the function to check.
+    ///
+    /// # Returns
+    /// `true` if the function is paused, `false` otherwise.
     pub fn is_function_paused(env: Env, function_name: String) -> bool {
         if let Some(state) = env
             .storage()
@@ -8592,6 +9660,24 @@ impl PaymentContract {
         false
     }
 
+    /// Sets an automatic escrow rule for a merchant.
+    ///
+    /// When enabled, qualifying payments to this merchant will trigger
+    /// automatic escrow creation via the configured escrow contract.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `merchant` - The merchant this rule applies to.
+    /// * `escrow_bps` - Percentage of payment to escrow, in basis points.
+    /// * `min_amount` - Minimum payment amount to trigger escrow.
+    /// * `token` - Token address that the rule applies to.
+    /// * `escrow_contract` - Address of the escrow contract to use.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the contract is paused or the caller is not an admin.
     pub fn set_auto_escrow_rule(
         env: Env,
         admin: Address,
@@ -8631,12 +9717,31 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves the auto-escrow rule for a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address.
+    ///
+    /// # Returns
+    /// `Some(AutoEscrowRule)` if a rule exists, `None` otherwise.
     pub fn get_auto_escrow_rule(env: Env, merchant: Address) -> Option<AutoEscrowRule> {
         env.storage()
             .instance()
             .get(&DataKey::State(StateDataKey::AutoEscrowRule(merchant)))
     }
 
+    /// Removes the auto-escrow rule for a merchant.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `merchant` - The merchant whose escrow rule should be removed.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the contract is paused, caller is not an admin,
+    /// or no escrow rule exists for the merchant.
     pub fn remove_auto_escrow_rule(
         env: Env,
         admin: Address,
@@ -8673,6 +9778,21 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Triggers automatic escrow for a completed payment if an active rule exists.
+    ///
+    /// Calculates the escrow amount based on the merchant's escrow rule (basis points),
+    /// creates an escrow via the escrow contract, and emits an event.
+    /// This function can be called by anyone after a payment is completed.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment to create escrow for.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the payment is not found, escrow was already triggered,
+    /// the rule is not found/inactive, or token/amount requirements are not met.
     pub fn trigger_auto_escrow(env: &Env, payment_id: u64) -> Result<(), Error> {
         // Check if payment exists
         if !env
@@ -8780,6 +9900,17 @@ impl PaymentContract {
 
     // ── LARGE PAYMENT MULTI-SIG FUNCTIONS ─────────────────────────────────────
 
+    /// Sets the threshold amount above which payments require multi-sig approval.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `threshold` - The payment amount threshold. Setting to 0 disables multi-sig.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an admin.
     pub fn set_large_payment_threshold(
         env: Env,
         admin: Address,
@@ -8811,6 +9942,10 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the current large payment threshold.
+    ///
+    /// # Returns
+    /// The threshold amount as `i128`. A value of 0 means multi-sig is disabled.
     pub fn get_large_payment_threshold(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -8818,6 +9953,22 @@ impl PaymentContract {
             .unwrap_or(0) // Default threshold of 0 disables multi-sig requirement
     }
 
+    /// Proposes a large payment for multi-sig approval.
+    ///
+    /// The payment amount must exceed the configured large payment threshold.
+    /// The merchant who owns the payment becomes the initial approver.
+    /// The proposal expires after `proposal_ttl` seconds from the multi-sig config.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant who owns the payment.
+    /// * `payment_id` - The ID of the payment to propose.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not the payment merchant, the payment
+    /// amount does not exceed the threshold, or a proposal already exists.
     pub fn propose_large_payment(
         env: Env,
         merchant: Address,
@@ -8891,6 +10042,21 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Approves a large payment proposal as a multi-sig admin.
+    ///
+    /// Each admin can only approve once. The proposal expires after the configured TTL.
+    /// Once the required number of approvals is reached, the payment can be executed.
+    ///
+    /// # Arguments
+    /// * `approver` - Admin address (must be a multi-sig admin).
+    /// * `payment_id` - The ID of the payment proposal to approve.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the approver is not an admin, the proposal is not found,
+    /// already executed, expired, or the approver has already approved.
     pub fn approve_large_payment(
         env: Env,
         approver: Address,
@@ -8945,6 +10111,21 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Executes an approved large payment proposal.
+    ///
+    /// Transfers funds from customer to merchant and marks both the payment
+    /// and proposal as completed. Requires the proposal to have enough approvals
+    /// and not be expired.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the large payment to execute.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the proposal is not found, expired, has insufficient
+    /// approvals, or the payment is not in pending status.
     pub fn execute_large_payment(env: Env, payment_id: u64) -> Result<(), Error> {
         let config: MultiSigConfig = env
             .storage()
@@ -9016,6 +10197,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the large payment proposal for a given payment ID.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The ID of the payment.
+    ///
+    /// # Returns
+    /// The `LargePaymentProposal` record.
+    ///
+    /// # Panics
+    /// Panics if no proposal exists for the given payment ID.
     pub fn get_large_payment_proposal(env: Env, payment_id: u64) -> LargePaymentProposal {
         env.storage()
             .instance()
@@ -9310,7 +10501,19 @@ impl PaymentContract {
         }
     }
 
-    // Dynamic fee calculation functions (#124)
+    /// Calculates a risk score for a payment based on amount, customer history, and currency.
+    ///
+    /// Higher scores indicate higher risk. Used by `get_effective_fee_for_payment`
+    /// to determine the dynamic fee surcharge.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address.
+    /// * `merchant` - The merchant address.
+    /// * `amount` - The payment amount.
+    /// * `currency` - The currency of the payment.
+    ///
+    /// # Returns
+    /// Risk score as basis points (0 = no additional risk).
     pub fn calculate_risk_score(
         env: Env,
         customer: Address,
@@ -9358,6 +10561,19 @@ impl PaymentContract {
         risk_score
     }
 
+    /// Calculates the total effective fee for a payment including risk-based surcharges.
+    ///
+    /// Combines the base fee with the risk score from `calculate_risk_score`.
+    /// The total fee is capped at 1000 basis points (10%).
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address.
+    /// * `merchant` - The merchant address.
+    /// * `amount` - The payment amount.
+    /// * `currency` - The currency of the payment.
+    ///
+    /// # Returns
+    /// Total effective fee in basis points.
     pub fn get_effective_fee_for_payment(
         env: Env,
         customer: Address,
@@ -9388,6 +10604,18 @@ impl PaymentContract {
         }
     }
 
+    /// Updates the risk-based fee configuration for dynamic fee calculation.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be the contract admin).
+    /// * `config` - The new `RiskFeeConfig` to apply.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not the admin, `base_fee_bps` exceeds 1000,
+    /// or `large_amount_threshold` is not positive.
     pub fn set_risk_fee_config(
         env: Env,
         admin: Address,
@@ -9461,6 +10689,26 @@ impl PaymentContract {
 
     // ── PAYMENT CHANNEL METHODS (#125) ──────────────────────────────────────
 
+    /// Opens a payment channel by depositing tokens from the customer.
+    ///
+    /// Creates a unidirectional payment channel for micropayments. The customer
+    /// deposits tokens upfront and signs off-chain updates. The merchant settles
+    /// the channel on-chain with a signed settlement transaction.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer opening the channel (must authorize).
+    /// * `merchant` - The merchant who will receive settlement.
+    /// * `token` - The token address for the channel.
+    /// * `amount` - Amount to deposit into the channel.
+    /// * `expires_at` - Ledger timestamp when the channel expires (0 for no expiry).
+    /// * `customer_pk` - Customer's Ed25519 public key for signature verification.
+    ///
+    /// # Returns
+    /// The channel ID on success.
+    ///
+    /// # Errors
+    /// Returns an error if the amount is non-positive, the merchant is the zero address,
+    /// or the token transfer fails.
     pub fn open_channel(
         env: Env,
         customer: Address,
@@ -9524,6 +10772,24 @@ impl PaymentContract {
         Ok(channel_id)
     }
 
+    /// Settles a payment channel with a signed off-chain state update.
+    ///
+    /// Verifies the customer's signature over (channel_id, merchant_amount, nonce),
+    /// transfers funds to the merchant and refunds the remainder to the customer,
+    /// then closes the channel.
+    ///
+    /// # Arguments
+    /// * `channel_id` - The ID of the channel to settle.
+    /// * `merchant_amount` - Amount to send to the merchant.
+    /// * `nonce` - Strictly increasing nonce to prevent replay attacks.
+    /// * `signature` - Ed25519 signature from the customer.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the channel is not found, closed, expired, nonce is stale,
+    /// amount exceeds deposit, or signature verification fails.
     pub fn settle_channel(
         env: Env,
         channel_id: u64,
@@ -9593,6 +10859,21 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Closes an expired payment channel and refunds the full deposit to the customer.
+    ///
+    /// Only the customer or merchant can call this. The channel must be open
+    /// and past its expiration timestamp.
+    ///
+    /// # Arguments
+    /// * `caller` - The address initiating the close (must be customer or merchant).
+    /// * `channel_id` - The ID of the expired channel.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not a channel participant, the channel
+    /// is not found, already closed, or not yet expired.
     pub fn close_channel_expired(env: Env, caller: Address, channel_id: u64) -> Result<(), Error> {
         caller.require_auth();
 
@@ -9637,6 +10918,16 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Retrieves a payment channel by its ID.
+    ///
+    /// # Arguments
+    /// * `channel_id` - The channel ID.
+    ///
+    /// # Returns
+    /// The `PaymentChannel` record.
+    ///
+    /// # Errors
+    /// Returns an error if the channel is not found.
     pub fn get_channel(env: Env, channel_id: u64) -> Result<PaymentChannel, Error> {
         env.storage()
             .instance()
@@ -9671,6 +10962,25 @@ impl PaymentContract {
         false
     }
 
+    /// Creates a split payment that distributes funds to multiple recipients.
+    ///
+    /// Each recipient specifies their share in basis points; total shares must equal 10000.
+    /// Up to 10 recipients are allowed. The payment is created in `Pending` status.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer initiating the payment (must authorize).
+    /// * `merchant` - The primary merchant for the payment.
+    /// * `amount` - Total payment amount in base token units.
+    /// * `token` - Address of the token contract.
+    /// * `recipients` - Vector of `SplitRecipient` with addresses and share_bps.
+    ///
+    /// # Returns
+    /// The payment ID on success.
+    ///
+    /// # Errors
+    /// Returns an error if there are too many recipients, shares don't sum to 10000,
+    /// the customer is a recipient, a recipient share is below the minimum,
+    /// or the customer's spend limit is exceeded.
     pub fn create_split_payment(
         env: Env,
         customer: Address,
@@ -9936,6 +11246,21 @@ impl PaymentContract {
         Ok(payment_id)
     }
 
+    /// Executes the settlement of a split payment, distributing funds to recipients.
+    ///
+    /// Only callable by an admin. Each recipient receives their pro-rata share
+    /// based on the `share_bps` values. The split config is marked as executed.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must authorize).
+    /// * `payment_id` - The ID of the split payment to settle.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the split config is not found, already executed,
+    /// or the payment is not found.
     pub fn execute_split_settlement(
         env: Env,
         admin: Address,
@@ -9976,12 +11301,30 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the split configuration for a payment.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The payment ID.
+    ///
+    /// # Returns
+    /// `Some(PaymentSplitConfig)` if a split was configured, `None` otherwise.
     pub fn get_split_config(env: Env, payment_id: u64) -> Option<PaymentSplitConfig> {
         env.storage()
             .instance()
             .get(&DataKey::Feature(FeatureKey::SplitConfig(payment_id)))
     }
 
+    /// Sets the minimum amount per split recipient for split payments.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `min_amount` - Minimum amount each recipient must receive.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an admin.
     pub fn set_min_split_amount(env: Env, admin: Address, min_amount: i128) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -9998,6 +11341,10 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the minimum amount configured for split payments.
+    ///
+    /// # Returns
+    /// `Some(i128)` if configured, `None` if no minimum is set.
     pub fn get_min_split_amount(env: Env) -> Option<i128> {
         env.storage()
             .instance()
@@ -10006,6 +11353,17 @@ impl PaymentContract {
 
     // ── FEE SWEEP (#216) ─────────────────────────────────────────────────────
 
+    /// Sets the recipient address for platform fee sweeps.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `recipient` - The address that will receive swept fees.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an admin.
     pub fn set_sweep_recipient(env: Env, admin: Address, recipient: Address) -> Result<(), Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -10022,6 +11380,20 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Sweeps all accumulated platform fees to the configured recipient.
+    ///
+    /// Transfers the full accumulated fee balance, resets the counter,
+    /// and records the sweep in history.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    ///
+    /// # Returns
+    /// The amount swept as `i128`.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an admin, the sweep recipient
+    /// is not set, the fee config is missing, or there are no fees to sweep.
     pub fn sweep_platform_fees(env: Env, admin: Address) -> Result<i128, Error> {
         admin.require_auth();
         let config: MultiSigConfig = env
@@ -10078,6 +11450,13 @@ impl PaymentContract {
         Ok(accumulated)
     }
 
+    /// Returns the most recent fee sweep records, up to the specified limit.
+    ///
+    /// # Arguments
+    /// * `limit` - Maximum number of sweep records to return.
+    ///
+    /// # Returns
+    /// A vector of `FeeSweepRecord`, ordered from oldest to newest within the limit.
     pub fn get_sweep_history(env: Env, limit: u32) -> Vec<FeeSweepRecord> {
         let total: u64 = env
             .storage()
@@ -10102,6 +11481,10 @@ impl PaymentContract {
         result
     }
 
+    /// Returns the total accumulated platform fees available for sweeping.
+    ///
+    /// # Returns
+    /// Accumulated fees as `i128`.
     pub fn get_sweepable_balance(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -10111,6 +11494,19 @@ impl PaymentContract {
 
     // ── CUSTOMER SPEND LIMITS (#217) ─────────────────────────────────────────
 
+    /// Sets a spending limit for a customer over a rolling time period.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `customer` - The customer to set the limit for.
+    /// * `limit` - Maximum spending amount within the period.
+    /// * `period_seconds` - Duration of the rolling period in seconds.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an admin.
     pub fn set_customer_spend_limit(
         env: Env,
         admin: Address,
@@ -10142,12 +11538,30 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the current spend limit configuration for a customer.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address.
+    ///
+    /// # Returns
+    /// `Some(CustomerSpendLimit)` if a limit is configured, `None` otherwise.
     pub fn get_spend_limit(env: Env, customer: Address) -> Option<CustomerSpendLimit> {
         env.storage()
             .instance()
             .get(&DataKey::Feature(FeatureKey::CustomerSpendLimit(customer)))
     }
 
+    /// Removes the spending limit for a customer.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `customer` - The customer whose limit should be removed.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an admin.
     pub fn remove_customer_spend_limit(
         env: Env,
         admin: Address,
@@ -10168,6 +11582,17 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Checks whether a customer can spend the given amount without exceeding their limit.
+    ///
+    /// Returns `true` if no limit is configured or if the amount fits within the
+    /// remaining allowance for the current period.
+    ///
+    /// # Arguments
+    /// * `customer` - The customer address.
+    /// * `amount` - The amount to check.
+    ///
+    /// # Returns
+    /// `true` if the spend is allowed, `false` if it would exceed the limit.
     pub fn check_spend_allowance(env: Env, customer: Address, amount: i128) -> bool {
         let limit: Option<CustomerSpendLimit> = env
             .storage()
@@ -10220,6 +11645,14 @@ impl PaymentContract {
 
     // ── SUBSCRIPTION GROUPS (#218) ────────────────────────────────────────────
 
+    /// Creates a new subscription group with a discount.
+    ///
+    /// # Arguments
+    /// * `owner` - The owner of the group (must authorize).
+    /// * `discount_bps` - Discount applied to group subscriptions, in basis points.
+    ///
+    /// # Returns
+    /// The group ID on success.
     pub fn create_subscription_group(
         env: Env,
         owner: Address,
@@ -10250,6 +11683,22 @@ impl PaymentContract {
         Ok(group_id)
     }
 
+    /// Adds a subscription to a group.
+    ///
+    /// Maximum 20 subscriptions per group. A subscription cannot belong
+    /// to multiple groups simultaneously.
+    ///
+    /// # Arguments
+    /// * `owner` - The group owner (must authorize).
+    /// * `group_id` - The group to add the subscription to.
+    /// * `subscription_id` - The subscription to add.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the group is not found, caller is not the owner,
+    /// the group is full, or the subscription is already in a group.
     pub fn add_to_group(
         env: Env,
         owner: Address,
@@ -10292,6 +11741,18 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Removes a subscription from a group.
+    ///
+    /// # Arguments
+    /// * `owner` - The group owner (must authorize).
+    /// * `group_id` - The group to remove the subscription from.
+    /// * `subscription_id` - The subscription to remove.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the group is not found or the caller is not the owner.
     pub fn remove_from_group(
         env: Env,
         owner: Address,
@@ -10326,12 +11787,26 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the subscription group record for a given group ID.
+    ///
+    /// # Arguments
+    /// * `group_id` - The group ID.
+    ///
+    /// # Returns
+    /// `Some(SubscriptionGroup)` if the group exists, `None` otherwise.
     pub fn get_subscription_group(env: Env, group_id: u64) -> Option<SubscriptionGroup> {
         env.storage()
             .instance()
             .get(&DataKey::Subscription(SubscriptionKey::Group(group_id)))
     }
 
+    /// Returns the earliest next billing timestamp across all subscriptions in a group.
+    ///
+    /// # Arguments
+    /// * `group_id` - The group ID.
+    ///
+    /// # Returns
+    /// The earliest `next_payment_at` timestamp, or 0 if the group has no subscriptions.
     pub fn get_group_next_billing(env: Env, group_id: u64) -> u64 {
         let group: Option<SubscriptionGroup> = env
             .storage()
@@ -10362,6 +11837,17 @@ impl PaymentContract {
 
     // ── FINALITY DELAY (#219) ─────────────────────────────────────────────────
 
+    /// Configures the finality delay settings for pending settlements.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must be a multi-sig admin).
+    /// * `config` - The `FinalityConfig` to apply.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not an admin.
     pub fn configure_finality_delay(
         env: Env,
         admin: Address,
@@ -10382,12 +11868,30 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns the current finality delay configuration.
+    ///
+    /// # Returns
+    /// `Some(FinalityConfig)` if configured, `None` otherwise.
     pub fn get_finality_config(env: Env) -> Option<FinalityConfig> {
         env.storage()
             .instance()
             .get(&DataKey::Config(ConfigKey::FinalityConfig))
     }
 
+    /// Finalizes a pending settlement by transferring funds to the merchant.
+    ///
+    /// The settlement's release time must have passed. After finalization,
+    /// the settlement is marked as finalized and cannot be finalized again.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The payment ID of the pending settlement.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the settlement is already finalized, not found,
+    /// or the release time has not yet passed.
     pub fn finalize_pending_settlement(env: Env, payment_id: u64) -> Result<(), Error> {
         if env
             .storage()
@@ -10420,6 +11924,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns all pending (non-finalized) settlements for a merchant.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant address.
+    ///
+    /// # Returns
+    /// A vector of `PendingSettlement` records that have not yet been finalized.
     pub fn get_pending_settlements(env: Env, merchant: Address) -> Vec<PendingSettlement> {
         let count: u64 = env
             .storage()
@@ -10588,7 +12099,22 @@ impl PaymentContract {
         Ok(())
     }
 
-    // Issue #210: Payment tagging system
+    /// Tags a payment with up to 10 arbitrary tag hashes.
+    ///
+    /// Tags can be used for categorization, filtering, or accounting.
+    /// Once set, tags cannot be overwritten; use `remove_payment_tag` first.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant who owns the payment (must authorize).
+    /// * `payment_id` - The payment to tag.
+    /// * `tags` - A vector of `BytesN<32>` tag hashes (max 10).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not the merchant, too many tags,
+    /// or tags have already been set on this payment.
     pub fn tag_payment(
         env: Env,
         merchant: Address,
@@ -10623,6 +12149,13 @@ impl PaymentContract {
         Ok(())
     }
 
+    /// Returns all tags associated with a payment.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The payment ID.
+    ///
+    /// # Returns
+    /// A vector of `BytesN<32>` tag hashes. Returns an empty vector if no tags exist.
     pub fn get_payment_tags(env: Env, payment_id: u64) -> Vec<BytesN<32>> {
         match env
             .storage()
@@ -10634,6 +12167,19 @@ impl PaymentContract {
         }
     }
 
+    /// Removes a specific tag from a payment.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant who owns the payment (must authorize).
+    /// * `payment_id` - The payment ID.
+    /// * `tag` - The tag hash to remove.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not the merchant, no tags exist,
+    /// or the specified tag is not found.
     pub fn remove_payment_tag(
         env: Env,
         merchant: Address,
@@ -10676,7 +12222,23 @@ impl PaymentContract {
         Ok(())
     }
 
-    // Issue #205: Invoice-based payment with line items
+    /// Attaches an invoice with line items to a payment.
+    ///
+    /// Validates that the sum of line item amounts plus tax equals the payment amount.
+    /// Each payment can only have one invoice attached.
+    ///
+    /// # Arguments
+    /// * `merchant` - The merchant who owns the payment (must authorize).
+    /// * `payment_id` - The payment to attach the invoice to.
+    /// * `items` - Vector of `LineItem` with description, quantity, unit_price, and amount.
+    /// * `tax` - Total tax amount.
+    ///
+    /// # Returns
+    /// The invoice ID on success.
+    ///
+    /// # Errors
+    /// Returns an error if the caller is not the merchant, an invoice already exists,
+    /// line items are invalid, or the total does not match the payment amount.
     pub fn attach_invoice(
         env: Env,
         merchant: Address,
@@ -10754,6 +12316,13 @@ impl PaymentContract {
         Ok(invoice_id)
     }
 
+    /// Returns an invoice by its invoice ID.
+    ///
+    /// # Arguments
+    /// * `invoice_id` - The invoice ID.
+    ///
+    /// # Returns
+    /// `Some(PaymentInvoice)` if the invoice exists, `None` otherwise.
     pub fn get_invoice(env: Env, invoice_id: u64) -> Option<PaymentInvoice> {
         let payment_id: u64 = env
             .storage()
@@ -10764,12 +12333,29 @@ impl PaymentContract {
             .get(&DataKey::Payment(PaymentKey::Invoice(payment_id)))
     }
 
+    /// Returns the invoice attached to a specific payment.
+    ///
+    /// # Arguments
+    /// * `payment_id` - The payment ID.
+    ///
+    /// # Returns
+    /// `Some(PaymentInvoice)` if an invoice is attached, `None` otherwise.
     pub fn get_payment_invoice(env: Env, payment_id: u64) -> Option<PaymentInvoice> {
         env.storage()
             .persistent()
             .get(&DataKey::Payment(PaymentKey::Invoice(payment_id)))
     }
 
+    /// Verifies that an invoice's stored total matches a recalculation of its line items.
+    ///
+    /// Useful for detecting tampering or data corruption.
+    ///
+    /// # Arguments
+    /// * `invoice_id` - The invoice ID.
+    ///
+    /// # Returns
+    /// `true` if the recalculation matches the stored total, `false` if
+    /// the invoice is not found or the totals do not match.
     pub fn verify_invoice_total(env: Env, invoice_id: u64) -> bool {
         if let Some(invoice) = Self::get_invoice(env, invoice_id) {
             let mut calculated_subtotal: i128 = 0;


### PR DESCRIPTION
## Summary
This PR adds comprehensive `///` rustdoc comments to all 199 public functions in `contracts/payment/src/lib.rs`, addressing issue #425.

## Changes
- Added ~1,590 lines of rustdoc comments covering every `pub fn` in the payment contract
- Each doc comment describes the function's purpose, parameters, return values, and error/panic conditions
- No logic or signature changes — purely documentation

## Verification
- All `pub fn` lines verified to have `///` doc comments above them
- `cargo check` fails due to a pre-existing `ethnum` dependency incompatibility with Rust 1.97.1 (unrelated to this change)

closes: #425