### PR TITLE
docs: add single test file example to Run Tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ cargo test --workspace
 cargo test -p escrow
 cargo test -p payment
 cargo test -p refund
+
+# Test a single test file or function within a contract
+cargo test -p refund test_arbitration_fees
+cargo test -p escrow test_dispute_resolution
+
+# Run tests matching a pattern
+cargo test -p payment test_fee
 ```
 
 ## 📂 Contract Overview


### PR DESCRIPTION
## Overview

This PR adds documentation on how to run a single test file or test function in the README's "Run Tests" section. Currently, the README only shows how to run all tests in the workspace or per-contract tests. Contributors need to know how to target a specific test file (e.g. contracts/refund/src/test_arbitration_fees.rs) without running the full test suite.

## Related Issue

Closes #450

## Changes

[MODIFY] README.md
- Add examples of running a single test file: cargo test -p refund test_arbitration_fees
- Add examples of running a single test function: cargo test -p escrow test_dispute_resolution
- Add example of running tests matching a pattern: cargo test -p payment test_fee

## Verification Results

- README correctly renders the new test examples in markdown
- Examples use actual test files referenced in the issue

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| README's Run Tests section shows an example of running a single test file | ✅ Added cargo test -p refund test_arbitration_fees |
| README's Run Tests section shows an example of a test function | ✅ Added cargo test -p escrow test_dispute_resolution |

