### PR TITLE
feat(escrow): add expire_appeal to force finality on timed-out appeals

### DIFF
--- a/contracts/escrow/src/appeal_expiry_test.rs
+++ b/contracts/escrow/src/appeal_expiry_test.rs
@@ -1,0 +1,118 @@
+#![cfg(test)]
+
+use crate::*;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env};
+
+fn setup(env: &Env) -> (EscrowContractClient, Address, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let token_addr = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = token::StellarAssetClient::new(env, &token_addr);
+    let customer = Address::generate(env);
+    let merchant = Address::generate(env);
+    token_admin.mint(&customer, &10_000);
+    token_admin.mint(&contract_id, &10_000);
+
+    (client, customer, merchant, token_addr)
+}
+
+/// Files an appeal and returns its id, leaving the escrow in the Appeal round.
+fn file_appeal(
+    env: &Env,
+    client: &EscrowContractClient,
+    customer: &Address,
+    merchant: &Address,
+    token: &Address,
+) -> (u64, u64) {
+    env.ledger().set_timestamp(1_000);
+    let escrow_id = client.create_escrow(
+        customer,
+        merchant,
+        &1_000_i128,
+        token,
+        &0_u64,
+        &0_u64,
+        &0_u64,
+        &false,
+    );
+    client.dispute_escrow(customer, &escrow_id);
+
+    // File the appeal one day into the 72-hour window.
+    env.ledger().set_timestamp(1_000 + 86_400);
+    let reason: BytesN<32> = BytesN::from_array(env, &[0u8; 32]);
+    let appeal_id = client.file_dispute_appeal(customer, &escrow_id, &reason);
+    (escrow_id, appeal_id)
+}
+
+#[test]
+fn expire_appeal_after_deadline_forces_finality() {
+    let env = Env::default();
+    let (client, customer, merchant, token) = setup(&env);
+    let (escrow_id, appeal_id) = file_appeal(&env, &client, &customer, &merchant, &token);
+
+    // Deadline is filed_at + 72h. Move just past it.
+    let appeal = client.get_appeal(&appeal_id).unwrap();
+    env.ledger().set_timestamp(appeal.appeal_deadline + 1);
+
+    client.expire_appeal(&appeal_id);
+
+    let appeal = client.get_appeal(&appeal_id).unwrap();
+    assert!(
+        appeal.resolved,
+        "appeal should be marked resolved after expiry"
+    );
+    assert_eq!(
+        client.get_dispute_round(&escrow_id),
+        DisputeRound::Final,
+        "dispute round should advance to Final"
+    );
+}
+
+#[test]
+fn expire_appeal_before_deadline_fails() {
+    let env = Env::default();
+    let (client, customer, merchant, token) = setup(&env);
+    let (_escrow_id, appeal_id) = file_appeal(&env, &client, &customer, &merchant, &token);
+
+    // Still inside the appeal window.
+    let appeal = client.get_appeal(&appeal_id).unwrap();
+    env.ledger().set_timestamp(appeal.appeal_deadline);
+    let result = client.try_expire_appeal(&appeal_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Escrow(EscrowError::TimeoutNotReached))),
+        "expiry should be rejected before the deadline passes"
+    );
+}
+
+#[test]
+fn expire_appeal_twice_fails() {
+    let env = Env::default();
+    let (client, customer, merchant, token) = setup(&env);
+    let (_escrow_id, appeal_id) = file_appeal(&env, &client, &customer, &merchant, &token);
+
+    let appeal = client.get_appeal(&appeal_id).unwrap();
+    env.ledger().set_timestamp(appeal.appeal_deadline + 1);
+    client.expire_appeal(&appeal_id);
+
+    let result = client.try_expire_appeal(&appeal_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Escrow(EscrowError::AlreadyProcessed))),
+        "an already-expired appeal cannot be expired again"
+    );
+}
+
+#[test]
+fn expire_nonexistent_appeal_fails() {
+    let env = Env::default();
+    let (client, _customer, _merchant, _token) = setup(&env);
+
+    let result = client.try_expire_appeal(&999);
+    assert_eq!(result, Err(Ok(Error::Escrow(EscrowError::NotFound))));
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -680,6 +680,15 @@ pub struct AppealResolved {
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppealExpired {
+    pub appeal_id: u64,
+    pub escrow_id: u64,
+    pub upheld_in_favor_of: Address,
+    pub expired_at: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TemplateCreated {
     pub template_id: u64,
     pub owner: Address,
@@ -5194,6 +5203,107 @@ impl EscrowContract {
             escrow_id,
             in_favor_of: in_favour_of,
             resolved_at: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Expires an unresolved dispute appeal once its `appeal_deadline` has passed.
+    ///
+    /// Permissionless counterpart to [`resolve_appeal`], mirroring
+    /// [`trigger_timeout_resolution`] for the initial dispute stage. If an admin never
+    /// calls `resolve_appeal`, anyone may call this once `now > appeal_deadline` to force
+    /// finality so the escrow is not stuck in the `Appeal` round indefinitely.
+    ///
+    /// The pre-appeal outcome stands: the escrow funds were already distributed to the
+    /// winner during the initial dispute resolution, so no transfer is performed here.
+    /// The appeal is rejected and the dispute round advanced to `Final`.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment.
+    /// * `appeal_id` - Identifier of the appeal to expire.
+    ///
+    /// # Returns
+    /// Results in `Ok(())` on success or `Err(Error)` on failure.
+    ///
+    /// # Errors
+    /// * `NotFound` - the appeal or its escrow does not exist.
+    /// * `AlreadyProcessed` - the appeal has already been resolved or expired.
+    /// * `TimeoutNotReached` - the appeal deadline has not yet passed.
+    pub fn expire_appeal(env: Env, appeal_id: u64) -> Result<(), Error> {
+        let mut appeal = env
+            .storage()
+            .instance()
+            .get::<DataKey, DisputeAppeal>(&DataKey::Dispute(DisputeKey::Appeal(appeal_id)))
+            .ok_or(Error::Escrow(EscrowError::NotFound))?;
+
+        if appeal.resolved {
+            return Err(Error::Escrow(EscrowError::AlreadyProcessed));
+        }
+
+        let now = env.ledger().timestamp();
+        if now <= appeal.appeal_deadline {
+            return Err(Error::Escrow(EscrowError::TimeoutNotReached));
+        }
+
+        let escrow_id = appeal.escrow_id;
+
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Escrow(EscrowKey::Data(escrow_id)))
+        {
+            return Err(Error::Escrow(EscrowError::NotFound));
+        }
+
+        // Mark the appeal resolved and advance the round to Final so the dispute state
+        // machine can no longer be blocked in the Appeal round.
+        appeal.resolved = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::Dispute(DisputeKey::Appeal(appeal_id)), &appeal);
+
+        env.storage().instance().set(
+            &DataKey::Dispute(DisputeKey::Round(escrow_id)),
+            &DisputeRound::Final,
+        );
+
+        // Reflect the timeout in the persisted audit record.
+        if let Some(mut record) = env
+            .storage()
+            .instance()
+            .get::<DataKey, AppealRecord>(&DataKey::Dispute(DisputeKey::AppealRecord(
+                escrow_id, appeal_id,
+            )))
+        {
+            record.status = AppealStatus::Rejected;
+            env.storage().instance().set(
+                &DataKey::Dispute(DisputeKey::AppealRecord(escrow_id, appeal_id)),
+                &record,
+            );
+        }
+
+        // The pre-appeal outcome stands. Funds were already transferred to the winner
+        // during the initial dispute resolution, so we only record which party the
+        // upheld outcome favored (Released => merchant, otherwise => customer).
+        let mut escrow = EscrowContract::get_escrow(&env, escrow_id);
+        let upheld_in_favor_of = if escrow.status == EscrowStatus::Released {
+            escrow.merchant.clone()
+        } else {
+            escrow.customer.clone()
+        };
+
+        escrow.last_activity_at = now;
+        env.storage()
+            .instance()
+            .set(&DataKey::Escrow(EscrowKey::Data(escrow_id)), &escrow);
+
+        AppealExpired {
+            appeal_id,
+            escrow_id,
+            upheld_in_favor_of,
+            expired_at: now,
         }
         .publish(&env);
 
@@ -11276,6 +11386,9 @@ mod hold_period_test;
 
 #[cfg(test)]
 mod succession_test;
+
+#[cfg(test)]
+mod appeal_expiry_test;
 
 #[cfg(test)]
 mod escalation_timeout_test;


### PR DESCRIPTION
PR SUMMARY

Filed appeals stored an appeal_deadline but had no counterpart to auto_resolve_dispute / trigger_timeout_resolution, so an appeal an admin never resolved left the escrow stuck in the Appeal round forever.

Adds a permissionless expire_appeal(appeal_id) that, once now > appeal_deadline, marks the appeal resolved, advances the dispute round to Final, and upholds the pre-appeal outcome (no re-transfer — funds were already distributed during the initial resolution). Emits a new AppealExpired event. Includes 4 tests; full suite passes (99/99), fmt and clippy clean.

Closes #505