### PR TITLE
document WASM size limit and check-size target (#449)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,32 @@ The root `Makefile` provides several helpful targets to streamline development. 
 | `clean` | Runs `cargo clean` to remove the generated `target/` directory and build artifacts. | Use this to free up disk space or if you want to ensure a completely fresh build from scratch. |
 | `check-size` | Checks the size of compiled `.wasm` artifacts against the `262144` bytes limit. | Runs automatically during `make build`. Use this manually if you just want to verify sizes without recompiling. |
 
+### WASM Size Limit
+
+Soroban networks enforce a maximum contract deployment size of **256 KB** (262,144 bytes). The `check-size` target enforces this limit to ensure contracts remain deployable on Stellar.
+
+**Why this limit exists:** Soroban caps WASM blob size to keep ledger storage manageable and maintain network performance. A contract that exceeds it will be rejected at deployment by the Stellar network.
+
+**If `make build` or `make check-size` fails with a size error:**
+
+1. Check which contract exceeded the limit — the error message prints the file path and size.
+2. **Build in release mode** — the default `stellar contract build` already compiles with optimizations.
+3. **Strip debug symbols** — add `strip = true` to the release profile in `Cargo.toml`:
+   ```toml
+   [profile.release]
+   strip = true
+   ```
+4. **Optimize for size** — add `opt-level = "z"` and `lto = true` in the release profile:
+   ```toml
+   [profile.release]
+   opt-level = "z"
+   lto = true
+   ```
+5. **Audit dependencies** — run `cargo bloat --crates` to identify large dependencies and consider lighter alternatives.
+6. **Minimize contract exports** — only export the Soroban functions you need; avoid pulling in unused SDK features.
+7. **Remove unused code** — use `cargo deadlinks` or review for dead code that the linker may still include.
+
+After making changes, run `make build` to re-check the size.
 
 ## 🔄 Development Workflow
 


### PR DESCRIPTION
Closes #449 

PR Summary: Adds a dedicated "WASM Size Limit" section to `CONTRIBUTING.md` explaining the 256 KB (262,144 bytes) Soroban deployment limit enforced by `make check-size`. Covers why the limit exists (ledger storage and network performance), and provides a step-by-step troubleshooting guide with concrete tips for reducing binary size: stripping debug symbols, optimizing the release profile with `opt-level = "z"` and LTO, auditing dependencies with `cargo bloat`, minimizing contract exports, and removing dead code.