### PR TITLE
Feat/382 385 analytics cache balance check

### DIFF
--- a/contracts/payment/src/lib.rs
+++ b/contracts/payment/src/lib.rs
@@ -247,6 +247,8 @@ pub enum FeatureError {
     InvalidForwardBps = 537,
     SenderIsRecipient = 538,
     BelowMinSplitAmount = 539,
+    // Issue #385: claimed settlement amounts must sum exactly to the channel deposit.
+    BalanceSumMismatch = 541,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10867,7 +10869,7 @@ impl PaymentContract {
             return Err(Error::Feature(FeatureError::InvalidNonce));
         }
 
-        if merchant_amount > channel.deposited {
+        if merchant_amount < 0 || merchant_amount > channel.deposited {
             return Err(Error::Basic(BasicError::InvalidAmount));
         }
 
@@ -10881,6 +10883,17 @@ impl PaymentContract {
             .ed25519_verify(&channel.customer_pk, &msg, &signature);
 
         let customer_refund = channel.deposited - merchant_amount;
+
+        // Issue #385: assert the claimed settlement conserves the original deposit —
+        // the merchant's claim plus the customer's derived refund must sum exactly
+        // to what was deposited, never more.
+        if merchant_amount
+            .checked_add(customer_refund)
+            .ok_or(Error::Feature(FeatureError::BalanceSumMismatch))?
+            != channel.deposited
+        {
+            return Err(Error::Feature(FeatureError::BalanceSumMismatch));
+        }
         let token_client = token::Client::new(&env, &channel.token);
         let contract_address = env.current_contract_address();
 

--- a/contracts/payment/src/test_payment_channel.rs
+++ b/contracts/payment/src/test_payment_channel.rs
@@ -183,6 +183,68 @@ fn test_settle_channel_invalid_nonce() {
 }
 
 #[test]
+fn test_settle_channel_rejects_negative_merchant_amount() {
+    // Issue #385: a negative merchant_amount would make
+    // customer_refund = deposited - merchant_amount exceed the deposit,
+    // letting the two parties claim more than was ever deposited.
+    use ed25519_dalek::{Signer, SigningKey};
+    use rand::rngs::OsRng;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+
+    let contract_id = env.register(PaymentContract, ());
+    let client = PaymentContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    token_admin_client.mint(&customer, &1000i128);
+
+    let mut rng = OsRng;
+    let signing_key = SigningKey::generate(&mut rng);
+    let pk_bytes = signing_key.verifying_key().to_bytes();
+    let customer_pk = BytesN::<32>::from_array(&env, &pk_bytes);
+
+    let channel_id = client.open_channel(
+        &customer,
+        &merchant,
+        &token_id,
+        &1000i128,
+        &0u64,
+        &customer_pk,
+    );
+
+    let merchant_amount: i128 = -500;
+    let nonce: u64 = 1;
+    let mut msg = Bytes::new(&env);
+    msg.append(&channel_id.to_xdr(&env));
+    msg.append(&merchant_amount.to_xdr(&env));
+    msg.append(&nonce.to_xdr(&env));
+
+    let msg_vec: alloc::vec::Vec<u8> = msg.iter().collect();
+    let signature = signing_key.sign(&msg_vec);
+    let sig_bn = BytesN::<64>::from_array(&env, &signature.to_bytes());
+
+    let result = client.try_settle_channel(&channel_id, &merchant_amount, &nonce, &sig_bn);
+    assert!(
+        result.is_err(),
+        "negative merchant_amount must be rejected before it can inflate the customer refund past the deposit"
+    );
+
+    let channel = client.get_channel(&channel_id);
+    assert!(channel.open, "channel must remain open on rejected settlement");
+}
+
+#[test]
 fn test_stale_nonce_replay_rejected() {
     // Demonstrate that a stale off-chain state (lower nonce) cannot be replayed
     // once the channel has been settled with a higher nonce.

--- a/contracts/refund/README.md
+++ b/contracts/refund/README.md
@@ -140,7 +140,7 @@ The `request_refund()` function requires a type-safe `RefundReasonCode` enum var
 - `get_merchant_pending_refunds()` — All pending refunds for a merchant.
 - `get_merchant_refund_summary()` — Aggregate refund stats for a merchant.
 - `get_refunds_by_reason_code()` — Paginated refunds filtered by canonical reason code.
-- `get_reason_code_analytics()` — Counts refunds by reason code, sorted by frequency.
+- `get_reason_code_analytics(window_start, window_end)` — Counts refunds by reason code within the given ledger-timestamp window, sorted by frequency. Cached per window and invalidated only when a refund inside that window is processed.
 - `get_total_refunded_amount()` — Cumulative refunded amount for a given payment.
 - `can_refund_payment()` — Checks if a refund would exceed the original payment amount.
 

--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -158,6 +158,13 @@ pub enum SystemKey {
     CustomerRefundCooldown(Address),
     RefundCooldownConfig,
     SchemaVersion,
+    // Issue #382: cached reason-code analytics for a given [window_start, window_end]
+    // ledger-timestamp range, so repeated queries over the same window don't
+    // re-scan the full refund history.
+    AnalyticsCache(u64, u64),
+    // Tracks the distinct (window_start, window_end) pairs cached above, so a newly
+    // processed refund can invalidate only the windows it actually falls within.
+    AnalyticsCacheWindows,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -3950,11 +3957,30 @@ impl RefundContract {
         results
     }
 
-    /// Get analytics showing the count of refunds for each reason code, sorted by frequency.
+    /// Get analytics showing the count of refunds for each reason code, sorted by frequency,
+    /// restricted to refunds created within `[window_start, window_end]` (inclusive).
+    ///
+    /// The result is deterministic for a given window and is cached under
+    /// `SystemKey::AnalyticsCache(window_start, window_end)`. The cache is invalidated
+    /// (recomputed) only when a refund whose `created_at` falls inside that window is
+    /// processed after the cache entry was written (see `process_refund_internal`).
     ///
     /// # Returns
     /// A vector of `(RefundReasonCode, count)` tuples sorted by descending count.
-    pub fn get_reason_code_analytics(env: Env) -> Vec<(RefundReasonCode, u64)> {
+    pub fn get_reason_code_analytics(
+        env: Env,
+        window_start: u64,
+        window_end: u64,
+    ) -> Vec<(RefundReasonCode, u64)> {
+        let cache_key = SystemKey::AnalyticsCache(window_start, window_end);
+        if let Some(cached) = env
+            .storage()
+            .instance()
+            .get::<_, Vec<(RefundReasonCode, u64)>>(&cache_key)
+        {
+            return cached;
+        }
+
         let mut product_defect: u64 = 0;
         let mut non_delivery: u64 = 0;
         let mut duplicate_charge: u64 = 0;
@@ -3975,13 +4001,15 @@ impl RefundContract {
                 .instance()
                 .get::<_, Refund>(&DataKey::Refund(id))
             {
-                match refund.reason_code {
-                    RefundReasonCode::ProductDefect => product_defect += 1,
-                    RefundReasonCode::NonDelivery => non_delivery += 1,
-                    RefundReasonCode::DuplicateCharge => duplicate_charge += 1,
-                    RefundReasonCode::Unauthorized => unauthorized += 1,
-                    RefundReasonCode::CustomerRequest => customer_request += 1,
-                    RefundReasonCode::Other => other += 1,
+                if refund.requested_at >= window_start && refund.requested_at <= window_end {
+                    match refund.reason_code {
+                        RefundReasonCode::ProductDefect => product_defect += 1,
+                        RefundReasonCode::NonDelivery => non_delivery += 1,
+                        RefundReasonCode::DuplicateCharge => duplicate_charge += 1,
+                        RefundReasonCode::Unauthorized => unauthorized += 1,
+                        RefundReasonCode::CustomerRequest => customer_request += 1,
+                        RefundReasonCode::Other => other += 1,
+                    }
                 }
             }
             id += 1;
@@ -4009,7 +4037,43 @@ impl RefundContract {
         for (code, count) in ordered {
             result.push_back((code, count));
         }
+
+        env.storage().instance().set(&cache_key, &result);
+
+        let mut windows: Vec<(u64, u64)> = env
+            .storage()
+            .instance()
+            .get(&SystemKey::AnalyticsCacheWindows)
+            .unwrap_or(Vec::new(&env));
+        if !windows.iter().any(|w| w == (window_start, window_end)) {
+            windows.push_back((window_start, window_end));
+            env.storage()
+                .instance()
+                .set(&SystemKey::AnalyticsCacheWindows, &windows);
+        }
+
         result
+    }
+
+    /// Invalidate any cached analytics window that contains `requested_at`.
+    ///
+    /// Only called when a refund is processed, per issue #382: caches are keyed by
+    /// window and there is no bounded index of "cache keys ever written," so we
+    /// track the small set of distinct windows queried so far and drop the ones
+    /// whose range covers the newly processed refund's `requested_at`.
+    fn invalidate_analytics_cache_for(env: &Env, requested_at: u64) {
+        let windows: Vec<(u64, u64)> = env
+            .storage()
+            .instance()
+            .get(&SystemKey::AnalyticsCacheWindows)
+            .unwrap_or(Vec::new(env));
+        for (window_start, window_end) in windows.iter() {
+            if requested_at >= window_start && requested_at <= window_end {
+                env.storage()
+                    .instance()
+                    .remove(&SystemKey::AnalyticsCache(window_start, window_end));
+            }
+        }
     }
 
     /// Get the total number of refunds in a given status.
@@ -5484,6 +5548,9 @@ impl RefundContract {
             .instance()
             .set(&DataKey::Refund(refund_id), &refund);
         Self::add_to_status_index(env, RefundStatus::Processed, refund_id);
+        // Issue #382: this refund's requested_at may fall within a previously
+        // cached analytics window, so drop that cache entry.
+        Self::invalidate_analytics_cache_for(env, refund.requested_at);
 
         (RefundProcessed {
             refund_id,

--- a/contracts/refund/src/test.rs
+++ b/contracts/refund/src/test.rs
@@ -1337,7 +1337,7 @@ fn test_reason_code_analytics_sorted_by_frequency() {
         &0_u64,
     );
 
-    let analytics = client.get_reason_code_analytics();
+    let analytics = client.get_reason_code_analytics(&0u64, &u64::MAX);
     assert_eq!(analytics.len(), 6);
 
     assert_eq!(
@@ -1361,6 +1361,74 @@ fn test_reason_code_analytics_sorted_by_frequency() {
         (RefundReasonCode::Unauthorized, 0u64),
     );
     assert_eq!(analytics.get(5).unwrap(), (RefundReasonCode::Other, 0u64));
+}
+
+#[test]
+fn test_reason_code_analytics_cache_invalidated_on_process_within_window() {
+    // Issue #382: a cached window's analytics must reflect refunds processed
+    // inside that window, but a cached window can otherwise be served without
+    // rescanning the whole refund history.
+    let env = Env::default();
+    let contract_id = env.register(RefundContract, ());
+    let client = RefundContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let reason = String::from_str(&env, "cache-test");
+
+    env.mock_all_auths();
+    client.set_fraud_config(
+        &admin,
+        &FraudConfig {
+            max_refund_rate_bps: 10000,
+            min_transactions_for_check: 100,
+            enabled: false,
+        },
+    );
+
+    let refund_id = client.request_refund(
+        &merchant,
+        &1u64,
+        &customer,
+        &100i128,
+        &100i128,
+        &token,
+        &reason,
+        &RefundReasonCode::ProductDefect,
+        &0_u64,
+    );
+
+    // Populate the cache for the full window before this refund is processed.
+    let analytics = client.get_reason_code_analytics(&0u64, &u64::MAX);
+    assert_eq!(analytics.get(0).unwrap(), (RefundReasonCode::ProductDefect, 1u64));
+
+    client.approve_refund(&admin, &refund_id);
+    client.process_refund(&admin, &refund_id);
+
+    let refund_id2 = client.request_refund(
+        &merchant,
+        &2u64,
+        &customer,
+        &100i128,
+        &100i128,
+        &token,
+        &reason,
+        &RefundReasonCode::ProductDefect,
+        &0_u64,
+    );
+    client.approve_refund(&admin, &refund_id2);
+    client.process_refund(&admin, &refund_id2);
+
+    // The cache entry covering this refund's requested_at must have been
+    // invalidated by processing, so the recount reflects both refunds.
+    let analytics_after = client.get_reason_code_analytics(&0u64, &u64::MAX);
+    assert_eq!(
+        analytics_after.get(0).unwrap(),
+        (RefundReasonCode::ProductDefect, 2u64),
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Fix #382 (analytics caching) and #385 (channel balance conservation)

## #382 — Cache reason-code analytics per window
`get_reason_code_analytics()` now takes `(window_start, window_end)`, caches the
result under `SystemKey::AnalyticsCache(window_start, window_end)`, and only
invalidates a window's cache when a refund with `requested_at` inside it is
processed.

## #385 — Enforce balance conservation on channel settlement
`settle_channel()` rejected `merchant_amount` only against the deposit's upper
bound. A negative claim let the derived customer refund exceed the deposit.
Added a lower-bound check and an explicit conservation assertion
(`merchant_amount + customer_refund == channel.deposited`) before any transfer.

## Testing
- `cargo build` passes for both `refund` and `payment` contracts.
- `cargo test` in `contracts/payment`: 348 passed, 0 failed (includes new test
  for negative `merchant_amount` rejection).
- `contracts/refund` test suite currently **fails to compile on `main`**
  (pre-existing, unrelated: `test_merchant_override_and_error_codes.rs` calls
  outdated function signatures) — not touched per scope. New refund tests were
  written and build correctly against the changed signature but could not be
  executed until that pre-existing breakage is separately fixed.

Closes #382
Closes #385
