### PR TITLE
docs(changelog): document existing min-split-amount guard (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved documentation coverage to reduce friction for off-chain integrators consuming Soroban events.
 
+- **Split Payment Dust Recipient Guard** — `create_split_payment()` rejects any recipient whose computed share falls below an admin-configured `min_split_amount` floor, preventing dust splits from bloating ledger storage. Enforced via `set_min_split_amount()` / `get_min_split_amount()` (see commit `061aeeb`).
+
 ---
 
 ## [Previous Versions]


### PR DESCRIPTION
# docs: document existing min-split-amount guard

Issue #335 (dust splits with no minimum per-recipient threshold) was already fixed in commit `061aeeb` — `create_split_payment()` validates each recipient's share against an admin-configurable `min_split_amount` before any storage write, with full test coverage in `test_split_payment.rs`. This PR just adds a CHANGELOG entry documenting that guard.

Closes #335
