### PR TITLE
docs: add storage versioning documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Recommended migration path:
 
 ## 🔗 Links
 
-<!-- - [Website](https://facilpay.com) coming soon -->
-<!-- - [Documentation](https://docs.facilpay.com) coming soon -->
+- [Storage Versioning Guide](docs/STORAGE_VERSIONING.md)
 - Telegram: https://t.me/+afM9uh7GGtVkYmZk
 - [API Repository](https://github.com/facilpay/facilpay-api)
 - [SDK Repository](https://github.com/facilpay/facilpay-sdk)
+
 
 ## License
 

--- a/contracts/refund/README.md
+++ b/contracts/refund/README.md
@@ -20,6 +20,20 @@ cargo test -p refund
 
 The refund contract defines a set of numeric error codes in [src/lib.rs](src/lib.rs). For a complete reference of every error variant, see [ERRORS.md](ERRORS.md).
 
+## 🏷️ Refund Reason Codes
+
+The `request_refund()` function requires a type-safe `RefundReasonCode` enum variant to categorize refund requests for structured querying and analytics (`get_reason_code_analytics()`).
+
+| Variant | Description | Intended Scenario |
+|---|---|---|
+| `ProductDefect` | Item or service was defective, damaged, non-functional, or significantly different from description. | Received a broken item, malfunctioning software, or flawed goods. |
+| `NonDelivery` | Goods or services were not received within the expected fulfillment window or were lost in transit. | Package lost in shipping, or service provider failed to show up. |
+| `DuplicateCharge` | Customer was billed multiple times by accident for a single order or transaction. | System or network error causing duplicate payment execution. |
+| `Unauthorized` | Transaction was initiated without the account owner's knowledge or consent (fraudulent activity). | Compromised account, stolen credentials, or unapproved charge. |
+| `CustomerRequest` | Buyer requested cancellation, return, or exchange under standard buyer's remorse or return policy. | Customer changed their mind, ordered wrong size, or no longer needed the item. |
+| `Other` | Fallback or unclassified refund reason that does not fit standard variants, or legacy backfills. | Custom agreements, edge cases, or initial code migrations for unknown historical reasons. |
+
+
 ## 📂 Public Functions
 
 ### Initialization & Schema

--- a/docs/STORAGE_VERSIONING.md
+++ b/docs/STORAGE_VERSIONING.md
@@ -1,0 +1,82 @@
+# Storage Schema Versioning
+
+FacilPay Soroban smart contracts (`contracts/payment`, `contracts/refund`, `contracts/escrow`) implement an explicit storage schema versioning convention. This allows deployed contracts to track their data storage layout version on-chain and perform state migrations as stored data structures evolve over time.
+
+---
+
+## 📐 How Storage Schema Versions Are Tracked
+
+Every contract tracks its schema version in instance storage under a dedicated storage key (`ConfigKey::SchemaVersion` or `SystemKey::SchemaVersion`).
+
+### Key Functions
+
+1. **`get_schema_version(env: Env) -> u32`**
+   - Returns the current schema version number stored in contract instance storage.
+   - Defaults to `1` (`INITIAL_SCHEMA_VERSION`) if no custom version has been written yet.
+
+2. **`migrate_schema(env: Env, admin: Address, target_version: u32) -> Result<(), Error>`**
+   - Authorized admin-only function that updates the contract schema version to `target_version`.
+   - Returns an error (`SchemaAlreadyAtTarget`) if the current stored version is already greater than or equal to `target_version`.
+
+---
+
+## 🛠️ Contributor Workflow: Changing Stored Data Shapes
+
+When modifying an existing stored data structure (such as adding fields to a struct, modifying enum variants, or restructuring storage keys), contributors must adhere to the following workflow:
+
+1. **Assess Breaking Changes**:
+   - Determine if the change breaks backwards compatibility with existing on-chain data.
+   - Adding non-optional fields or re-interpreting existing byte encodings requires a schema migration.
+
+2. **Define Migration Logic**:
+   - Update `migrate_schema()` in the relevant contract (e.g., [`contracts/payment/src/lib.rs`](../contracts/payment/src/lib.rs) or [`contracts/refund/src/lib.rs`](../contracts/refund/src/lib.rs)) to handle reading historical data shapes and writing upgraded data structures.
+
+3. **Increment Target Schema Version**:
+   - Ensure contract calls specify the new target version integer (`target_version > current_version`).
+
+4. **Add & Update Unit Tests**:
+   - Create or update contract tests to verify that:
+     - `get_schema_version()` starts at `1` after contract `initialize()`.
+     - `migrate_schema()` successfully increments the version when called by an authorized admin.
+     - Calling `migrate_schema()` with a target version `<= current_version` fails with `SchemaAlreadyAtTarget`.
+
+---
+
+## 🧪 Reference Examples
+
+The repository includes explicit tests demonstrating schema version initialization and migration enforcement:
+
+- **Payment Contract**: [`contracts/payment/src/schema_version_test.rs`](../contracts/payment/src/schema_version_test.rs)
+- **Refund Contract**: [`contracts/refund/src/schema_version_test.rs`](../contracts/refund/src/schema_version_test.rs)
+
+### Example Test Pattern
+
+```rust
+#[test]
+fn test_schema_version_initialized_to_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    assert_eq!(client.get_schema_version(), 1);
+}
+
+#[test]
+fn test_migrate_schema_rejects_already_at_target() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.migrate_schema(&admin, &2);
+    assert_eq!(client.get_schema_version(), 2);
+
+    let result = client.try_migrate_schema(&admin, &2);
+    assert_eq!(result, Err(Ok(Error::Ext(ExtError::SchemaAlreadyAtTarget))));
+}
+```


### PR DESCRIPTION
#Closes
#447 

PR Title
docs: add storage versioning guide and refund reason code descriptions

PR Body
markdown
## Summary
- **What changed?**
  - Created [`docs/STORAGE_VERSIONING.md`](file:///home/a-one/Desktop/Drip%20Project/facilpay-contracts/docs/STORAGE_VERSIONING.md) documenting how storage schema versions are tracked on-chain across Soroban contracts (`contracts/payment`, `contracts/refund`, `contracts/escrow`).
  - Outlined the `migrate_schema()` and `get_schema_version()` contract interface, admin authorization requirements, and guard conditions (`SchemaAlreadyAtTarget`).
  - Added step-by-step contributor guidelines for state migration when modifying stored data shapes.
  - Referenced existing schema version test implementations in [`contracts/payment/src/schema_version_test.rs`](file:///home/a-one/Desktop/Drip%20Project/facilpay-contracts/contracts/payment/src/schema_version_test.rs) and [`contracts/refund/src/schema_version_test.rs`](file:///home/a-one/Desktop/Drip%20Project/facilpay-contracts/contracts/refund/src/schema_version_test.rs).
  - Added a reference link to the Storage Versioning Guide in the root [`README.md`](file:///home/a-one/Desktop/Drip%20Project/facilpay-contracts/README.md#L107-L113).
  - Added the `## 🏷️ Refund Reason Codes` table in [`contracts/refund/README.md`](file:///home/a-one/Desktop/Drip%20Project/facilpay-contracts/contracts/refund/README.md#L23-L35) detailing all `RefundReasonCode` variants and their target scenarios.
- **Why is this needed?**
  - Contract storage versioning conventions and contributor migration steps were previously undocumented.
  - Integrations and contract callers required clear guidance on choosing `RefundReasonCode` variants following recent breaking signature changes.
- **Any relevant context or linked issues?**
  - Resolves missing documentation for storage schema versioning conventions and canonical refund reason codes.
## Test Plan
- [x] I reviewed the diff for unintended changes (`git diff`)
- [x] Verified link references and Markdown formatting across `README.md`, `docs/STORAGE_VERSIONING.md`, and `contracts/refund/README.md`